### PR TITLE
#653: Url encode content to fix JSON breaking pattern descriptions

### DIFF
--- a/search_index.json
+++ b/search_index.json
@@ -21,7 +21,7 @@
         "tags"     : "{{ page.tags | join: ', ' }}",
         "url"      : "{{ site.baseurl }}{{ page.url }}",
         "date"     : "{{ page.date }}",
-        "content"  : "{{ page.content | strip_html | strip_newlines | replace: '"', '' }}",
+        "content"  : "{{ page.content | strip_html | strip_newlines | url_encode | replace: '"', '' }}",
         "layout"   : "{{ page.layout }}"
      {% endif %}
    } {% unless forloop.last %},{% endunless %}


### PR DESCRIPTION
Some of the patterns contain braces that will break jQuery's
`getJSON` method when it attempts to parse the response. Adding
the `url_encode` filter ensures that this doesn't happen again.