### PR TITLE
squid:S2325 - private methods that don't access instance data should …

### DIFF
--- a/facade/src/main/java/com/iluwatar/facade/DwarvenGoldmineFacade.java
+++ b/facade/src/main/java/com/iluwatar/facade/DwarvenGoldmineFacade.java
@@ -60,7 +60,7 @@ public class DwarvenGoldmineFacade {
     makeActions(workers, DwarvenMineWorker.Action.GO_HOME, DwarvenMineWorker.Action.GO_TO_SLEEP);
   }
 
-  private void makeActions(Collection<DwarvenMineWorker> workers,
+  private static void makeActions(Collection<DwarvenMineWorker> workers,
       DwarvenMineWorker.Action... actions) {
     for (DwarvenMineWorker worker : workers) {
       worker.action(actions);

--- a/front-controller/src/main/java/com/iluwatar/front/controller/FrontController.java
+++ b/front-controller/src/main/java/com/iluwatar/front/controller/FrontController.java
@@ -44,7 +44,7 @@ public class FrontController {
     }
   }
 
-  private Class getCommandClass(String request) {
+  private static Class getCommandClass(String request) {
     Class result;
     try {
       result = Class.forName("com.iluwatar.front.controller." + request + "Command");

--- a/reactor/src/main/java/com/iluwatar/reactor/app/LoggingHandler.java
+++ b/reactor/src/main/java/com/iluwatar/reactor/app/LoggingHandler.java
@@ -58,7 +58,7 @@ public class LoggingHandler implements ChannelHandler {
     }
   }
 
-  private void sendReply(AbstractNioChannel channel, DatagramPacket incomingPacket, SelectionKey key) {
+  private static void sendReply(AbstractNioChannel channel, DatagramPacket incomingPacket, SelectionKey key) {
     /*
      * Create a reply acknowledgement datagram packet setting the receiver to the sender of incoming
      * message.
@@ -69,12 +69,12 @@ public class LoggingHandler implements ChannelHandler {
     channel.write(replyPacket, key);
   }
 
-  private void sendReply(AbstractNioChannel channel, SelectionKey key) {
+  private static void sendReply(AbstractNioChannel channel, SelectionKey key) {
     ByteBuffer buffer = ByteBuffer.wrap(ACK);
     channel.write(buffer, key);
   }
 
-  private void doLogging(ByteBuffer data) {
+  private static void doLogging(ByteBuffer data) {
     // assuming UTF-8 :(
     System.out.println(new String(data.array(), 0, data.limit()));
   }

--- a/reactor/src/main/java/com/iluwatar/reactor/framework/NioReactor.java
+++ b/reactor/src/main/java/com/iluwatar/reactor/framework/NioReactor.java
@@ -186,7 +186,7 @@ public class NioReactor {
     }
   }
 
-  private void onChannelWritable(SelectionKey key) throws IOException {
+  private static void onChannelWritable(SelectionKey key) throws IOException {
     AbstractNioChannel channel = (AbstractNioChannel) key.attachment();
     channel.flush(key);
   }

--- a/reader-writer-lock/src/main/java/com/iluwatar/reader/writer/lock/ReaderWriterLock.java
+++ b/reader-writer-lock/src/main/java/com/iluwatar/reader/writer/lock/ReaderWriterLock.java
@@ -89,7 +89,7 @@ public class ReaderWriterLock implements ReadWriteLock {
     return globalMutex.isEmpty();
   }
 
-  private void waitUninterruptibly(Object o) {
+  private static void waitUninterruptibly(Object o) {
     try {
       o.wait();
     } catch (InterruptedException e) {

--- a/repository/src/main/java/com/iluwatar/repository/AppConfig.java
+++ b/repository/src/main/java/com/iluwatar/repository/AppConfig.java
@@ -76,7 +76,7 @@ public class AppConfig {
   /**
    * Properties for Jpa
    */
-  private Properties jpaProperties() {
+  private static Properties jpaProperties() {
     Properties properties = new Properties();
     properties.setProperty("hibernate.dialect", "org.hibernate.dialect.H2Dialect");
     properties.setProperty("hibernate.hbm2ddl.auto", "create-drop");


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar squid:S2325 - "private" methods that don't access instance data should be "static"

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2325

Please let me know if you have any questions.

M-Ezzat