### PR TITLE
Update license year from 2014 to range '2014-2016'

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014 Ilkka Seppälä
+Copyright (c) 2014-2016 Ilkka Seppälä
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
[How to use GNU licenses for your own software (Most parts also apply to the MIT license)](http://www.gnu.org/licenses/gpl-howto.html)

> The copyright notice should include the year in which you finished preparing the release (so if you finished it in 1998 but didn't post it until 1999, use 1998). You should add the proper year for each release; for example, “Copyright 1998, 1999 Terry Jones” if some versions were finished in 1998 and some were finished in 1999.
> ...
> For software with several releases over multiple years, it's okay to use a range (“2008-2010”) instead of listing individual years (“2008, 2009, 2010”) if and only if every year in the range, inclusive, really is a “copyrightable” year that would be listed individually; and you make an explicit statement in your documentation about this usage.
> 

There was definitely copyrightable activity on all years:
``git log --format="%ad" --date="iso" | cut -c -4 | sort | uniq``

So this pull requests updates the year '_2014_' in LICENSE.md to a range '_2014-2016_