### PR TITLE
Callback pattern description amendment

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,8 @@ Behavioral patterns are concerned with algorithms and the assignment of responsi
 **Applicability:** Use the Callback pattern when
 * When some arbitrary synchronous or asynchronous action must be performed after execution of some defined activity.
 
+**Real world examples:**
+* [CyclicBarrier] (http://docs.oracle.com/javase/7/docs/api/java/util/concurrent/CyclicBarrier.html#CyclicBarrier%28int,%20java.lang.Runnable%29) constructor can accept callback that will be triggered every time when barrier is tripped.
 
 # Frequently asked questions
 

--- a/callback/src/main/java/com/iluwatar/App.java
+++ b/callback/src/main/java/com/iluwatar/App.java
@@ -1,7 +1,7 @@
 package com.iluwatar;
 
 /**
- * Callback pattern is more native for dynamic languages where function are first-class citizen.
+ * Callback pattern is more native for functional languages where function is treated as first-class citizen.
  * Prior to Java8 can be simulated using simple (alike command) interfaces.
  */
 public class App {


### PR DESCRIPTION
Guess this description will be more close to accurate.

Also come up with kind of controversial **Real world example**: one of [CyclicBarrier] (http://docs.oracle.com/javase/7/docs/api/java/util/concurrent/CyclicBarrier.html#CyclicBarrier%28int,%20java.lang.Runnable%29) constructors can accept callback that will be triggered every time when barrier is tripped.
Though ideologically, I think, it is good Callback example its very differ in implementation.
Would it be appropriate to mention this case in description?