### PR TITLE
squid:S00119 - Type parameter names should comply with a naming conve…

### DIFF
--- a/fluentinterface/src/main/java/com/iluwatar/fluentinterface/app/App.java
+++ b/fluentinterface/src/main/java/com/iluwatar/fluentinterface/app/App.java
@@ -114,14 +114,14 @@ public class App {
     return integer -> integer > 0;
   }
 
-  private static <TYPE> void prettyPrint(String prefix, Iterable<TYPE> iterable) {
+  private static <E> void prettyPrint(String prefix, Iterable<E> iterable) {
     prettyPrint(", ", prefix, iterable);
   }
 
-  private static <TYPE> void prettyPrint(String delimiter, String prefix,
-                                         Iterable<TYPE> iterable) {
+  private static <E> void prettyPrint(String delimiter, String prefix,
+                                         Iterable<E> iterable) {
     StringJoiner joiner = new StringJoiner(delimiter, prefix, ".");
-    Iterator<TYPE> iterator = iterable.iterator();
+    Iterator<E> iterator = iterable.iterator();
     while (iterator.hasNext()) {
       joiner.add(iterator.next().toString());
     }

--- a/fluentinterface/src/main/java/com/iluwatar/fluentinterface/fluentiterable/FluentIterable.java
+++ b/fluentinterface/src/main/java/com/iluwatar/fluentinterface/fluentiterable/FluentIterable.java
@@ -34,9 +34,9 @@ import java.util.function.Predicate;
  * the fluent interface design pattern. This interface defines common operations, but doesn't aim to
  * be complete. It was inspired by Guava's com.google.common.collect.FluentIterable.
  * 
- * @param <TYPE> is the class of objects the iterable contains
+ * @param <E> is the class of objects the iterable contains
  */
-public interface FluentIterable<TYPE> extends Iterable<TYPE> {
+public interface FluentIterable<E> extends Iterable<E> {
 
   /**
    * Filters the contents of Iterable using the given predicate, leaving only the ones which satisfy
@@ -46,7 +46,7 @@ public interface FluentIterable<TYPE> extends Iterable<TYPE> {
    *        tested object is removed by the iterator.
    * @return a filtered FluentIterable
    */
-  FluentIterable<TYPE> filter(Predicate<? super TYPE> predicate);
+  FluentIterable<E> filter(Predicate<? super E> predicate);
 
   /**
    * Returns an Optional containing the first element of this iterable if present, else returns
@@ -54,55 +54,55 @@ public interface FluentIterable<TYPE> extends Iterable<TYPE> {
    * 
    * @return the first element after the iteration is evaluated
    */
-  Optional<TYPE> first();
+  Optional<E> first();
 
   /**
    * Evaluates the iteration and leaves only the count first elements.
    * 
    * @return the first count elements as an Iterable
    */
-  FluentIterable<TYPE> first(int count);
+  FluentIterable<E> first(int count);
 
   /**
    * Evaluates the iteration and returns the last element. This is a terminating operation.
    * 
    * @return the last element after the iteration is evaluated
    */
-  Optional<TYPE> last();
+  Optional<E> last();
 
   /**
    * Evaluates the iteration and leaves only the count last elements.
    * 
    * @return the last counts elements as an Iterable
    */
-  FluentIterable<TYPE> last(int count);
+  FluentIterable<E> last(int count);
 
   /**
-   * Transforms this FluentIterable into a new one containing objects of the type NEW_TYPE.
+   * Transforms this FluentIterable into a new one containing objects of the type T.
    * 
-   * @param function a function that transforms an instance of TYPE into an instance of NEW_TYPE
-   * @param <NEW_TYPE> the target type of the transformation
+   * @param function a function that transforms an instance of E into an instance of T
+   * @param <T> the target type of the transformation
    * @return a new FluentIterable of the new type
    */
-  <NEW_TYPE> FluentIterable<NEW_TYPE> map(Function<? super TYPE, NEW_TYPE> function);
+  <T> FluentIterable<T> map(Function<? super E, T> function);
 
   /**
    * Returns the contents of this Iterable as a List.
    * 
    * @return a List representation of this Iterable
    */
-  List<TYPE> asList();
+  List<E> asList();
 
   /**
    * Utility method that iterates over iterable and adds the contents to a list.
    * 
    * @param iterable the iterable to collect
-   * @param <TYPE> the type of the objects to iterate
+   * @param <E> the type of the objects to iterate
    * @return a list with all objects of the given iterator
    */
-  static <TYPE> List<TYPE> copyToList(Iterable<TYPE> iterable) {
-    ArrayList<TYPE> copy = new ArrayList<>();
-    Iterator<TYPE> iterator = iterable.iterator();
+  static <E> List<E> copyToList(Iterable<E> iterable) {
+    ArrayList<E> copy = new ArrayList<>();
+    Iterator<E> iterator = iterable.iterator();
     while (iterator.hasNext()) {
       copy.add(iterator.next());
     }

--- a/fluentinterface/src/main/java/com/iluwatar/fluentinterface/fluentiterable/lazy/DecoratingIterator.java
+++ b/fluentinterface/src/main/java/com/iluwatar/fluentinterface/fluentiterable/lazy/DecoratingIterator.java
@@ -28,16 +28,16 @@ import java.util.Iterator;
  * This class is used to realize LazyFluentIterables. It decorates a given iterator. Does not
  * support consecutive hasNext() calls.
  */
-public abstract class DecoratingIterator<TYPE> implements Iterator<TYPE> {
+public abstract class DecoratingIterator<E> implements Iterator<E> {
 
-  protected final Iterator<TYPE> fromIterator;
+  protected final Iterator<E> fromIterator;
 
-  private TYPE next;
+  private E next;
 
   /**
    * Creates an iterator that decorates the given iterator.
    */
-  public DecoratingIterator(Iterator<TYPE> fromIterator) {
+  public DecoratingIterator(Iterator<E> fromIterator) {
     this.fromIterator = fromIterator;
   }
 
@@ -58,11 +58,11 @@ public abstract class DecoratingIterator<TYPE> implements Iterator<TYPE> {
    * @return the next element of the Iterable, or null if not present.
    */
   @Override
-  public final TYPE next() {
+  public final E next() {
     if (next == null) {
       return fromIterator.next();
     } else {
-      final TYPE result = next;
+      final E result = next;
       next = null;
       return result;
     }
@@ -74,5 +74,5 @@ public abstract class DecoratingIterator<TYPE> implements Iterator<TYPE> {
    * 
    * @return the next element of the Iterable.
    */
-  public abstract TYPE computeNext();
+  public abstract E computeNext();
 }

--- a/fluentinterface/src/main/java/com/iluwatar/fluentinterface/fluentiterable/lazy/LazyFluentIterable.java
+++ b/fluentinterface/src/main/java/com/iluwatar/fluentinterface/fluentiterable/lazy/LazyFluentIterable.java
@@ -35,18 +35,18 @@ import com.iluwatar.fluentinterface.fluentiterable.FluentIterable;
  * This is a lazy implementation of the FluentIterable interface. It evaluates all chained
  * operations when a terminating operation is applied.
  * 
- * @param <TYPE> the type of the objects the iteration is about
+ * @param <E> the type of the objects the iteration is about
  */
-public class LazyFluentIterable<TYPE> implements FluentIterable<TYPE> {
+public class LazyFluentIterable<E> implements FluentIterable<E> {
 
-  private final Iterable<TYPE> iterable;
+  private final Iterable<E> iterable;
 
   /**
    * This constructor creates a new LazyFluentIterable. It wraps the given iterable.
    * 
    * @param iterable the iterable this FluentIterable works on.
    */
-  protected LazyFluentIterable(Iterable<TYPE> iterable) {
+  protected LazyFluentIterable(Iterable<E> iterable) {
     this.iterable = iterable;
   }
 
@@ -66,15 +66,15 @@ public class LazyFluentIterable<TYPE> implements FluentIterable<TYPE> {
    * @return a new FluentIterable object that decorates the source iterable
    */
   @Override
-  public FluentIterable<TYPE> filter(Predicate<? super TYPE> predicate) {
-    return new LazyFluentIterable<TYPE>() {
+  public FluentIterable<E> filter(Predicate<? super E> predicate) {
+    return new LazyFluentIterable<E>() {
       @Override
-      public Iterator<TYPE> iterator() {
-        return new DecoratingIterator<TYPE>(iterable.iterator()) {
+      public Iterator<E> iterator() {
+        return new DecoratingIterator<E>(iterable.iterator()) {
           @Override
-          public TYPE computeNext() {
+          public E computeNext() {
             while (fromIterator.hasNext()) {
-              TYPE candidate = fromIterator.next();
+              E candidate = fromIterator.next();
               if (predicate.test(candidate)) {
                 return candidate;
               }
@@ -93,8 +93,8 @@ public class LazyFluentIterable<TYPE> implements FluentIterable<TYPE> {
    * @return an Optional containing the first object of this Iterable
    */
   @Override
-  public Optional<TYPE> first() {
-    Iterator<TYPE> resultIterator = first(1).iterator();
+  public Optional<E> first() {
+    Iterator<E> resultIterator = first(1).iterator();
     return resultIterator.hasNext() ? Optional.of(resultIterator.next()) : Optional.empty();
   }
 
@@ -106,17 +106,17 @@ public class LazyFluentIterable<TYPE> implements FluentIterable<TYPE> {
    *         objects.
    */
   @Override
-  public FluentIterable<TYPE> first(int count) {
-    return new LazyFluentIterable<TYPE>() {
+  public FluentIterable<E> first(int count) {
+    return new LazyFluentIterable<E>() {
       @Override
-      public Iterator<TYPE> iterator() {
-        return new DecoratingIterator<TYPE>(iterable.iterator()) {
+      public Iterator<E> iterator() {
+        return new DecoratingIterator<E>(iterable.iterator()) {
           int currentIndex;
 
           @Override
-          public TYPE computeNext() {
+          public E computeNext() {
             if (currentIndex < count && fromIterator.hasNext()) {
-              TYPE candidate = fromIterator.next();
+              E candidate = fromIterator.next();
               currentIndex++;
               return candidate;
             }
@@ -133,8 +133,8 @@ public class LazyFluentIterable<TYPE> implements FluentIterable<TYPE> {
    * @return an Optional containing the last object of this Iterable
    */
   @Override
-  public Optional<TYPE> last() {
-    Iterator<TYPE> resultIterator = last(1).iterator();
+  public Optional<E> last() {
+    Iterator<E> resultIterator = last(1).iterator();
     return resultIterator.hasNext() ? Optional.of(resultIterator.next()) : Optional.empty();
   }
 
@@ -148,21 +148,21 @@ public class LazyFluentIterable<TYPE> implements FluentIterable<TYPE> {
    *         objects
    */
   @Override
-  public FluentIterable<TYPE> last(int count) {
-    return new LazyFluentIterable<TYPE>() {
+  public FluentIterable<E> last(int count) {
+    return new LazyFluentIterable<E>() {
       @Override
-      public Iterator<TYPE> iterator() {
-        return new DecoratingIterator<TYPE>(iterable.iterator()) {
+      public Iterator<E> iterator() {
+        return new DecoratingIterator<E>(iterable.iterator()) {
           private int stopIndex;
           private int totalElementsCount;
-          private List<TYPE> list;
+          private List<E> list;
           private int currentIndex;
 
           @Override
-          public TYPE computeNext() {
+          public E computeNext() {
             initialize();
 
-            TYPE candidate = null;
+            E candidate = null;
             while (currentIndex < stopIndex && fromIterator.hasNext()) {
               currentIndex++;
               fromIterator.next();
@@ -176,7 +176,7 @@ public class LazyFluentIterable<TYPE> implements FluentIterable<TYPE> {
           private void initialize() {
             if (list == null) {
               list = new ArrayList<>();
-              Iterator<TYPE> newIterator = iterable.iterator();
+              Iterator<E> newIterator = iterable.iterator();
               while (newIterator.hasNext()) {
                 list.add(newIterator.next());
               }
@@ -191,24 +191,24 @@ public class LazyFluentIterable<TYPE> implements FluentIterable<TYPE> {
   }
 
   /**
-   * Transforms this FluentIterable into a new one containing objects of the type NEW_TYPE.
+   * Transforms this FluentIterable into a new one containing objects of the type T.
    * 
-   * @param function a function that transforms an instance of TYPE into an instance of NEW_TYPE
-   * @param <NEW_TYPE> the target type of the transformation
+   * @param function a function that transforms an instance of E into an instance of T
+   * @param <T> the target type of the transformation
    * @return a new FluentIterable of the new type
    */
   @Override
-  public <NEW_TYPE> FluentIterable<NEW_TYPE> map(Function<? super TYPE, NEW_TYPE> function) {
-    return new LazyFluentIterable<NEW_TYPE>() {
+  public <T> FluentIterable<T> map(Function<? super E, T> function) {
+    return new LazyFluentIterable<T>() {
       @Override
-      public Iterator<NEW_TYPE> iterator() {
-        return new DecoratingIterator<NEW_TYPE>(null) {
-          Iterator<TYPE> oldTypeIterator = iterable.iterator();
+      public Iterator<T> iterator() {
+        return new DecoratingIterator<T>(null) {
+          Iterator<E> oldTypeIterator = iterable.iterator();
 
           @Override
-          public NEW_TYPE computeNext() {
+          public T computeNext() {
             if (oldTypeIterator.hasNext()) {
-              TYPE candidate = oldTypeIterator.next();
+              E candidate = oldTypeIterator.next();
               return function.apply(candidate);
             } else {
               return null;
@@ -225,15 +225,15 @@ public class LazyFluentIterable<TYPE> implements FluentIterable<TYPE> {
    * @return a list with all remaining objects of this iteration
    */
   @Override
-  public List<TYPE> asList() {
+  public List<E> asList() {
     return FluentIterable.copyToList(iterable);
   }
 
   @Override
-  public Iterator<TYPE> iterator() {
-    return new DecoratingIterator<TYPE>(iterable.iterator()) {
+  public Iterator<E> iterator() {
+    return new DecoratingIterator<E>(iterable.iterator()) {
       @Override
-      public TYPE computeNext() {
+      public E computeNext() {
         return fromIterator.hasNext() ? fromIterator.next() : null;
       }
     };
@@ -242,7 +242,7 @@ public class LazyFluentIterable<TYPE> implements FluentIterable<TYPE> {
   /**
    * @return a FluentIterable from a given iterable. Calls the LazyFluentIterable constructor.
    */
-  public static final <TYPE> FluentIterable<TYPE> from(Iterable<TYPE> iterable) {
+  public static final <E> FluentIterable<E> from(Iterable<E> iterable) {
     return new LazyFluentIterable<>(iterable);
   }
 

--- a/fluentinterface/src/main/java/com/iluwatar/fluentinterface/fluentiterable/simple/SimpleFluentIterable.java
+++ b/fluentinterface/src/main/java/com/iluwatar/fluentinterface/fluentiterable/simple/SimpleFluentIterable.java
@@ -37,18 +37,18 @@ import com.iluwatar.fluentinterface.fluentiterable.FluentIterable;
  * This is a simple implementation of the FluentIterable interface. It evaluates all chained
  * operations eagerly. This implementation would be costly to be utilized in real applications.
  * 
- * @param <TYPE> the type of the objects the iteration is about
+ * @param <E> the type of the objects the iteration is about
  */
-public class SimpleFluentIterable<TYPE> implements FluentIterable<TYPE> {
+public class SimpleFluentIterable<E> implements FluentIterable<E> {
 
-  private final Iterable<TYPE> iterable;
+  private final Iterable<E> iterable;
 
   /**
    * This constructor creates a copy of a given iterable's contents.
    * 
    * @param iterable the iterable this interface copies to work on.
    */
-  protected SimpleFluentIterable(Iterable<TYPE> iterable) {
+  protected SimpleFluentIterable(Iterable<E> iterable) {
     this.iterable = iterable;
   }
 
@@ -61,10 +61,10 @@ public class SimpleFluentIterable<TYPE> implements FluentIterable<TYPE> {
    * @return the same FluentIterable with a filtered collection
    */
   @Override
-  public final FluentIterable<TYPE> filter(Predicate<? super TYPE> predicate) {
-    Iterator<TYPE> iterator = iterator();
+  public final FluentIterable<E> filter(Predicate<? super E> predicate) {
+    Iterator<E> iterator = iterator();
     while (iterator.hasNext()) {
-      TYPE nextElement = iterator.next();
+      E nextElement = iterator.next();
       if (!predicate.test(nextElement)) {
         iterator.remove();
       }
@@ -78,8 +78,8 @@ public class SimpleFluentIterable<TYPE> implements FluentIterable<TYPE> {
    * @return an option of the first object of the Iterable
    */
   @Override
-  public final Optional<TYPE> first() {
-    Iterator<TYPE> resultIterator = first(1).iterator();
+  public final Optional<E> first() {
+    Iterator<E> resultIterator = first(1).iterator();
     return resultIterator.hasNext() ? Optional.of(resultIterator.next()) : Optional.empty();
   }
 
@@ -91,8 +91,8 @@ public class SimpleFluentIterable<TYPE> implements FluentIterable<TYPE> {
    *         objects.
    */
   @Override
-  public final FluentIterable<TYPE> first(int count) {
-    Iterator<TYPE> iterator = iterator();
+  public final FluentIterable<E> first(int count) {
+    Iterator<E> iterator = iterator();
     int currentCount = 0;
     while (iterator.hasNext()) {
       iterator.next();
@@ -110,8 +110,8 @@ public class SimpleFluentIterable<TYPE> implements FluentIterable<TYPE> {
    * @return an option of the last object of the Iterable
    */
   @Override
-  public final Optional<TYPE> last() {
-    List<TYPE> list = last(1).asList();
+  public final Optional<E> last() {
+    List<E> list = last(1).asList();
     if (list.isEmpty()) {
       return Optional.empty();
     }
@@ -126,9 +126,9 @@ public class SimpleFluentIterable<TYPE> implements FluentIterable<TYPE> {
    *         objects
    */
   @Override
-  public final FluentIterable<TYPE> last(int count) {
+  public final FluentIterable<E> last(int count) {
     int remainingElementsCount = getRemainingElementsCount();
-    Iterator<TYPE> iterator = iterator();
+    Iterator<E> iterator = iterator();
     int currentIndex = 0;
     while (iterator.hasNext()) {
       iterator.next();
@@ -142,16 +142,16 @@ public class SimpleFluentIterable<TYPE> implements FluentIterable<TYPE> {
   }
 
   /**
-   * Transforms this FluentIterable into a new one containing objects of the type NEW_TYPE.
+   * Transforms this FluentIterable into a new one containing objects of the type T.
    * 
-   * @param function a function that transforms an instance of TYPE into an instance of NEW_TYPE
-   * @param <NEW_TYPE> the target type of the transformation
+   * @param function a function that transforms an instance of E into an instance of T
+   * @param <T> the target type of the transformation
    * @return a new FluentIterable of the new type
    */
   @Override
-  public final <NEW_TYPE> FluentIterable<NEW_TYPE> map(Function<? super TYPE, NEW_TYPE> function) {
-    List<NEW_TYPE> temporaryList = new ArrayList<>();
-    Iterator<TYPE> iterator = iterator();
+  public final <T> FluentIterable<T> map(Function<? super E, T> function) {
+    List<T> temporaryList = new ArrayList<>();
+    Iterator<E> iterator = iterator();
     while (iterator.hasNext()) {
       temporaryList.add(function.apply(iterator.next()));
     }
@@ -164,35 +164,35 @@ public class SimpleFluentIterable<TYPE> implements FluentIterable<TYPE> {
    * @return a list with all remaining objects of this Iterable
    */
   @Override
-  public List<TYPE> asList() {
+  public List<E> asList() {
     return toList(iterable.iterator());
   }
 
   /**
    * @return a FluentIterable from a given iterable. Calls the SimpleFluentIterable constructor.
    */
-  public static final <TYPE> FluentIterable<TYPE> from(Iterable<TYPE> iterable) {
+  public static final <E> FluentIterable<E> from(Iterable<E> iterable) {
     return new SimpleFluentIterable<>(iterable);
   }
 
-  public static final <TYPE> FluentIterable<TYPE> fromCopyOf(Iterable<TYPE> iterable) {
-    List<TYPE> copy = FluentIterable.copyToList(iterable);
+  public static final <E> FluentIterable<E> fromCopyOf(Iterable<E> iterable) {
+    List<E> copy = FluentIterable.copyToList(iterable);
     return new SimpleFluentIterable<>(copy);
   }
 
   @Override
-  public Iterator<TYPE> iterator() {
+  public Iterator<E> iterator() {
     return iterable.iterator();
   }
 
   @Override
-  public void forEach(Consumer<? super TYPE> action) {
+  public void forEach(Consumer<? super E> action) {
     iterable.forEach(action);
   }
 
 
   @Override
-  public Spliterator<TYPE> spliterator() {
+  public Spliterator<E> spliterator() {
     return iterable.spliterator();
   }
 
@@ -201,7 +201,7 @@ public class SimpleFluentIterable<TYPE> implements FluentIterable<TYPE> {
    */
   public final int getRemainingElementsCount() {
     int counter = 0;
-    Iterator<TYPE> iterator = iterator();
+    Iterator<E> iterator = iterator();
     while (iterator.hasNext()) {
       iterator.next();
       counter++;
@@ -214,8 +214,8 @@ public class SimpleFluentIterable<TYPE> implements FluentIterable<TYPE> {
    * 
    * @return a new List with the remaining objects.
    */
-  public static <TYPE> List<TYPE> toList(Iterator<TYPE> iterator) {
-    List<TYPE> copy = new ArrayList<>();
+  public static <E> List<E> toList(Iterator<E> iterator) {
+    List<E> copy = new ArrayList<>();
     while (iterator.hasNext()) {
       copy.add(iterator.next());
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S00119 - Type parameter names should comply with a naming convention

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S00119

Please let me know if you have any questions.

M-Ezzat