### PR TITLE
Fix naked objects thesis url

### DIFF
--- a/naked-objects/README.md
+++ b/naked-objects/README.md
@@ -29,4 +29,4 @@ Use the Naked Objects pattern when
 
 ## Credits
 
-* [Richard Pawson - Naked Objects](https://isis.apache.org/resources/thesis/Pawson-Naked-Objects-thesis.pdf)
+* [Richard Pawson - Naked Objects](http://downloads.nakedobjects.net/resources/Pawson%20thesis.pdf)


### PR DESCRIPTION
The commit fixes the URL, changing from a non-working URL to an actually
working one.
The URL was copied from the wikipedia page for Naked Objects.