### PR TITLE
(Abstract Factory) Add factory of factories

### DIFF
--- a/abstract-factory/README.md
+++ b/abstract-factory/README.md
@@ -120,6 +120,45 @@ king.getDescription(); // Output: This is the Elven king!
 army.getDescription(); // Output: This is the Elven Army!
 ```
 
+Now, we can design a factory for our different kingdom factories. In this example, we created FactoryMaker, responsible for returning an instance of either ElfKingdomFactory or OrcKingdomFactory.  
+The client can use FactoryMaker to create the desired concrete factory which, in turn, will produce different concrete objects (Army, King, Castle).  
+In this example, we also used an enum to parameterize which type of kingdom factory the client will ask for.
+
+```
+public static class FactoryMaker {
+
+  public enum KingdomType {
+    ELF, ORC
+  }
+
+  public static KingdomFactory makeFactory(KingdomType type) {
+    switch (type) {
+      case ELF:
+        return new ElfKingdomFactory();
+      case ORC:
+        return new OrcKingdomFactory();
+      default:
+        throw new IllegalArgumentException("KingdomType not supported.");
+    }
+  }
+}
+
+public static void main(String[] args) {
+  App app = new App();
+
+  LOGGER.info("Elf Kingdom");
+  app.createKingdom(FactoryMaker.makeFactory(KingdomType.ELF));
+  LOGGER.info(app.getArmy().getDescription());
+  LOGGER.info(app.getCastle().getDescription());
+  LOGGER.info(app.getKing().getDescription());
+
+  LOGGER.info("Orc Kingdom");
+  app.createKingdom(FactoryMaker.makeFactory(KingdomType.ORC));
+  -- similar use of the orc factory
+}
+```
+
+
 ## Applicability
 Use the Abstract Factory pattern when
 

--- a/abstract-factory/src/main/java/com/iluwatar/abstractfactory/App.java
+++ b/abstract-factory/src/main/java/com/iluwatar/abstractfactory/App.java
@@ -95,17 +95,20 @@ public class App {
     this.army = army;
   }
 
+  /**
+   * The factory of kingdom factories.
+   */
   public static class FactoryMaker {
 
-    private FactoryMaker() {
-    }
-
+    /**
+     * Enumeration for the different types of Kingdoms.
+     */
     public enum KingdomType {
       ELF, ORC
     }
 
     /**
-     * The factory of kingdom factories.
+     * The factory method to create KingdomFactory concrete objects.
      */
     public static KingdomFactory makeFactory(KingdomType type) {
       switch (type) {

--- a/abstract-factory/src/main/java/com/iluwatar/abstractfactory/App.java
+++ b/abstract-factory/src/main/java/com/iluwatar/abstractfactory/App.java
@@ -95,33 +95,32 @@ public class App {
     this.army = army;
   }
 
-  /**
-   * The factory of kingdom factories.
-   */
   public static class FactoryMaker {
-	    
-	private FactoryMaker() {}
-	
-	public enum KingdomType {
-	  ELF,
-	  ORC
-	}
-	  
-	public static KingdomFactory makeFactory(KingdomType type) {
 
-	  switch (type) {
-		case ELF:
-		  return new ElfKingdomFactory();
-		case ORC:
-		  return new OrcKingdomFactory();
-		default:
-		  throw new IllegalArgumentException("KingdomType not supported.");
-	  }
-	}
+    private FactoryMaker() {
+    }
+
+    public enum KingdomType {
+      ELF, ORC
+    }
+
+    /**
+     * The factory of kingdom factories.
+     */
+    public static KingdomFactory makeFactory(KingdomType type) {
+      switch (type) {
+        case ELF:
+          return new ElfKingdomFactory();
+        case ORC:
+          return new OrcKingdomFactory();
+        default:
+          throw new IllegalArgumentException("KingdomType not supported.");
+      }
+    }
   }
-  
+
   /**
-   * Program entry point
+   * Program entry point.
    * 
    * @param args
    *          command line args

--- a/abstract-factory/src/main/java/com/iluwatar/abstractfactory/App.java
+++ b/abstract-factory/src/main/java/com/iluwatar/abstractfactory/App.java
@@ -25,6 +25,8 @@ package com.iluwatar.abstractfactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.iluwatar.abstractfactory.App.FactoryMaker.KingdomType;
+
 /**
  * 
  * The Abstract Factory pattern provides a way to encapsulate a group of individual factories that have a common theme
@@ -56,7 +58,7 @@ public class App {
     setCastle(factory.createCastle());
     setArmy(factory.createArmy());
   }
-
+  
   King getKing(final KingdomFactory factory) {
     return factory.createKing();
   }
@@ -92,6 +94,31 @@ public class App {
   private void setArmy(final Army army) {
     this.army = army;
   }
+
+  /**
+   * The factory of kingdom factories.
+   */
+  public static class FactoryMaker {
+	    
+	private FactoryMaker() {}
+	
+	public enum KingdomType {
+	  ELF,
+	  ORC
+	}
+	  
+	public static KingdomFactory makeFactory(KingdomType type) {
+
+	  switch (type) {
+		case ELF:
+		  return new ElfKingdomFactory();
+		case ORC:
+		  return new OrcKingdomFactory();
+		default:
+		  throw new IllegalArgumentException("KingdomType not supported.");
+	  }
+	}
+  }
   
   /**
    * Program entry point
@@ -104,17 +131,15 @@ public class App {
     App app = new App();
 
     LOGGER.info("Elf Kingdom");
-    app.createKingdom(new ElfKingdomFactory());
+    app.createKingdom(FactoryMaker.makeFactory(KingdomType.ELF));
     LOGGER.info(app.getArmy().getDescription());
     LOGGER.info(app.getCastle().getDescription());
     LOGGER.info(app.getKing().getDescription());
 
     LOGGER.info("Orc Kingdom");
-    app.createKingdom(new OrcKingdomFactory());
+    app.createKingdom(FactoryMaker.makeFactory(KingdomType.ORC));
     LOGGER.info(app.getArmy().getDescription());
     LOGGER.info(app.getCastle().getDescription());
     LOGGER.info(app.getKing().getDescription());
-
   }
-
 }

--- a/abstract-factory/src/test/java/com/iluwatar/abstractfactory/AbstractFactoryTest.java
+++ b/abstract-factory/src/test/java/com/iluwatar/abstractfactory/AbstractFactoryTest.java
@@ -28,6 +28,9 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.iluwatar.abstractfactory.App.FactoryMaker;
+import com.iluwatar.abstractfactory.App.FactoryMaker.KingdomType;
+
 /**
  * Test for abstract factory
  */
@@ -39,8 +42,8 @@ public class AbstractFactoryTest {
 
   @Before
   public void setUp() {
-    elfFactory = new ElfKingdomFactory();
-    orcFactory = new OrcKingdomFactory();
+    elfFactory = FactoryMaker.makeFactory(KingdomType.ELF);
+    orcFactory = FactoryMaker.makeFactory(KingdomType.ORC);
   }
 
   @Test

--- a/abstract-factory/src/test/java/com/iluwatar/abstractfactory/AbstractFactoryTest.java
+++ b/abstract-factory/src/test/java/com/iluwatar/abstractfactory/AbstractFactoryTest.java
@@ -25,11 +25,11 @@ package com.iluwatar.abstractfactory;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import org.junit.Before;
-import org.junit.Test;
-
 import com.iluwatar.abstractfactory.App.FactoryMaker;
 import com.iluwatar.abstractfactory.App.FactoryMaker.KingdomType;
+
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * Test for abstract factory


### PR DESCRIPTION
The explanation for the pattern mentions that it is "a factory of factories", but the example does not have any factory class that returns the concrete classes of **KingdomFactory**.

This commit removes the direct instantiation of **ElfKingdomFactory** and **OrcKingdomFactory** from **App.main()** and delegates their creation to a new (factory of factories) **FactoryMaker** inner class of **App**.

Even though the pattern itself does not necessarily need this, it helps to synchronize the explanation text with the coding example, making it easier to understand that statement.