### PR TITLE
Changed improper description about double dispatch in FAQ section

### DIFF
--- a/README.md
+++ b/README.md
@@ -736,7 +736,7 @@ While the implementations look similar there are differences. The Chain of Respo
 
 **<a id="Q5">Q: What is the difference between Visitor and Double Dispatch patterns?</a>**
 
-The Visitor pattern is a means of adding a new operation to existing classes. Double dispatch is a means of dispatching function calls with respect to two polymorphic types, rather than a single polymorphic type, which is what languages like C++ and Java support directly.
+The Visitor pattern is a means of adding a new operation to existing classes. Double dispatch is a means of dispatching function calls with respect to two polymorphic types, rather than a single polymorphic type, which is what languages like C++ and Java _do not_ support directly.
 
 **<a id="Q6">Q: What are the differences between Flyweight and Object Pool patterns?</a>**
 


### PR DESCRIPTION
The FAQ section about the difference between double dispatch and Visitor states that C++ and Java **support** this. But actually they do not support it. Have corrected the mistake.