### PR TITLE
#587 SonarQube reports bugs - async-method-invocation

### DIFF
--- a/async-method-invocation/src/main/java/com/iluwatar/async/method/invocation/ThreadAsyncExecutor.java
+++ b/async-method-invocation/src/main/java/com/iluwatar/async/method/invocation/ThreadAsyncExecutor.java
@@ -139,7 +139,7 @@ public class ThreadAsyncExecutor implements AsyncExecutor {
     @Override
     public void await() throws InterruptedException {
       synchronized (lock) {
-        if (!isCompleted()) {
+        while (!isCompleted()) {
           lock.wait();
         }
       }


### PR DESCRIPTION
As recommended in
https://sonarcloud.io/organizations/default/rules#rule_key=squid%3AS2274 
Used while insteadof if - for waiting upon a condition.