### PR TITLE
#587 SonarQube reports bugs

### DIFF
--- a/model-view-presenter/src/main/java/com/iluwatar/model/view/presenter/FileLoader.java
+++ b/model-view-presenter/src/main/java/com/iluwatar/model/view/presenter/FileLoader.java
@@ -25,6 +25,10 @@ package com.iluwatar.model.view.presenter;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
+import java.io.Serializable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Every instance of this class represents the Model component in the Model-View-Presenter
@@ -32,7 +36,14 @@ import java.io.FileReader;
  * <p>
  * It is responsible for reading and loading the contents of a given file.
  */
-public class FileLoader {
+public class FileLoader implements Serializable{
+
+  /**
+   * Generated serial version UID
+   */
+  private static final long serialVersionUID = -4745803872902019069L;
+  
+  private static final Logger LOGGER = LoggerFactory.getLogger(FileLoader.class);
 
   /**
    * Indicates if the file is loaded or not.
@@ -48,7 +59,8 @@ public class FileLoader {
    * Loads the data of the file specified.
    */
   public String loadData() {
-    try (BufferedReader br = new BufferedReader(new FileReader(new File(this.fileName)))) {
+    String dataFileName = this.fileName;
+    try (BufferedReader br = new BufferedReader(new FileReader(new File(dataFileName)))) {
       StringBuilder sb = new StringBuilder();
       String line;
 
@@ -60,7 +72,7 @@ public class FileLoader {
 
       return sb.toString();
     } catch (Exception e) {
-      e.printStackTrace();
+      LOGGER.error("File {} does not exist", dataFileName);
     }
 
     return null;

--- a/model-view-presenter/src/main/java/com/iluwatar/model/view/presenter/FileSelectorPresenter.java
+++ b/model-view-presenter/src/main/java/com/iluwatar/model/view/presenter/FileSelectorPresenter.java
@@ -22,13 +22,20 @@
  */
 package com.iluwatar.model.view.presenter;
 
+import java.io.Serializable;
+
 /**
  * Every instance of this class represents the Presenter component in the Model-View-Presenter
  * architectural pattern.
  * <p>
  * It is responsible for reacting to the user's actions and update the View component.
  */
-public class FileSelectorPresenter {
+public class FileSelectorPresenter implements Serializable{
+
+  /**
+   * Generated serial version UID
+   */
+  private static final long serialVersionUID = 1210314339075855074L;
 
   /**
    * The View component that the presenter interacts with.

--- a/model-view-presenter/src/main/java/com/iluwatar/model/view/presenter/FileSelectorView.java
+++ b/model-view-presenter/src/main/java/com/iluwatar/model/view/presenter/FileSelectorView.java
@@ -22,11 +22,13 @@
  */
 package com.iluwatar.model.view.presenter;
 
+import java.io.Serializable;
+
 /**
  * This interface represents the View component in the Model-View-Presenter pattern. It can be
  * implemented by either the GUI components, or by the Stub.
  */
-public interface FileSelectorView {
+public interface FileSelectorView extends Serializable{
 
   /**
    * Opens the view.


### PR DESCRIPTION
Marking FileLoader (Model) as Serializable, because model is an interface to provide data and it can provide caching behaviour. Presenter should be able to restore the model in any event.
Marking FileSelectorView as Serializable as I think view is made up of some static structure and Serializable data (from model).
Presenter is an middle-man who manages View and Model. Both View and Model will be given to Presenter by the application. It will not make any harm to make presenter as Serializable. It will be useful serialize model and view as it is tied to one another.

Or, we could set //NOSONAR and let the consumer application framework to decide whether to mark as Serializable or not based on their design.


References: 
https://en.wikipedia.org/wiki/Model%E2%80%93view%E2%80%93presenter
https://medium.com/@cervonefrancesco/model-view-presenter-android-guidelines-94970b430ddf