### PR TITLE
Utility classes should not have public constructors

### DIFF
--- a/caching/src/main/java/com/iluwatar/caching/AppManager.java
+++ b/caching/src/main/java/com/iluwatar/caching/AppManager.java
@@ -15,6 +15,9 @@ public class AppManager {
 
   private static CachingPolicy cachingPolicy;
 
+  private AppManager() {
+  }
+
   /**
    *
    * Developer/Tester is able to choose whether the application should use MongoDB as its underlying

--- a/caching/src/main/java/com/iluwatar/caching/CacheStore.java
+++ b/caching/src/main/java/com/iluwatar/caching/CacheStore.java
@@ -11,6 +11,9 @@ public class CacheStore {
 
   static LruCache cache = null;
 
+  private CacheStore() {
+  }
+
   /**
    * Init cache capacity
    */

--- a/caching/src/main/java/com/iluwatar/caching/DbManager.java
+++ b/caching/src/main/java/com/iluwatar/caching/DbManager.java
@@ -29,6 +29,9 @@ public class DbManager {
 
   private static HashMap<String, UserAccount> virtualDB;
 
+  private DbManager() {
+  }
+
   /**
    * Create DB
    */

--- a/naked-objects/integtests/src/test/java/domainapp/integtests/bootstrap/SimpleAppSystemInitializer.java
+++ b/naked-objects/integtests/src/test/java/domainapp/integtests/bootstrap/SimpleAppSystemInitializer.java
@@ -21,6 +21,9 @@ import org.apache.isis.objectstore.jdo.datanucleus.IsisConfigurationForJdoIntegT
 
 public class SimpleAppSystemInitializer {
 
+  private SimpleAppSystemInitializer() {
+  }
+
   /**
    * Init test system
    */

--- a/service-layer/src/main/java/com/iluwatar/servicelayer/hibernate/HibernateUtil.java
+++ b/service-layer/src/main/java/com/iluwatar/servicelayer/hibernate/HibernateUtil.java
@@ -32,6 +32,9 @@ public class HibernateUtil {
     }
   }
 
+  private HibernateUtil() {
+  }
+
   public static SessionFactory getSessionFactory() {
     return SESSION_FACTORY;
   }

--- a/service-locator/src/main/java/com/iluwatar/servicelocator/ServiceLocator.java
+++ b/service-locator/src/main/java/com/iluwatar/servicelocator/ServiceLocator.java
@@ -10,6 +10,9 @@ public class ServiceLocator {
 
   private static ServiceCache serviceCache = new ServiceCache();
 
+  private ServiceLocator() {
+  }
+
   /**
    * Fetch the service with the name param from the cache first, if no service is found, lookup the
    * service from the {@link InitContext} and then add the newly created service into the cache map

--- a/tolerant-reader/src/main/java/com/iluwatar/tolerantreader/RainbowFishSerializer.java
+++ b/tolerant-reader/src/main/java/com/iluwatar/tolerantreader/RainbowFishSerializer.java
@@ -18,6 +18,9 @@ import java.util.Map;
  */
 public class RainbowFishSerializer {
 
+  private RainbowFishSerializer() {
+  }
+
   /**
    * Write V1 RainbowFish to file
    */


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118

Please let me know if you have any questions.
Kirill Vlasov