### PR TITLE
Fix FactoryMethodTest and PrototypeTest

### DIFF
--- a/factory-method/src/test/java/com/iluwatar/factory/method/FactoryMethodTest.java
+++ b/factory-method/src/test/java/com/iluwatar/factory/method/FactoryMethodTest.java
@@ -95,7 +95,7 @@ public class FactoryMethodTest {
    */
   private void verifyWeapon(Weapon weapon, WeaponType expectedWeaponType, Class<?> clazz) {
     assertTrue("Weapon must be an object of: " + clazz.getName(), clazz.isInstance(weapon));
-    assertEquals("Weapon must be of weaponType: " + clazz.getName(), expectedWeaponType,
+    assertEquals("Weapon must be of weaponType: " + expectedWeaponType, expectedWeaponType,
         weapon.getWeaponType());
   }
 }

--- a/prototype/src/test/java/com/iluwatar/prototype/PrototypeTest.java
+++ b/prototype/src/test/java/com/iluwatar/prototype/PrototypeTest.java
@@ -56,7 +56,7 @@ public class PrototypeTest<P extends Prototype> {
   /**
    * The tested prototype instance
    */
-  private final Prototype testedPrototype;
+  private final P testedPrototype;
 
   /**
    * The expected {@link Prototype#toString()} value
@@ -69,7 +69,7 @@ public class PrototypeTest<P extends Prototype> {
    * @param testedPrototype  The tested prototype instance
    * @param expectedToString The expected {@link Prototype#toString()} value
    */
-  public PrototypeTest(final Prototype testedPrototype, final String expectedToString) {
+  public PrototypeTest(final P testedPrototype, final String expectedToString) {
     this.expectedToString = expectedToString;
     this.testedPrototype = testedPrototype;
   }


### PR DESCRIPTION
- The test message for the WeaponType assertion should tell the expected WeaponType instead of the Weapon class name.
- Remove compiler warning of unused generic type in PrototypeTest