### PR TITLE
Applied skeletal implementation to interface migration automated refactoring

### DIFF
--- a/abstract-document/src/main/java/com/iluwatar/abstractdocument/AbstractDocument.java
+++ b/abstract-document/src/main/java/com/iluwatar/abstractdocument/AbstractDocument.java
@@ -22,12 +22,8 @@
  */
 package com.iluwatar.abstractdocument;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
-import java.util.function.Function;
-import java.util.stream.Stream;
 
 /**
  * Abstract implementation of Document interface
@@ -50,13 +46,6 @@ public abstract class AbstractDocument implements Document {
   @Override
   public Object get(String key) {
     return properties.get(key);
-  }
-
-  @Override
-  public <T> Stream<T> children(String key, Function<Map<String, Object>, T> constructor) {
-    Optional<List<Map<String, Object>>> any = Stream.of(get(key)).filter(el -> el != null)
-        .map(el -> (List<Map<String, Object>>) el).findAny();
-    return any.isPresent() ? any.get().stream().map(constructor) : Stream.empty();
   }
 
   @Override

--- a/abstract-document/src/main/java/com/iluwatar/abstractdocument/Document.java
+++ b/abstract-document/src/main/java/com/iluwatar/abstractdocument/Document.java
@@ -22,7 +22,9 @@
  */
 package com.iluwatar.abstractdocument;
 
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
@@ -55,5 +57,9 @@ public interface Document {
    * @param constructor constructor of child class
    * @return child documents
    */
-  <T> Stream<T> children(String key, Function<Map<String, Object>, T> constructor);
+  default <T> Stream<T> children(String key, Function<Map<String, Object>, T> constructor) {
+    Optional<List<Map<String, Object>>> any = Stream.of(get(key)).filter(el -> el != null)
+        .map(el -> (List<Map<String, Object>>) el).findAny();
+    return any.isPresent() ? any.get().stream().map(constructor) : Stream.empty();
+  }
 }

--- a/intercepting-filter/src/main/java/com/iluwatar/intercepting/filter/AbstractFilter.java
+++ b/intercepting-filter/src/main/java/com/iluwatar/intercepting/filter/AbstractFilter.java
@@ -45,22 +45,4 @@ public abstract class AbstractFilter implements Filter {
   public Filter getNext() {
     return next;
   }
-
-  @Override
-  public Filter getLast() {
-    Filter last = this;
-    while (last.getNext() != null) {
-      last = last.getNext();
-    }
-    return last;
-  }
-
-  @Override
-  public String execute(Order order) {
-    if (getNext() != null) {
-      return getNext().execute(order);
-    } else {
-      return "";
-    }
-  }
 }

--- a/intercepting-filter/src/main/java/com/iluwatar/intercepting/filter/Filter.java
+++ b/intercepting-filter/src/main/java/com/iluwatar/intercepting/filter/Filter.java
@@ -34,7 +34,13 @@ public interface Filter {
   /**
    * Execute order processing filter.
    */
-  String execute(Order order);
+  default String execute(Order order) {
+    if (getNext() != null) {
+      return getNext().execute(order);
+    } else {
+      return "";
+    }
+  }
 
   /**
    * Set next filter in chain after this.
@@ -49,5 +55,11 @@ public interface Filter {
   /**
    * Get last filter in the chain.
    */
-  Filter getLast();
+  default Filter getLast() {
+    Filter last = this;
+    while (last.getNext() != null) {
+      last = last.getNext();
+    }
+    return last;
+  }
 }

--- a/mediator/src/main/java/com/iluwatar/mediator/PartyMember.java
+++ b/mediator/src/main/java/com/iluwatar/mediator/PartyMember.java
@@ -31,7 +31,9 @@ public interface PartyMember {
 
   void joinedParty(Party party);
 
-  void partyAction(Action action);
+  default void partyAction(Action action) {
+    System.out.println(this + " " + action.getDescription());
+  }
 
   void act(Action action);
 }

--- a/mediator/src/main/java/com/iluwatar/mediator/PartyMemberBase.java
+++ b/mediator/src/main/java/com/iluwatar/mediator/PartyMemberBase.java
@@ -38,11 +38,6 @@ public abstract class PartyMemberBase implements PartyMember {
   }
 
   @Override
-  public void partyAction(Action action) {
-    System.out.println(this + " " + action.getDescription());
-  }
-
-  @Override
   public void act(Action action) {
     if (party != null) {
       System.out.println(this + " " + action.toString());


### PR DESCRIPTION
This is a semantics-preserving automated refactoring that migrates existing method implementations in classes to the corresponding implemented interface methods as `default` methods. The tool **does not** add new code; it only rearranges *existing* code.

- We are evaluating a research prototype automated refactoring Eclipse plug-in called [Migrate Skeletal Implementation to Interface](https://github.com/khatchad/Migrate-Skeletal-Implementation-to-Interface-Refactoring). We have applied the tool to your project in the hopes of receiving feedback.
- The approach is very conservative. Specifically, it only performs a migration if the target interface is unambiguous. That may mean that not all changes that can be made were made. Please feel free to continue the refactoring manually if you wish.
- We only migrated methods declared in abstract classes. We believe such methods to be likely suitable default methods in corresponding interfaces.
- The source code should be semantically equivalent to the original.

Thank you for your help in this evaluation! Any feedback you can provide would be very helpful. In particular, we are interested if *each* of the proposed changes are helpful or not.