### PR TITLE
Jekyll does not like enumerations w/o blank lines

### DIFF
--- a/flyweight/index.md
+++ b/flyweight/index.md
@@ -15,6 +15,7 @@ efficiently.
 **Applicability:** The Flyweight pattern's effectiveness depends heavily on how
 and where it's used. Apply the Flyweight pattern when all of the following are
 true
+
 * an application uses a large number of objects
 * storage costs are high because of the sheer quantity of objects
 * most object state can be made extrinsic

--- a/interpreter/index.md
+++ b/interpreter/index.md
@@ -16,5 +16,6 @@ language.
 **Applicability:** Use the Interpreter pattern when there is a language to
 interpret, and you can represent statements in the language as abstract syntax
 trees. The Interpreter pattern works best when
+
 * the grammar is simple. For complex grammars, the class hierarchy for the grammar becomes large and unmanageable. Tools such as parser generators are a better alternative in such cases. They can interpret expressions without building abstract syntax trees, which can save space and possibly time
 * efficiency is not a critical concern. The most efficient interpreters are usually not implemented by interpreting parse trees directly but by first translating them into another form. For example, regular expressions are often transformed into state machines. But even then, the translator can be implemented by the Interpreter pattern, so the pattern is still applicable

--- a/model-view-presenter/index.md
+++ b/model-view-presenter/index.md
@@ -14,5 +14,6 @@ developers to build and test user interfaces.
 
 **Applicability:** Use the Model-View-Presenter in any of the following
 situations
+
 * when you want to improve the "Separation of Concerns" principle in presentation logic
 * when a user interface development and testing is necessary.


### PR DESCRIPTION
See on http://iluwatar.github.io/java-design-patterns/patterns/flyweight/ that `*` are not converted to proper unordered lists.