### PR TITLE
squid:S2974 - Classes without public constructors should be final

### DIFF
--- a/builder/src/main/java/com/iluwatar/builder/Hero.java
+++ b/builder/src/main/java/com/iluwatar/builder/Hero.java
@@ -27,7 +27,7 @@ package com.iluwatar.builder;
  * Hero, the class with many parameters.
  * 
  */
-public class Hero {
+public final class Hero {
 
   private final Profession profession;
   private final String name;

--- a/caching/src/main/java/com/iluwatar/caching/AppManager.java
+++ b/caching/src/main/java/com/iluwatar/caching/AppManager.java
@@ -33,7 +33,7 @@ import java.text.ParseException;
  * CacheStore class.
  *
  */
-public class AppManager {
+public final class AppManager {
 
   private static CachingPolicy cachingPolicy;
 

--- a/caching/src/main/java/com/iluwatar/caching/DbManager.java
+++ b/caching/src/main/java/com/iluwatar/caching/DbManager.java
@@ -43,7 +43,7 @@ import com.mongodb.client.model.UpdateOptions;
  * during runtime (createVirtualDB()).</p>
  * 
  */
-public class DbManager {
+public final class DbManager {
 
   private static MongoClient mongoClient;
   private static MongoDatabase db;

--- a/flux/src/main/java/com/iluwatar/flux/dispatcher/Dispatcher.java
+++ b/flux/src/main/java/com/iluwatar/flux/dispatcher/Dispatcher.java
@@ -37,7 +37,7 @@ import com.iluwatar.flux.store.Store;
  * Dispatcher sends Actions to registered Stores.
  *
  */
-public class Dispatcher {
+public final class Dispatcher {
 
   private static Dispatcher instance = new Dispatcher();
 

--- a/multiton/src/main/java/com/iluwatar/multiton/Nazgul.java
+++ b/multiton/src/main/java/com/iluwatar/multiton/Nazgul.java
@@ -30,7 +30,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * Nazgul is a Multiton class. Nazgul instances can be queried using {@link #getInstance} method.
  *
  */
-public class Nazgul {
+public final class Nazgul {
 
   private static Map<NazgulName, Nazgul> nazguls;
 

--- a/naked-objects/integtests/src/test/java/domainapp/integtests/bootstrap/SimpleAppSystemInitializer.java
+++ b/naked-objects/integtests/src/test/java/domainapp/integtests/bootstrap/SimpleAppSystemInitializer.java
@@ -19,7 +19,7 @@ import org.apache.isis.core.integtestsupport.IsisSystemForTest;
 import org.apache.isis.objectstore.jdo.datanucleus.DataNucleusPersistenceMechanismInstaller;
 import org.apache.isis.objectstore.jdo.datanucleus.IsisConfigurationForJdoIntegTests;
 
-public class SimpleAppSystemInitializer {
+public final class SimpleAppSystemInitializer {
 
   private SimpleAppSystemInitializer() {
   }

--- a/null-object/src/main/java/com/iluwatar/nullobject/NullNode.java
+++ b/null-object/src/main/java/com/iluwatar/nullobject/NullNode.java
@@ -29,7 +29,7 @@ package com.iluwatar.nullobject;
  * Implemented as Singleton, since all the NullNodes are the same.
  *
  */
-public class NullNode implements Node {
+public final class NullNode implements Node {
 
   private static NullNode instance = new NullNode();
 

--- a/service-layer/src/main/java/com/iluwatar/servicelayer/hibernate/HibernateUtil.java
+++ b/service-layer/src/main/java/com/iluwatar/servicelayer/hibernate/HibernateUtil.java
@@ -32,7 +32,7 @@ import org.hibernate.cfg.Configuration;
 /**
  * Produces the Hibernate {@link SessionFactory}.
  */
-public class HibernateUtil {
+public final class HibernateUtil {
 
   /**
    * The cached session factory

--- a/service-locator/src/main/java/com/iluwatar/servicelocator/ServiceLocator.java
+++ b/service-locator/src/main/java/com/iluwatar/servicelocator/ServiceLocator.java
@@ -28,7 +28,7 @@ package com.iluwatar.servicelocator;
  *
  * @author saifasif
  */
-public class ServiceLocator {
+public final class ServiceLocator {
 
   private static ServiceCache serviceCache = new ServiceCache();
 

--- a/singleton/src/main/java/com/iluwatar/singleton/InitializingOnDemandHolderIdiom.java
+++ b/singleton/src/main/java/com/iluwatar/singleton/InitializingOnDemandHolderIdiom.java
@@ -34,7 +34,7 @@ import java.io.Serializable;
  *
  * @author mortezaadi@gmail.com
  */
-public class InitializingOnDemandHolderIdiom implements Serializable {
+public final class InitializingOnDemandHolderIdiom implements Serializable {
 
   private static final long serialVersionUID = 1L;
 

--- a/singleton/src/main/java/com/iluwatar/singleton/ThreadSafeDoubleCheckLocking.java
+++ b/singleton/src/main/java/com/iluwatar/singleton/ThreadSafeDoubleCheckLocking.java
@@ -31,7 +31,7 @@ package com.iluwatar.singleton;
  *
  * @author mortezaadi@gmail.com
  */
-public class ThreadSafeDoubleCheckLocking {
+public final class ThreadSafeDoubleCheckLocking {
 
   private static volatile ThreadSafeDoubleCheckLocking instance;
 

--- a/singleton/src/main/java/com/iluwatar/singleton/ThreadSafeLazyLoadedIvoryTower.java
+++ b/singleton/src/main/java/com/iluwatar/singleton/ThreadSafeLazyLoadedIvoryTower.java
@@ -29,7 +29,7 @@ package com.iluwatar.singleton;
  * Note: if created by reflection then a singleton will not be created but multiple options in the
  * same classloader
  */
-public class ThreadSafeLazyLoadedIvoryTower {
+public final class ThreadSafeLazyLoadedIvoryTower {
 
   private static ThreadSafeLazyLoadedIvoryTower instance = null;
 

--- a/step-builder/src/main/java/com/iluwatar/stepbuilder/CharacterStepBuilder.java
+++ b/step-builder/src/main/java/com/iluwatar/stepbuilder/CharacterStepBuilder.java
@@ -28,7 +28,7 @@ import java.util.List;
 /**
  * The Step Builder class.
  */
-public class CharacterStepBuilder {
+public final class CharacterStepBuilder {
 
   private CharacterStepBuilder() {}
 

--- a/tolerant-reader/src/main/java/com/iluwatar/tolerantreader/RainbowFishSerializer.java
+++ b/tolerant-reader/src/main/java/com/iluwatar/tolerantreader/RainbowFishSerializer.java
@@ -38,7 +38,7 @@ import java.util.Map;
  * added to the schema.
  *
  */
-public class RainbowFishSerializer {
+public final class RainbowFishSerializer {
 
   private RainbowFishSerializer() {
   }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2974 - Classes without "public" constructors should be "final"

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2974

Please let me know if you have any questions.

M-Ezzat