### PR TITLE
squid:S1186 - Methods should not be empty

### DIFF
--- a/null-object/src/main/java/com/iluwatar/nullobject/NullNode.java
+++ b/null-object/src/main/java/com/iluwatar/nullobject/NullNode.java
@@ -60,5 +60,7 @@ public class NullNode implements Node {
   }
 
   @Override
-  public void walk() {}
+  public void walk() {
+    // Do nothing
+  }
 }

--- a/visitor/src/main/java/com/iluwatar/visitor/CommanderVisitor.java
+++ b/visitor/src/main/java/com/iluwatar/visitor/CommanderVisitor.java
@@ -30,10 +30,14 @@ package com.iluwatar.visitor;
 public class CommanderVisitor implements UnitVisitor {
 
   @Override
-  public void visitSoldier(Soldier soldier) {}
+  public void visitSoldier(Soldier soldier) {
+    // Do nothing
+  }
 
   @Override
-  public void visitSergeant(Sergeant sergeant) {}
+  public void visitSergeant(Sergeant sergeant) {
+    // Do nothing
+  }
 
   @Override
   public void visitCommander(Commander commander) {

--- a/visitor/src/main/java/com/iluwatar/visitor/SergeantVisitor.java
+++ b/visitor/src/main/java/com/iluwatar/visitor/SergeantVisitor.java
@@ -30,7 +30,9 @@ package com.iluwatar.visitor;
 public class SergeantVisitor implements UnitVisitor {
 
   @Override
-  public void visitSoldier(Soldier soldier) {}
+  public void visitSoldier(Soldier soldier) {
+    // Do nothing
+  }
 
   @Override
   public void visitSergeant(Sergeant sergeant) {
@@ -38,5 +40,7 @@ public class SergeantVisitor implements UnitVisitor {
   }
 
   @Override
-  public void visitCommander(Commander commander) {}
+  public void visitCommander(Commander commander) {
+    // Do nothing
+  }
 }

--- a/visitor/src/main/java/com/iluwatar/visitor/SoldierVisitor.java
+++ b/visitor/src/main/java/com/iluwatar/visitor/SoldierVisitor.java
@@ -35,8 +35,12 @@ public class SoldierVisitor implements UnitVisitor {
   }
 
   @Override
-  public void visitSergeant(Sergeant sergeant) {}
+  public void visitSergeant(Sergeant sergeant) {
+    // Do nothing
+  }
 
   @Override
-  public void visitCommander(Commander commander) {}
+  public void visitCommander(Commander commander) {
+    // Do nothing
+  }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1186 - Methods should not 
be empty

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1186

Please let me know if you have any questions.

M-Ezzat