### PR TITLE
squid:S1699 - Constructors should only call non-overridable methods

### DIFF
--- a/event-aggregator/src/main/java/com/iluwatar/event/aggregator/EventEmitter.java
+++ b/event-aggregator/src/main/java/com/iluwatar/event/aggregator/EventEmitter.java
@@ -43,7 +43,7 @@ public abstract class EventEmitter {
     registerObserver(obs);
   }
 
-  public void registerObserver(EventObserver obs) {
+  public final void registerObserver(EventObserver obs) {
     observers.add(obs);
   }
 

--- a/iterator/src/main/java/com/iluwatar/iterator/Item.java
+++ b/iterator/src/main/java/com/iluwatar/iterator/Item.java
@@ -46,7 +46,7 @@ public class Item {
     return type;
   }
 
-  public void setType(ItemType type) {
+  public final void setType(ItemType type) {
     this.type = type;
   }
 }

--- a/layers/src/main/java/com/iluwatar/layers/Cake.java
+++ b/layers/src/main/java/com/iluwatar/layers/Cake.java
@@ -75,7 +75,7 @@ public class Cake {
     return layers;
   }
 
-  public void setLayers(Set<CakeLayer> layers) {
+  public final void setLayers(Set<CakeLayer> layers) {
     this.layers = layers;
   }
 

--- a/layers/src/main/java/com/iluwatar/layers/CakeLayer.java
+++ b/layers/src/main/java/com/iluwatar/layers/CakeLayer.java
@@ -66,7 +66,7 @@ public class CakeLayer {
     return name;
   }
 
-  public void setName(String name) {
+  public final void setName(String name) {
     this.name = name;
   }
 
@@ -74,7 +74,7 @@ public class CakeLayer {
     return calories;
   }
 
-  public void setCalories(int calories) {
+  public final void setCalories(int calories) {
     this.calories = calories;
   }
 

--- a/layers/src/main/java/com/iluwatar/layers/CakeTopping.java
+++ b/layers/src/main/java/com/iluwatar/layers/CakeTopping.java
@@ -66,11 +66,11 @@ public class CakeTopping {
     return name;
   }
 
-  public void setName(String name) {
+  public final void setName(String name) {
     this.name = name;
   }
 
-  public int getCalories() {
+  public final int getCalories() {
     return calories;
   }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1699 - Constructors should only call non-overridable methods

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1699

Please let me know if you have any questions.

M-Ezzat