### PR TITLE
squid:S1488 - Local Variables should not be declared and then immedia…

### DIFF
--- a/caching/src/main/java/com/iluwatar/caching/DbManager.java
+++ b/caching/src/main/java/com/iluwatar/caching/DbManager.java
@@ -72,9 +72,7 @@ public class DbManager {
       return null;
     }
     Document doc = iterable.first();
-    UserAccount userAccount =
-        new UserAccount(userId, doc.getString("userName"), doc.getString("additionalInfo"));
-    return userAccount;
+    return new UserAccount(userId, doc.getString("userName"), doc.getString("additionalInfo"));
   }
 
   /**

--- a/dao/src/main/java/com/iluwatar/dao/Customer.java
+++ b/dao/src/main/java/com/iluwatar/dao/Customer.java
@@ -66,7 +66,6 @@ public class Customer {
 
   @Override
   public int hashCode() {
-    int result = getId();
-    return result;
+    return getId();
   }
 }

--- a/fluentinterface/src/main/java/com/iluwatar/fluentinterface/fluentiterable/lazy/LazyFluentIterable.java
+++ b/fluentinterface/src/main/java/com/iluwatar/fluentinterface/fluentiterable/lazy/LazyFluentIterable.java
@@ -204,8 +204,7 @@ public class LazyFluentIterable<TYPE> implements FluentIterable<TYPE> {
    */
   @Override
   public List<TYPE> asList() {
-    List<TYPE> copy = FluentIterable.copyToList(iterable);
-    return copy;
+    return FluentIterable.copyToList(iterable);
   }
 
   @Override

--- a/naked-objects/webapp/src/main/java/domainapp/webapp/SimpleApplication.java
+++ b/naked-objects/webapp/src/main/java/domainapp/webapp/SimpleApplication.java
@@ -118,8 +118,7 @@ public class SimpleApplication extends IsisWicketApplication {
     } catch (Exception e) {
       System.out.println(e);
     }
-    WebRequest request = super.newWebRequest(servletRequest, filterPath);
-    return request;
+    return super.newWebRequest(servletRequest, filterPath);
   }
 
   @Override
@@ -150,8 +149,7 @@ public class SimpleApplication extends IsisWicketApplication {
       List<String> readLines =
           Resources.readLines(Resources.getResource(contextClass, resourceName),
               Charset.defaultCharset());
-      final String aboutText = Joiner.on("\n").join(readLines);
-      return aboutText;
+      return Joiner.on("\n").join(readLines);
     } catch (IOException e) {
       return "This is a simple app";
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1488
Local Variables should not be declared and then immediately returned or thrown
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1488
Please let me know if you have any questions.
M-Ezzat