### PR TITLE
Adding Setter Dependency Injection as a second subtype of DI

### DIFF
--- a/dependency-injection/src/main/java/com/iluwatar/dependency/injection/AdvancedSorceress.java
+++ b/dependency-injection/src/main/java/com/iluwatar/dependency/injection/AdvancedSorceress.java
@@ -28,7 +28,6 @@ package com.iluwatar.dependency.injection;
  *
  * AdvancedSorceress implements inversion of control. It depends on abstraction that can be injected
  * through its setter.
- *
  */
 public class AdvancedSorceress implements Wizard {
 

--- a/dependency-injection/src/main/java/com/iluwatar/dependency/injection/AdvancedSorceress.java
+++ b/dependency-injection/src/main/java/com/iluwatar/dependency/injection/AdvancedSorceress.java
@@ -3,17 +3,17 @@ package com.iluwatar.dependency.injection;
 /**
  * The MIT License
  * Copyright (c) 2014-2017 Ilkka Seppälä
- *
+ * <p>
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *
+ * <p>
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- *
+ * <p>
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -32,14 +32,14 @@ package com.iluwatar.dependency.injection;
  */
 public class AdvancedSorceress implements Wizard {
 
-    private Tobacco tobacco;
+  private Tobacco tobacco;
 
-    public void setTobacco(Tobacco tobacco) {
-        this.tobacco = tobacco;
-    }
+  public void setTobacco(Tobacco tobacco) {
+    this.tobacco = tobacco;
+  }
 
-    @Override
-    public void smoke() {
-        tobacco.smoke(this);
-    }
+  @Override
+  public void smoke() {
+    tobacco.smoke(this);
+  }
 }

--- a/dependency-injection/src/main/java/com/iluwatar/dependency/injection/AdvancedSorceress.java
+++ b/dependency-injection/src/main/java/com/iluwatar/dependency/injection/AdvancedSorceress.java
@@ -25,7 +25,6 @@ package com.iluwatar.dependency.injection;
 
 
 /**
- *
  * AdvancedSorceress implements inversion of control. It depends on abstraction that can be injected
  * through its setter.
  */

--- a/dependency-injection/src/main/java/com/iluwatar/dependency/injection/AdvancedSorceress.java
+++ b/dependency-injection/src/main/java/com/iluwatar/dependency/injection/AdvancedSorceress.java
@@ -1,0 +1,45 @@
+package com.iluwatar.dependency.injection;
+
+/**
+ * The MIT License
+ * Copyright (c) 2014-2017 Ilkka Seppälä
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
+/**
+ *
+ * AdvancedSorceress implements inversion of control. It depends on abstraction that can be injected
+ * through its setter.
+ *
+ */
+public class AdvancedSorceress implements Wizard {
+
+    private Tobacco tobacco;
+
+    public void setTobacco(Tobacco tobacco) {
+        this.tobacco = tobacco;
+    }
+
+    @Override
+    public void smoke() {
+        tobacco.smoke(this);
+    }
+}

--- a/dependency-injection/src/main/java/com/iluwatar/dependency/injection/App.java
+++ b/dependency-injection/src/main/java/com/iluwatar/dependency/injection/App.java
@@ -1,17 +1,17 @@
 /**
  * The MIT License
  * Copyright (c) 2014-2016 Ilkka Seppälä
- *
+ * <p>
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *
+ * <p>
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- *
+ * <p>
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -26,7 +26,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 
 /**
- * 
+ *
  * Dependency Injection pattern deals with how objects handle their dependencies. The pattern
  * implements so called inversion of control principle. Inversion of control has two specific rules:
  * - High-level modules should not depend on low-level modules. Both should depend on abstractions.
@@ -36,32 +36,37 @@ import com.google.inject.Injector;
  * naive implementation violating the inversion of control principle. It depends directly on a
  * concrete implementation which cannot be changed.
  * <p>
- * The second wizard ({@link AdvancedWizard}) is more flexible. It does not depend on any concrete
- * implementation but abstraction. It utilizes Dependency Injection pattern allowing its
- * {@link Tobacco} dependency to be injected through its constructor. This way, handling the
- * dependency is no longer the wizard's responsibility. It is resolved outside the wizard class.
+ * The second and third wizards({@link AdvancedWizard} and {@link AdvancedSorceress}) are more flexible.
+ * They do not depend on any concrete implementation but abstraction. They utilizes Dependency Injection
+ * pattern allowing their {@link Tobacco} dependency to be injected through constructor ({@link AdvancedWizard})
+ * or setter ({@link AdvancedSorceress}). This way, handling the dependency is no longer the wizard's
+ * responsibility. It is resolved outside the wizard class.
  * <p>
- * The third example takes the pattern a step further. It uses Guice framework for Dependency
+ * The fourth example takes the pattern a step further. It uses Guice framework for Dependency
  * Injection. {@link TobaccoModule} binds a concrete implementation to abstraction. Injector is then
  * used to create {@link GuiceWizard} object with correct dependencies.
  *
  */
 public class App {
 
-  /**
-   * Program entry point
-   * 
-   * @param args command line args
-   */
-  public static void main(String[] args) {
-    SimpleWizard simpleWizard = new SimpleWizard();
-    simpleWizard.smoke();
+    /**
+     * Program entry point
+     *
+     * @param args command line args
+     */
+    public static void main(String[] args) {
+        SimpleWizard simpleWizard = new SimpleWizard();
+        simpleWizard.smoke();
 
-    AdvancedWizard advancedWizard = new AdvancedWizard(new SecondBreakfastTobacco());
-    advancedWizard.smoke();
+        AdvancedWizard advancedWizard = new AdvancedWizard(new SecondBreakfastTobacco());
+        advancedWizard.smoke();
 
-    Injector injector = Guice.createInjector(new TobaccoModule());
-    GuiceWizard guiceWizard = injector.getInstance(GuiceWizard.class);
-    guiceWizard.smoke();
-  }
+        AdvancedSorceress advancedSorceress = new AdvancedSorceress();
+        advancedSorceress.setTobacco(new SecondBreakfastTobacco());
+        advancedSorceress.smoke();
+
+        Injector injector = Guice.createInjector(new TobaccoModule());
+        GuiceWizard guiceWizard = injector.getInstance(GuiceWizard.class);
+        guiceWizard.smoke();
+    }
 }

--- a/dependency-injection/src/main/java/com/iluwatar/dependency/injection/App.java
+++ b/dependency-injection/src/main/java/com/iluwatar/dependency/injection/App.java
@@ -26,7 +26,6 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 
 /**
- *
  * Dependency Injection pattern deals with how objects handle their dependencies. The pattern
  * implements so called inversion of control principle. Inversion of control has two specific rules:
  * - High-level modules should not depend on low-level modules. Both should depend on abstractions.
@@ -45,28 +44,27 @@ import com.google.inject.Injector;
  * The fourth example takes the pattern a step further. It uses Guice framework for Dependency
  * Injection. {@link TobaccoModule} binds a concrete implementation to abstraction. Injector is then
  * used to create {@link GuiceWizard} object with correct dependencies.
- *
  */
 public class App {
 
-    /**
-     * Program entry point
-     *
-     * @param args command line args
-     */
-    public static void main(String[] args) {
-        SimpleWizard simpleWizard = new SimpleWizard();
-        simpleWizard.smoke();
+  /**
+   * Program entry point
+   *
+   * @param args command line args
+   */
+  public static void main(String[] args) {
+    SimpleWizard simpleWizard = new SimpleWizard();
+    simpleWizard.smoke();
 
-        AdvancedWizard advancedWizard = new AdvancedWizard(new SecondBreakfastTobacco());
-        advancedWizard.smoke();
+    AdvancedWizard advancedWizard = new AdvancedWizard(new SecondBreakfastTobacco());
+    advancedWizard.smoke();
 
-        AdvancedSorceress advancedSorceress = new AdvancedSorceress();
-        advancedSorceress.setTobacco(new SecondBreakfastTobacco());
-        advancedSorceress.smoke();
+    AdvancedSorceress advancedSorceress = new AdvancedSorceress();
+    advancedSorceress.setTobacco(new SecondBreakfastTobacco());
+    advancedSorceress.smoke();
 
-        Injector injector = Guice.createInjector(new TobaccoModule());
-        GuiceWizard guiceWizard = injector.getInstance(GuiceWizard.class);
-        guiceWizard.smoke();
-    }
+    Injector injector = Guice.createInjector(new TobaccoModule());
+    GuiceWizard guiceWizard = injector.getInstance(GuiceWizard.class);
+    guiceWizard.smoke();
+  }
 }

--- a/dependency-injection/src/test/java/com/iluwatar/dependency/injection/AdvancedSorceressTest.java
+++ b/dependency-injection/src/test/java/com/iluwatar/dependency/injection/AdvancedSorceressTest.java
@@ -26,44 +26,51 @@ import com.iluwatar.dependency.injection.utils.InMemoryAppender;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
 import static org.junit.Assert.assertEquals;
+
+/**
+ * Date: 28/04/17 - 7:40 AM
+ *
+ * @author Stanislav Kapinus
+ */
 
 public class AdvancedSorceressTest {
 
-    private InMemoryAppender appender;
+  private InMemoryAppender appender;
 
-    @Before
-    public void setUp() {
-        appender = new InMemoryAppender(Tobacco.class);
+  @Before
+  public void setUp() {
+    appender = new InMemoryAppender(Tobacco.class);
+  }
+
+  @After
+  public void tearDown() {
+    appender.stop();
+  }
+
+  /**
+   * Test if the {@link AdvancedSorceress} smokes whatever instance of {@link Tobacco} is passed to her
+   * through the setter's parameter
+   */
+  @Test
+  public void testSmokeEveryThing() throws Exception {
+
+    final Tobacco[] tobaccos = {
+        new OldTobyTobacco(), new RivendellTobacco(), new SecondBreakfastTobacco()
+    };
+
+    for (final Tobacco tobacco : tobaccos) {
+      final AdvancedSorceress advancedSorceress = new AdvancedSorceress();
+      advancedSorceress.setTobacco(tobacco);
+      advancedSorceress.smoke();
+      // Verify if the sorceress is smoking the correct tobacco ...
+      assertEquals("AdvancedSorceress smoking " + tobacco.getClass().getSimpleName(), appender.getLastMessage());
+
     }
 
-    @After
-    public void tearDown() {
-        appender.stop();
-    }
+    // ... and nothing else is happening.
+    assertEquals(tobaccos.length, appender.getLogSize());
 
-    /**
-     * Test if the {@link AdvancedSorceress} smokes whatever instance of {@link Tobacco} is passed to her
-     * through the setter's parameter
-     */
-    
-    @Test
-    public void testSmokeEveryThing() throws Exception {
-
-        final Tobacco[] tobaccos = {
-                new OldTobyTobacco(), new RivendellTobacco(), new SecondBreakfastTobacco()
-        };
-
-        for (final Tobacco tobacco : tobaccos) {
-            final AdvancedSorceress advancedSorceress = new AdvancedSorceress();
-            advancedSorceress.setTobacco(tobacco);
-            advancedSorceress.smoke();
-            // Verify if the sorceress is smoking the correct tobacco ...
-            assertEquals("AdvancedSorceress smoking " + tobacco.getClass().getSimpleName(), appender.getLastMessage());
-
-        }
-
-        // ... and nothing else is happening.
-        assertEquals(tobaccos.length, appender.getLogSize());
-    }
+  }
 }

--- a/dependency-injection/src/test/java/com/iluwatar/dependency/injection/AdvancedSorceressTest.java
+++ b/dependency-injection/src/test/java/com/iluwatar/dependency/injection/AdvancedSorceressTest.java
@@ -26,14 +26,7 @@ import com.iluwatar.dependency.injection.utils.InMemoryAppender;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
 import static org.junit.Assert.assertEquals;
-
-/**
- * Date: 28/04/17 - 7:40 AM
- *
- * @author Stanislav Kapinus
- */
 
 public class AdvancedSorceressTest {
 

--- a/dependency-injection/src/test/java/com/iluwatar/dependency/injection/AdvancedSorceressTest.java
+++ b/dependency-injection/src/test/java/com/iluwatar/dependency/injection/AdvancedSorceressTest.java
@@ -1,0 +1,77 @@
+/**
+ * The MIT License
+ * Copyright (c) 2014-2016 Ilkka Seppälä
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * <p>
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * <p>
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.iluwatar.dependency.injection;
+
+import com.iluwatar.dependency.injection.utils.InMemoryAppender;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Date: 28/04/17 - 7:40 AM
+ *
+ * @author Stanislav Kapinus
+ */
+
+public class AdvancedSorceressTest {
+
+    private InMemoryAppender appender;
+
+    @Before
+    public void setUp() {
+        appender = new InMemoryAppender(Tobacco.class);
+    }
+
+    @After
+    public void tearDown() {
+        appender.stop();
+    }
+
+    /**
+     * Test if the {@link AdvancedSorceress} smokes whatever instance of {@link Tobacco} is passed to her
+     * through the setter's parameter
+     */
+    @Test
+    public void testSmokeEveryThing() throws Exception {
+
+        final Tobacco[] tobaccos = {
+                new OldTobyTobacco(), new RivendellTobacco(), new SecondBreakfastTobacco()
+        };
+
+        for (final Tobacco tobacco : tobaccos) {
+            final AdvancedSorceress advancedSorceress = new AdvancedSorceress();
+            advancedSorceress.setTobacco(tobacco);
+            advancedSorceress.smoke();
+            // Verify if the sorceress is smoking the correct tobacco ...
+            assertEquals("AdvancedSorceress smoking " + tobacco.getClass().getSimpleName(), appender.getLastMessage());
+
+        }
+
+        // ... and nothing else is happening.
+        assertEquals(tobaccos.length, appender.getLogSize());
+
+    }
+
+}

--- a/dependency-injection/src/test/java/com/iluwatar/dependency/injection/AdvancedSorceressTest.java
+++ b/dependency-injection/src/test/java/com/iluwatar/dependency/injection/AdvancedSorceressTest.java
@@ -46,6 +46,7 @@ public class AdvancedSorceressTest {
      * Test if the {@link AdvancedSorceress} smokes whatever instance of {@link Tobacco} is passed to her
      * through the setter's parameter
      */
+    
     @Test
     public void testSmokeEveryThing() throws Exception {
 
@@ -64,7 +65,5 @@ public class AdvancedSorceressTest {
 
         // ... and nothing else is happening.
         assertEquals(tobaccos.length, appender.getLogSize());
-
     }
-
 }


### PR DESCRIPTION
There are two types of dependency injection: Constructor dependency injection and Setter Dependency Injection. Both types have pluses and minuses and wide used (f.e. in Spring Framework). This patch describes second type of DI - Setter Dependency Injection. 

Class AdvancedSorceress is constructed by analogy with AdvancedWizard. Difference between them is in the way of dependency injection. Tests attached.