### PR TITLE
Update ObjectPool.java

### DIFF
--- a/object-pool/src/main/java/com/iluwatar/object/pool/ObjectPool.java
+++ b/object-pool/src/main/java/com/iluwatar/object/pool/ObjectPool.java
@@ -40,7 +40,7 @@ public abstract class ObjectPool<T> {
    * Checkout object from pool
    */
   public synchronized T checkOut() {
-    if (available.size() <= 0) {
+    if (available.isEmpty()) {
       available.add(create());
     }
     T instance = available.iterator().next();


### PR DESCRIPTION
available.size() < 0 is impossible, so it has sense only in case available.size() = 0, and it means that collection is empty, besides function isEmpty() is faster, than checking of the size.