### PR TITLE
Just  Just a quick fix for the Front-controller pattern.

### DIFF
--- a/front-controller/src/main/java/com/iluwatar/front/controller/FrontController.java
+++ b/front-controller/src/main/java/com/iluwatar/front/controller/FrontController.java
@@ -25,7 +25,7 @@ public class FrontController {
 	private Class getCommandClass(String request) {
 		Class result;
 		try {
-			result = Class.forName("com.iluwatar." + request + "Command");
+			result = Class.forName("com.iluwatar.front.controller." + request + "Command");
 		} catch (ClassNotFoundException e) {
 			result = UnknownCommand.class;
 		}


### PR DESCRIPTION
Hiya!

I was just checking out this pattern and it returned three times the same string 
> Error 500
> Error 500
> Error 500

Correct output should be
>Displaying archers
>Displaying catapults
>Error 500

The problem was the name of the package was not the correct one in FrontController.java, line 28.

The class should be probably be uptaded to not get the Class names from hard-coded Strings.