### PR TITLE
squid:S1611 - Parentheses should be removed from a single lambda inpu…

### DIFF
--- a/flux/src/main/java/com/iluwatar/flux/dispatcher/Dispatcher.java
+++ b/flux/src/main/java/com/iluwatar/flux/dispatcher/Dispatcher.java
@@ -71,6 +71,6 @@ public final class Dispatcher {
   }
 
   private void dispatchAction(Action action) {
-    stores.stream().forEach((store) -> store.onAction(action));
+    stores.stream().forEach( store -> store.onAction(action));
   }
 }

--- a/flux/src/main/java/com/iluwatar/flux/store/Store.java
+++ b/flux/src/main/java/com/iluwatar/flux/store/Store.java
@@ -44,6 +44,6 @@ public abstract class Store {
   }
 
   protected void notifyChange() {
-    views.stream().forEach((view) -> view.storeChanged(this));
+    views.stream().forEach(view -> view.storeChanged(this));
   }
 }

--- a/layers/src/main/java/com/iluwatar/layers/CakeBakingServiceImpl.java
+++ b/layers/src/main/java/com/iluwatar/layers/CakeBakingServiceImpl.java
@@ -54,7 +54,7 @@ public class CakeBakingServiceImpl implements CakeBakingService {
   public void bakeNewCake(CakeInfo cakeInfo) throws CakeBakingException {
     List<CakeTopping> allToppings = getAvailableToppingEntities();
     List<CakeTopping> matchingToppings =
-        allToppings.stream().filter((t) -> t.getName().equals(cakeInfo.cakeToppingInfo.name))
+        allToppings.stream().filter( t -> t.getName().equals(cakeInfo.cakeToppingInfo.name))
             .collect(Collectors.toList());
     if (matchingToppings.isEmpty()) {
       throw new CakeBakingException(String.format("Topping %s is not available",
@@ -64,7 +64,7 @@ public class CakeBakingServiceImpl implements CakeBakingService {
     Set<CakeLayer> foundLayers = new HashSet<>();
     for (CakeLayerInfo info : cakeInfo.cakeLayerInfos) {
       Optional<CakeLayer> found =
-          allLayers.stream().filter((layer) -> layer.getName().equals(info.name)).findFirst();
+          allLayers.stream().filter( layer -> layer.getName().equals(info.name)).findFirst();
       if (!found.isPresent()) {
         throw new CakeBakingException(String.format("Layer %s is not available", info.name));
       } else {

--- a/layers/src/main/java/com/iluwatar/layers/CakeViewImpl.java
+++ b/layers/src/main/java/com/iluwatar/layers/CakeViewImpl.java
@@ -36,6 +36,6 @@ public class CakeViewImpl implements View {
   }
 
   public void render() {
-    cakeBakingService.getAllCakes().stream().forEach((cake) -> System.out.println(cake));
+    cakeBakingService.getAllCakes().stream().forEach( cake -> System.out.println(cake));
   }
 }

--- a/message-channel/src/main/java/com/iluwatar/message/channel/App.java
+++ b/message-channel/src/main/java/com/iluwatar/message/channel/App.java
@@ -66,7 +66,7 @@ public class App {
     });
 
     context.start();
-    context.getRoutes().stream().forEach((r) -> System.out.println(r));
+    context.getRoutes().stream().forEach( r -> System.out.println(r));
     context.stop();
   }
 }

--- a/publish-subscribe/src/main/java/com/iluwatar/publish/subscribe/App.java
+++ b/publish-subscribe/src/main/java/com/iluwatar/publish/subscribe/App.java
@@ -61,7 +61,7 @@ public class App {
     });
     ProducerTemplate template = context.createProducerTemplate();
     context.start();
-    context.getRoutes().stream().forEach((r) -> System.out.println(r));
+    context.getRoutes().stream().forEach( r -> System.out.println(r));
     template.sendBody("direct:origin", "Hello from origin");
     context.stop();
   }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1611 - Parentheses should be removed from a single lambda input parameter when its type is inferred

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1611

Please let me know if you have any questions.

M-Ezzat