### PR TITLE
Migrate to JUnit5

### DIFF
--- a/abstract-document/pom.xml
+++ b/abstract-document/pom.xml
@@ -34,8 +34,13 @@
     <artifactId>abstract-document</artifactId>
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/abstract-document/src/test/java/com/iluwatar/abstractdocument/AbstractDocumentTest.java
+++ b/abstract-document/src/test/java/com/iluwatar/abstractdocument/AbstractDocumentTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.abstractdocument;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -30,8 +30,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * AbstractDocument test class

--- a/abstract-document/src/test/java/com/iluwatar/abstractdocument/AppTest.java
+++ b/abstract-document/src/test/java/com/iluwatar/abstractdocument/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.abstractdocument;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Simple App test

--- a/abstract-document/src/test/java/com/iluwatar/abstractdocument/DomainTest.java
+++ b/abstract-document/src/test/java/com/iluwatar/abstractdocument/DomainTest.java
@@ -28,13 +28,13 @@ import com.iluwatar.abstractdocument.domain.HasParts;
 import com.iluwatar.abstractdocument.domain.HasPrice;
 import com.iluwatar.abstractdocument.domain.HasType;
 import com.iluwatar.abstractdocument.domain.Part;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test for Part and Car

--- a/abstract-factory/pom.xml
+++ b/abstract-factory/pom.xml
@@ -34,8 +34,13 @@
   <artifactId>abstract-factory</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/abstract-factory/src/test/java/com/iluwatar/abstractfactory/AbstractFactoryTest.java
+++ b/abstract-factory/src/test/java/com/iluwatar/abstractfactory/AbstractFactoryTest.java
@@ -22,14 +22,14 @@
  */
 package com.iluwatar.abstractfactory;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.iluwatar.abstractfactory.App.FactoryMaker;
 import com.iluwatar.abstractfactory.App.FactoryMaker.KingdomType;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test for abstract factory
@@ -40,7 +40,7 @@ public class AbstractFactoryTest {
   private KingdomFactory elfFactory;
   private KingdomFactory orcFactory;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     elfFactory = FactoryMaker.makeFactory(KingdomType.ELF);
     orcFactory = FactoryMaker.makeFactory(KingdomType.ORC);

--- a/abstract-factory/src/test/java/com/iluwatar/abstractfactory/AppTest.java
+++ b/abstract-factory/src/test/java/com/iluwatar/abstractfactory/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.abstractfactory;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 

--- a/adapter/pom.xml
+++ b/adapter/pom.xml
@@ -34,8 +34,13 @@
   <artifactId>adapter</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/adapter/src/test/java/com/iluwatar/adapter/AdapterPatternTest.java
+++ b/adapter/src/test/java/com/iluwatar/adapter/AdapterPatternTest.java
@@ -22,8 +22,8 @@
  */
 package com.iluwatar.adapter;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -46,7 +46,7 @@ public class AdapterPatternTest {
   /**
    * This method runs before the test execution and sets the bean objects in the beans Map.
    */
-  @Before
+  @BeforeEach
   public void setup() {
     beans = new HashMap<>();
 

--- a/adapter/src/test/java/com/iluwatar/adapter/AppTest.java
+++ b/adapter/src/test/java/com/iluwatar/adapter/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.adapter;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 

--- a/aggregator-microservices/aggregator-service/pom.xml
+++ b/aggregator-microservices/aggregator-service/pom.xml
@@ -54,8 +54,13 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/aggregator-microservices/aggregator-service/src/test/java/com/iluwatar/aggregator/microservices/AggregatorTest.java
+++ b/aggregator-microservices/aggregator-service/src/test/java/com/iluwatar/aggregator/microservices/AggregatorTest.java
@@ -22,14 +22,14 @@
  */
 package com.iluwatar.aggregator.microservices;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.when;
-
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
 
 /**
  * Test Aggregation of domain objects
@@ -45,7 +45,7 @@ public class AggregatorTest {
   @Mock
   private ProductInventoryClient inventoryClient;
 
-  @Before
+  @BeforeEach
   public void setup() {
     MockitoAnnotations.initMocks(this);
   }

--- a/aggregator-microservices/information-microservice/pom.xml
+++ b/aggregator-microservices/information-microservice/pom.xml
@@ -54,8 +54,13 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/aggregator-microservices/information-microservice/src/test/java/com/iluwatar/information/microservice/InformationControllerTest.java
+++ b/aggregator-microservices/information-microservice/src/test/java/com/iluwatar/information/microservice/InformationControllerTest.java
@@ -22,8 +22,9 @@
  */
 package com.iluwatar.information.microservice;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test for Information Rest Controller
@@ -36,7 +37,7 @@ public class InformationControllerTest {
 
     String title = infoController.getProductTitle();
 
-    Assert.assertEquals("The Product Title.", title);
+    assertEquals("The Product Title.", title);
   }
 
 }

--- a/aggregator-microservices/inventory-microservice/pom.xml
+++ b/aggregator-microservices/inventory-microservice/pom.xml
@@ -54,8 +54,13 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/aggregator-microservices/inventory-microservice/src/test/java/com/iluwatar/inventory/microservice/InventoryControllerTest.java
+++ b/aggregator-microservices/inventory-microservice/src/test/java/com/iluwatar/inventory/microservice/InventoryControllerTest.java
@@ -22,8 +22,9 @@
  */
 package com.iluwatar.inventory.microservice;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test Inventory Rest Controller
@@ -35,6 +36,6 @@ public class InventoryControllerTest {
 
     int numberOfInventories = inventoryController.getProductInventories();
 
-    Assert.assertEquals(5, numberOfInventories);
+    assertEquals(5, numberOfInventories);
   }
 }

--- a/api-gateway/api-gateway-service/pom.xml
+++ b/api-gateway/api-gateway-service/pom.xml
@@ -53,8 +53,13 @@
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/api-gateway/api-gateway-service/src/test/java/com/iluwatar/api/gateway/ApiGatewayTest.java
+++ b/api-gateway/api-gateway-service/src/test/java/com/iluwatar/api/gateway/ApiGatewayTest.java
@@ -22,14 +22,14 @@
  */
 package com.iluwatar.api.gateway;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.when;
-
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
 
 /**
  * Test API Gateway Pattern
@@ -45,7 +45,7 @@ public class ApiGatewayTest {
   @Mock
   private PriceClient priceClient;
 
-  @Before
+  @BeforeEach
   public void setup() {
     MockitoAnnotations.initMocks(this);
   }

--- a/api-gateway/image-microservice/pom.xml
+++ b/api-gateway/image-microservice/pom.xml
@@ -54,8 +54,13 @@
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/api-gateway/image-microservice/src/test/java/com/iluwatar/image/microservice/ImageControllerTest.java
+++ b/api-gateway/image-microservice/src/test/java/com/iluwatar/image/microservice/ImageControllerTest.java
@@ -22,8 +22,9 @@
  */
 package com.iluwatar.image.microservice;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test for Image Rest Controller
@@ -35,6 +36,6 @@ public class ImageControllerTest {
 
     String imagePath = imageController.getImagePath();
 
-    Assert.assertEquals("/product-image.png", imagePath);
+    assertEquals("/product-image.png", imagePath);
   }
 }

--- a/api-gateway/price-microservice/pom.xml
+++ b/api-gateway/price-microservice/pom.xml
@@ -54,8 +54,13 @@
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/api-gateway/price-microservice/src/test/java/com/iluwatar/price/microservice/PriceControllerTest.java
+++ b/api-gateway/price-microservice/src/test/java/com/iluwatar/price/microservice/PriceControllerTest.java
@@ -22,9 +22,9 @@
  */
 package com.iluwatar.price.microservice;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test for Price Rest Controller
@@ -36,6 +36,6 @@ public class PriceControllerTest {
 
     String price = priceController.getPrice();
 
-    Assert.assertEquals("20", price);
+    assertEquals("20", price);
   }
 }

--- a/async-method-invocation/pom.xml
+++ b/async-method-invocation/pom.xml
@@ -34,8 +34,13 @@
   <artifactId>async-method-invocation</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/async-method-invocation/src/test/java/com/iluwatar/async/method/invocation/AppTest.java
+++ b/async-method-invocation/src/test/java/com/iluwatar/async/method/invocation/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.async.method.invocation;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * 

--- a/async-method-invocation/src/test/java/com/iluwatar/async/method/invocation/ThreadAsyncExecutorTest.java
+++ b/async-method-invocation/src/test/java/com/iluwatar/async/method/invocation/ThreadAsyncExecutorTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.async.method.invocation;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Matchers;
 
@@ -30,8 +30,21 @@ import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static java.time.Duration.ofMillis;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTimeout;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
 
 /**
@@ -44,205 +57,217 @@ public class ThreadAsyncExecutorTest {
   /**
    * Test used to verify the happy path of {@link ThreadAsyncExecutor#startProcess(Callable)}
    */
-  @Test(timeout = 3000)
+  @Test
   public void testSuccessfulTaskWithoutCallback() throws Exception {
-    // Instantiate a new executor and start a new 'null' task ...
-    final ThreadAsyncExecutor executor = new ThreadAsyncExecutor();
+    assertTimeout(ofMillis(3000), () -> {
+      // Instantiate a new executor and start a new 'null' task ...
+      final ThreadAsyncExecutor executor = new ThreadAsyncExecutor();
 
-    final Object result = new Object();
-    final Callable<Object> task = mock(Callable.class);
-    when(task.call()).thenReturn(result);
+      final Object result = new Object();
+      final Callable<Object> task = mock(Callable.class);
+      when(task.call()).thenReturn(result);
 
-    final AsyncResult<Object> asyncResult = executor.startProcess(task);
-    assertNotNull(asyncResult);
-    asyncResult.await(); // Prevent timing issues, and wait until the result is available
-    assertTrue(asyncResult.isCompleted());
+      final AsyncResult<Object> asyncResult = executor.startProcess(task);
+      assertNotNull(asyncResult);
+      asyncResult.await(); // Prevent timing issues, and wait until the result is available
+      assertTrue(asyncResult.isCompleted());
 
-    // Our task should only execute once ...
-    verify(task, times(1)).call();
+      // Our task should only execute once ...
+      verify(task, times(1)).call();
 
-    // ... and the result should be exactly the same object
-    assertSame(result, asyncResult.getValue());
+      // ... and the result should be exactly the same object
+      assertSame(result, asyncResult.getValue());
+    });
   }
 
   /**
    * Test used to verify the happy path of {@link ThreadAsyncExecutor#startProcess(Callable, AsyncCallback)}
    */
-  @Test(timeout = 3000)
+  @Test
   public void testSuccessfulTaskWithCallback() throws Exception {
-    // Instantiate a new executor and start a new 'null' task ...
-    final ThreadAsyncExecutor executor = new ThreadAsyncExecutor();
+    assertTimeout(ofMillis(3000), () -> {
+      // Instantiate a new executor and start a new 'null' task ...
+      final ThreadAsyncExecutor executor = new ThreadAsyncExecutor();
 
-    final Object result = new Object();
-    final Callable<Object> task = mock(Callable.class);
-    when(task.call()).thenReturn(result);
+      final Object result = new Object();
+      final Callable<Object> task = mock(Callable.class);
+      when(task.call()).thenReturn(result);
 
-    final AsyncCallback callback = mock(AsyncCallback.class);
-    final AsyncResult<Object> asyncResult = executor.startProcess(task, callback);
-    assertNotNull(asyncResult);
-    asyncResult.await(); // Prevent timing issues, and wait until the result is available
-    assertTrue(asyncResult.isCompleted());
+      final AsyncCallback callback = mock(AsyncCallback.class);
+      final AsyncResult<Object> asyncResult = executor.startProcess(task, callback);
+      assertNotNull(asyncResult);
+      asyncResult.await(); // Prevent timing issues, and wait until the result is available
+      assertTrue(asyncResult.isCompleted());
 
-    // Our task should only execute once ...
-    verify(task, times(1)).call();
+      // Our task should only execute once ...
+      verify(task, times(1)).call();
 
-    // ... same for the callback, we expect our object
-    final ArgumentCaptor<Optional<Exception>> optionalCaptor = ArgumentCaptor.forClass((Class) Optional.class);
-    verify(callback, times(1)).onComplete(eq(result), optionalCaptor.capture());
+      // ... same for the callback, we expect our object
+      final ArgumentCaptor<Optional<Exception>> optionalCaptor = ArgumentCaptor.forClass((Class) Optional.class);
+      verify(callback, times(1)).onComplete(eq(result), optionalCaptor.capture());
 
-    final Optional<Exception> optionalException = optionalCaptor.getValue();
-    assertNotNull(optionalException);
-    assertFalse(optionalException.isPresent());
+      final Optional<Exception> optionalException = optionalCaptor.getValue();
+      assertNotNull(optionalException);
+      assertFalse(optionalException.isPresent());
 
-    // ... and the result should be exactly the same object
-    assertSame(result, asyncResult.getValue());
+      // ... and the result should be exactly the same object
+      assertSame(result, asyncResult.getValue());
+    });
   }
 
   /**
    * Test used to verify the happy path of {@link ThreadAsyncExecutor#startProcess(Callable)} when a task takes a while
    * to execute
    */
-  @Test(timeout = 5000)
+  @Test
   public void testLongRunningTaskWithoutCallback() throws Exception {
-    // Instantiate a new executor and start a new 'null' task ...
-    final ThreadAsyncExecutor executor = new ThreadAsyncExecutor();
+    assertTimeout(ofMillis(5000), () -> {
+      // Instantiate a new executor and start a new 'null' task ...
+      final ThreadAsyncExecutor executor = new ThreadAsyncExecutor();
 
-    final Object result = new Object();
-    final Callable<Object> task = mock(Callable.class);
-    when(task.call()).thenAnswer(i -> {
-      Thread.sleep(1500);
-      return result;
+      final Object result = new Object();
+      final Callable<Object> task = mock(Callable.class);
+      when(task.call()).thenAnswer(i -> {
+        Thread.sleep(1500);
+        return result;
+      });
+
+      final AsyncResult<Object> asyncResult = executor.startProcess(task);
+      assertNotNull(asyncResult);
+      assertFalse(asyncResult.isCompleted());
+
+      try {
+        asyncResult.getValue();
+        fail("Expected IllegalStateException when calling AsyncResult#getValue on a non-completed task");
+      } catch (IllegalStateException e) {
+        assertNotNull(e.getMessage());
+      }
+
+      // Our task should only execute once, but it can take a while ...
+      verify(task, timeout(3000).times(1)).call();
+
+      // Prevent timing issues, and wait until the result is available
+      asyncResult.await();
+      assertTrue(asyncResult.isCompleted());
+      verifyNoMoreInteractions(task);
+
+      // ... and the result should be exactly the same object
+      assertSame(result, asyncResult.getValue());
     });
-
-    final AsyncResult<Object> asyncResult = executor.startProcess(task);
-    assertNotNull(asyncResult);
-    assertFalse(asyncResult.isCompleted());
-
-    try {
-      asyncResult.getValue();
-      fail("Expected IllegalStateException when calling AsyncResult#getValue on a non-completed task");
-    } catch (IllegalStateException e) {
-      assertNotNull(e.getMessage());
-    }
-
-    // Our task should only execute once, but it can take a while ...
-    verify(task, timeout(3000).times(1)).call();
-
-    // Prevent timing issues, and wait until the result is available
-    asyncResult.await();
-    assertTrue(asyncResult.isCompleted());
-    verifyNoMoreInteractions(task);
-
-    // ... and the result should be exactly the same object
-    assertSame(result, asyncResult.getValue());
   }
 
   /**
    * Test used to verify the happy path of {@link ThreadAsyncExecutor#startProcess(Callable, AsyncCallback)} when a task
    * takes a while to execute
    */
-  @Test(timeout = 5000)
+  @Test
   public void testLongRunningTaskWithCallback() throws Exception {
-    // Instantiate a new executor and start a new 'null' task ...
-    final ThreadAsyncExecutor executor = new ThreadAsyncExecutor();
+    assertTimeout(ofMillis(5000), () -> {
+      // Instantiate a new executor and start a new 'null' task ...
+      final ThreadAsyncExecutor executor = new ThreadAsyncExecutor();
 
-    final Object result = new Object();
-    final Callable<Object> task = mock(Callable.class);
-    when(task.call()).thenAnswer(i -> {
-      Thread.sleep(1500);
-      return result;
+      final Object result = new Object();
+      final Callable<Object> task = mock(Callable.class);
+      when(task.call()).thenAnswer(i -> {
+        Thread.sleep(1500);
+        return result;
+      });
+
+      final AsyncCallback<Object> callback = mock(AsyncCallback.class);
+      final AsyncResult<Object> asyncResult = executor.startProcess(task, callback);
+      assertNotNull(asyncResult);
+      assertFalse(asyncResult.isCompleted());
+
+      verifyZeroInteractions(callback);
+
+      try {
+        asyncResult.getValue();
+        fail("Expected IllegalStateException when calling AsyncResult#getValue on a non-completed task");
+      } catch (IllegalStateException e) {
+        assertNotNull(e.getMessage());
+      }
+
+      // Our task should only execute once, but it can take a while ...
+      verify(task, timeout(3000).times(1)).call();
+
+      final ArgumentCaptor<Optional<Exception>> optionalCaptor = ArgumentCaptor.forClass((Class) Optional.class);
+      verify(callback, timeout(3000).times(1)).onComplete(eq(result), optionalCaptor.capture());
+
+      final Optional<Exception> optionalException = optionalCaptor.getValue();
+      assertNotNull(optionalException);
+      assertFalse(optionalException.isPresent());
+
+      // Prevent timing issues, and wait until the result is available
+      asyncResult.await();
+      assertTrue(asyncResult.isCompleted());
+      verifyNoMoreInteractions(task, callback);
+
+      // ... and the result should be exactly the same object
+      assertSame(result, asyncResult.getValue());
     });
-
-    final AsyncCallback<Object> callback = mock(AsyncCallback.class);
-    final AsyncResult<Object> asyncResult = executor.startProcess(task, callback);
-    assertNotNull(asyncResult);
-    assertFalse(asyncResult.isCompleted());
-
-    verifyZeroInteractions(callback);
-
-    try {
-      asyncResult.getValue();
-      fail("Expected IllegalStateException when calling AsyncResult#getValue on a non-completed task");
-    } catch (IllegalStateException e) {
-      assertNotNull(e.getMessage());
-    }
-
-    // Our task should only execute once, but it can take a while ...
-    verify(task, timeout(3000).times(1)).call();
-
-    final ArgumentCaptor<Optional<Exception>> optionalCaptor = ArgumentCaptor.forClass((Class) Optional.class);
-    verify(callback, timeout(3000).times(1)).onComplete(eq(result), optionalCaptor.capture());
-
-    final Optional<Exception> optionalException = optionalCaptor.getValue();
-    assertNotNull(optionalException);
-    assertFalse(optionalException.isPresent());
-
-    // Prevent timing issues, and wait until the result is available
-    asyncResult.await();
-    assertTrue(asyncResult.isCompleted());
-    verifyNoMoreInteractions(task, callback);
-
-    // ... and the result should be exactly the same object
-    assertSame(result, asyncResult.getValue());
   }
 
   /**
    * Test used to verify the happy path of {@link ThreadAsyncExecutor#startProcess(Callable)} when a task takes a while
    * to execute, while waiting on the result using {@link ThreadAsyncExecutor#endProcess(AsyncResult)}
    */
-  @Test(timeout = 5000)
+  @Test
   public void testEndProcess() throws Exception {
-    // Instantiate a new executor and start a new 'null' task ...
-    final ThreadAsyncExecutor executor = new ThreadAsyncExecutor();
+    assertTimeout(ofMillis(5000), () -> {
+      // Instantiate a new executor and start a new 'null' task ...
+      final ThreadAsyncExecutor executor = new ThreadAsyncExecutor();
 
-    final Object result = new Object();
-    final Callable<Object> task = mock(Callable.class);
-    when(task.call()).thenAnswer(i -> {
-      Thread.sleep(1500);
-      return result;
+      final Object result = new Object();
+      final Callable<Object> task = mock(Callable.class);
+      when(task.call()).thenAnswer(i -> {
+        Thread.sleep(1500);
+        return result;
+      });
+
+      final AsyncResult<Object> asyncResult = executor.startProcess(task);
+      assertNotNull(asyncResult);
+      assertFalse(asyncResult.isCompleted());
+
+      try {
+        asyncResult.getValue();
+        fail("Expected IllegalStateException when calling AsyncResult#getValue on a non-completed task");
+      } catch (IllegalStateException e) {
+        assertNotNull(e.getMessage());
+      }
+
+      assertSame(result, executor.endProcess(asyncResult));
+      verify(task, times(1)).call();
+      assertTrue(asyncResult.isCompleted());
+
+      // Calling end process a second time while already finished should give the same result
+      assertSame(result, executor.endProcess(asyncResult));
+      verifyNoMoreInteractions(task);
     });
-
-    final AsyncResult<Object> asyncResult = executor.startProcess(task);
-    assertNotNull(asyncResult);
-    assertFalse(asyncResult.isCompleted());
-
-    try {
-      asyncResult.getValue();
-      fail("Expected IllegalStateException when calling AsyncResult#getValue on a non-completed task");
-    } catch (IllegalStateException e) {
-      assertNotNull(e.getMessage());
-    }
-
-    assertSame(result, executor.endProcess(asyncResult));
-    verify(task, times(1)).call();
-    assertTrue(asyncResult.isCompleted());
-
-    // Calling end process a second time while already finished should give the same result
-    assertSame(result, executor.endProcess(asyncResult));
-    verifyNoMoreInteractions(task);
   }
 
   /**
    * Test used to verify the behaviour of {@link ThreadAsyncExecutor#startProcess(Callable)} when the callable is 'null'
    */
-  @Test(timeout = 3000)
+  @Test
   public void testNullTask() throws Exception {
-    // Instantiate a new executor and start a new 'null' task ...
-    final ThreadAsyncExecutor executor = new ThreadAsyncExecutor();
-    final AsyncResult<Object> asyncResult = executor.startProcess(null);
+    assertTimeout(ofMillis(3000), () -> {
+      // Instantiate a new executor and start a new 'null' task ...
+      final ThreadAsyncExecutor executor = new ThreadAsyncExecutor();
+      final AsyncResult<Object> asyncResult = executor.startProcess(null);
 
-    assertNotNull("The AsyncResult should not be 'null', even though the task was 'null'.", asyncResult);
-    asyncResult.await(); // Prevent timing issues, and wait until the result is available
-    assertTrue(asyncResult.isCompleted());
+      assertNotNull(asyncResult, "The AsyncResult should not be 'null', even though the task was 'null'.");
+      asyncResult.await(); // Prevent timing issues, and wait until the result is available
+      assertTrue(asyncResult.isCompleted());
 
-    try {
-      asyncResult.getValue();
-      fail("Expected ExecutionException with NPE as cause");
-    } catch (final ExecutionException e) {
-      assertNotNull(e.getMessage());
-      assertNotNull(e.getCause());
-      assertEquals(NullPointerException.class, e.getCause().getClass());
-    }
+      try {
+        asyncResult.getValue();
+        fail("Expected ExecutionException with NPE as cause");
+      } catch (final ExecutionException e) {
+        assertNotNull(e.getMessage());
+        assertNotNull(e.getCause());
+        assertEquals(NullPointerException.class, e.getCause().getClass());
+      }
+    });
 
   }
 
@@ -250,36 +275,38 @@ public class ThreadAsyncExecutorTest {
    * Test used to verify the behaviour of {@link ThreadAsyncExecutor#startProcess(Callable, AsyncCallback)} when the
    * callable is 'null', but the asynchronous callback is provided
    */
-  @Test(timeout = 3000)
+  @Test
   public void testNullTaskWithCallback() throws Exception {
-    // Instantiate a new executor and start a new 'null' task ...
-    final ThreadAsyncExecutor executor = new ThreadAsyncExecutor();
-    final AsyncCallback<Object> callback = mock(AsyncCallback.class);
-    final AsyncResult<Object> asyncResult = executor.startProcess(null, callback);
+    assertTimeout(ofMillis(3000), () -> {
+      // Instantiate a new executor and start a new 'null' task ...
+      final ThreadAsyncExecutor executor = new ThreadAsyncExecutor();
+      final AsyncCallback<Object> callback = mock(AsyncCallback.class);
+      final AsyncResult<Object> asyncResult = executor.startProcess(null, callback);
 
-    assertNotNull("The AsyncResult should not be 'null', even though the task was 'null'.", asyncResult);
-    asyncResult.await(); // Prevent timing issues, and wait until the result is available
-    assertTrue(asyncResult.isCompleted());
+      assertNotNull(asyncResult, "The AsyncResult should not be 'null', even though the task was 'null'.");
+      asyncResult.await(); // Prevent timing issues, and wait until the result is available
+      assertTrue(asyncResult.isCompleted());
 
-    final ArgumentCaptor<Optional<Exception>> optionalCaptor = ArgumentCaptor.forClass((Class) Optional.class);
-    verify(callback, times(1)).onComplete(Matchers.isNull(), optionalCaptor.capture());
+      final ArgumentCaptor<Optional<Exception>> optionalCaptor = ArgumentCaptor.forClass((Class) Optional.class);
+      verify(callback, times(1)).onComplete(Matchers.isNull(), optionalCaptor.capture());
 
-    final Optional<Exception> optionalException = optionalCaptor.getValue();
-    assertNotNull(optionalException);
-    assertTrue(optionalException.isPresent());
+      final Optional<Exception> optionalException = optionalCaptor.getValue();
+      assertNotNull(optionalException);
+      assertTrue(optionalException.isPresent());
 
-    final Exception exception = optionalException.get();
-    assertNotNull(exception);
-    assertEquals(NullPointerException.class, exception.getClass());
+      final Exception exception = optionalException.get();
+      assertNotNull(exception);
+      assertEquals(NullPointerException.class, exception.getClass());
 
-    try {
-      asyncResult.getValue();
-      fail("Expected ExecutionException with NPE as cause");
-    } catch (final ExecutionException e) {
-      assertNotNull(e.getMessage());
-      assertNotNull(e.getCause());
-      assertEquals(NullPointerException.class, e.getCause().getClass());
-    }
+      try {
+        asyncResult.getValue();
+        fail("Expected ExecutionException with NPE as cause");
+      } catch (final ExecutionException e) {
+        assertNotNull(e.getMessage());
+        assertNotNull(e.getCause());
+        assertEquals(NullPointerException.class, e.getCause().getClass());
+      }
+    });
 
   }
 
@@ -287,24 +314,29 @@ public class ThreadAsyncExecutorTest {
    * Test used to verify the behaviour of {@link ThreadAsyncExecutor#startProcess(Callable, AsyncCallback)} when both
    * the callable and the asynchronous callback are 'null'
    */
-  @Test(timeout = 3000)
+  @Test
   public void testNullTaskWithNullCallback() throws Exception {
-    // Instantiate a new executor and start a new 'null' task ...
-    final ThreadAsyncExecutor executor = new ThreadAsyncExecutor();
-    final AsyncResult<Object> asyncResult = executor.startProcess(null, null);
+    assertTimeout(ofMillis(3000), () -> {
+      // Instantiate a new executor and start a new 'null' task ...
+      final ThreadAsyncExecutor executor = new ThreadAsyncExecutor();
+      final AsyncResult<Object> asyncResult = executor.startProcess(null, null);
 
-    assertNotNull("The AsyncResult should not be 'null', even though the task and callback were 'null'.", asyncResult);
-    asyncResult.await(); // Prevent timing issues, and wait until the result is available
-    assertTrue(asyncResult.isCompleted());
+      assertNotNull(
+          asyncResult,
+          "The AsyncResult should not be 'null', even though the task and callback were 'null'."
+      );
+      asyncResult.await(); // Prevent timing issues, and wait until the result is available
+      assertTrue(asyncResult.isCompleted());
 
-    try {
-      asyncResult.getValue();
-      fail("Expected ExecutionException with NPE as cause");
-    } catch (final ExecutionException e) {
-      assertNotNull(e.getMessage());
-      assertNotNull(e.getCause());
-      assertEquals(NullPointerException.class, e.getCause().getClass());
-    }
+      try {
+        asyncResult.getValue();
+        fail("Expected ExecutionException with NPE as cause");
+      } catch (final ExecutionException e) {
+        assertNotNull(e.getMessage());
+        assertNotNull(e.getCause());
+        assertEquals(NullPointerException.class, e.getCause().getClass());
+      }
+    });
 
   }
 

--- a/balking/pom.xml
+++ b/balking/pom.xml
@@ -36,8 +36,13 @@
   <artifactId>balking</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/balking/src/test/java/com/iluwatar/balking/AppTest.java
+++ b/balking/src/test/java/com/iluwatar/balking/AppTest.java
@@ -23,7 +23,7 @@
 
 package com.iluwatar.balking;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Application test

--- a/balking/src/test/java/com/iluwatar/balking/WashingMachineTest.java
+++ b/balking/src/test/java/com/iluwatar/balking/WashingMachineTest.java
@@ -22,13 +22,13 @@
  */
 package com.iluwatar.balking;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests for {@link WashingMachine}

--- a/bridge/pom.xml
+++ b/bridge/pom.xml
@@ -34,8 +34,13 @@
   <artifactId>bridge</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/bridge/src/test/java/com/iluwatar/bridge/AppTest.java
+++ b/bridge/src/test/java/com/iluwatar/bridge/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.bridge;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * 

--- a/bridge/src/test/java/com/iluwatar/bridge/HammerTest.java
+++ b/bridge/src/test/java/com/iluwatar/bridge/HammerTest.java
@@ -22,11 +22,10 @@
  */
 package com.iluwatar.bridge;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
 
 /**
  * Tests for hammer

--- a/bridge/src/test/java/com/iluwatar/bridge/SwordTest.java
+++ b/bridge/src/test/java/com/iluwatar/bridge/SwordTest.java
@@ -22,11 +22,10 @@
  */
 package com.iluwatar.bridge;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
 
 /**
  * Tests for sword

--- a/bridge/src/test/java/com/iluwatar/bridge/WeaponTest.java
+++ b/bridge/src/test/java/com/iluwatar/bridge/WeaponTest.java
@@ -22,10 +22,11 @@
  */
 package com.iluwatar.bridge;
 
-import static org.junit.Assert.assertNotNull;
+import org.junit.jupiter.api.Disabled;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.internal.verification.VerificationModeFactory.times;
 
 /**
  * Base class for weapon tests

--- a/builder/pom.xml
+++ b/builder/pom.xml
@@ -34,8 +34,13 @@
   <artifactId>builder</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/builder/src/test/java/com/iluwatar/builder/AppTest.java
+++ b/builder/src/test/java/com/iluwatar/builder/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.builder;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * 

--- a/builder/src/test/java/com/iluwatar/builder/HeroTest.java
+++ b/builder/src/test/java/com/iluwatar/builder/HeroTest.java
@@ -22,10 +22,11 @@
  */
 package com.iluwatar.builder;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Date: 12/6/15 - 11:01 PM
@@ -37,17 +38,17 @@ public class HeroTest {
   /**
    * Test if we get the expected exception when trying to create a hero without a profession
    */
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testMissingProfession() throws Exception {
-    new Hero.Builder(null, "Sir without a job");
+    assertThrows(IllegalArgumentException.class, () -> new Hero.Builder(null, "Sir without a job"));
   }
 
   /**
    * Test if we get the expected exception when trying to create a hero without a name
    */
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testMissingName() throws Exception {
-    new Hero.Builder(Profession.THIEF, null);
+    assertThrows(IllegalArgumentException.class, () -> new Hero.Builder(Profession.THIEF, null));
   }
 
   /**

--- a/business-delegate/pom.xml
+++ b/business-delegate/pom.xml
@@ -35,8 +35,13 @@
 	<artifactId>business-delegate</artifactId>
 	<dependencies>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/business-delegate/src/test/java/com/iluwatar/business/delegate/AppTest.java
+++ b/business-delegate/src/test/java/com/iluwatar/business/delegate/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.business.delegate;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 

--- a/business-delegate/src/test/java/com/iluwatar/business/delegate/BusinessDelegateTest.java
+++ b/business-delegate/src/test/java/com/iluwatar/business/delegate/BusinessDelegateTest.java
@@ -22,12 +22,12 @@
  */
 package com.iluwatar.business.delegate;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-
-import org.junit.Before;
-import org.junit.Test;
 
 /**
  * The Business Delegate pattern adds an abstraction layer between the presentation and business
@@ -53,7 +53,7 @@ public class BusinessDelegateTest {
    * This method sets up the instance variables of this test class. It is executed before the
    * execution of every test.
    */
-  @Before
+  @BeforeEach
   public void setup() {
     ejbService = spy(new EjbService());
     jmsService = spy(new JmsService());

--- a/caching/pom.xml
+++ b/caching/pom.xml
@@ -34,8 +34,13 @@
   <artifactId>caching</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/caching/src/test/java/com/iluwatar/caching/AppTest.java
+++ b/caching/src/test/java/com/iluwatar/caching/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.caching;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 

--- a/caching/src/test/java/com/iluwatar/caching/CachingTest.java
+++ b/caching/src/test/java/com/iluwatar/caching/CachingTest.java
@@ -22,8 +22,8 @@
  */
 package com.iluwatar.caching;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  *
@@ -36,7 +36,7 @@ public class CachingTest {
   /**
    * Setup of application test includes: initializing DB connection and cache size/capacity.
    */
-  @Before
+  @BeforeEach
   public void setUp() {
     AppManager.initDb(false); // VirtualDB (instead of MongoDB) was used in running the JUnit tests
                               // to avoid Maven compilation errors. Set flag to true to run the

--- a/callback/pom.xml
+++ b/callback/pom.xml
@@ -34,8 +34,13 @@
   <artifactId>callback</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/callback/src/test/java/com/iluwatar/callback/AppTest.java
+++ b/callback/src/test/java/com/iluwatar/callback/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.callback;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 

--- a/callback/src/test/java/com/iluwatar/callback/CallbackTest.java
+++ b/callback/src/test/java/com/iluwatar/callback/CallbackTest.java
@@ -22,9 +22,9 @@
  */
 package com.iluwatar.callback;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Add a field as a counter. Every time the callback method is called increment this field. Unit
@@ -47,15 +47,15 @@ public class CallbackTest {
 
     Task task = new SimpleTask();
 
-    assertEquals("Initial calling count of 0", new Integer(0), callingCount);
+    assertEquals(new Integer(0), callingCount, "Initial calling count of 0");
 
     task.executeWith(callback);
 
-    assertEquals("Callback called once", new Integer(1), callingCount);
+    assertEquals(new Integer(1), callingCount, "Callback called once");
 
     task.executeWith(callback);
 
-    assertEquals("Callback called twice", new Integer(2), callingCount);
+    assertEquals(new Integer(2), callingCount, "Callback called twice");
 
   }
 
@@ -65,15 +65,15 @@ public class CallbackTest {
 
     Task task = new SimpleTask();
 
-    assertEquals("Initial calling count of 0", new Integer(0), callingCount);
+    assertEquals(new Integer(0), callingCount, "Initial calling count of 0");
 
     task.executeWith(callback);
 
-    assertEquals("Callback called once", new Integer(1), callingCount);
+    assertEquals(new Integer(1), callingCount, "Callback called once");
 
     task.executeWith(callback);
 
-    assertEquals("Callback called twice", new Integer(2), callingCount);
+    assertEquals(new Integer(2), callingCount, "Callback called twice");
 
   }
 }

--- a/chain/pom.xml
+++ b/chain/pom.xml
@@ -34,8 +34,13 @@
   <artifactId>chain</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/chain/src/test/java/com/iluwatar/chain/AppTest.java
+++ b/chain/src/test/java/com/iluwatar/chain/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.chain;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * 

--- a/chain/src/test/java/com/iluwatar/chain/OrcKingTest.java
+++ b/chain/src/test/java/com/iluwatar/chain/OrcKingTest.java
@@ -22,9 +22,9 @@
  */
 package com.iluwatar.chain;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Date: 12/6/15 - 9:29 PM
@@ -49,8 +49,8 @@ public class OrcKingTest {
     for (final Request request : REQUESTS) {
       king.makeRequest(request);
       assertTrue(
-          "Expected all requests from King to be handled, but [" + request + "] was not!",
-          request.isHandled()
+          request.isHandled(),
+          "Expected all requests from King to be handled, but [" + request + "] was not!"
       );
     }
 

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -179,7 +179,7 @@
             <property name="allowMissingThrowsTags" value="true"/>
             <property name="allowMissingReturnTag" value="true"/>
             <property name="minLineCount" value="2"/>
-            <property name="allowedAnnotations" value="Override, Test, Before, After, Parameters, Given, When, BeforeClass, AfterClass, Parameterized"/>
+            <property name="allowedAnnotations" value="Override, Test, Before, After, Parameters, Given, When, BeforeClass, AfterClass, Parameterized, ParameterizedTest, BeforeAll, BeforeEach"/>
             <property name="allowThrowsTagsForSubclasses" value="true"/>
         </module>
         <module name="JavadocType">

--- a/command/pom.xml
+++ b/command/pom.xml
@@ -34,13 +34,13 @@
   <artifactId>command</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/command/src/test/java/com/iluwatar/command/AppTest.java
+++ b/command/src/test/java/com/iluwatar/command/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.command;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 

--- a/command/src/test/java/com/iluwatar/command/CommandTest.java
+++ b/command/src/test/java/com/iluwatar/command/CommandTest.java
@@ -22,9 +22,9 @@
  */
 package com.iluwatar.command;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * The Command pattern is a behavioral design pattern in which an object is used to encapsulate all
@@ -85,9 +85,9 @@ public class CommandTest {
    */
   private void verifyGoblin(Goblin goblin, String expectedName, Size expectedSize,
       Visibility expectedVisibility) {
-    assertEquals("Goblin's name must be same as expectedName", expectedName, goblin.toString());
-    assertEquals("Goblin's size must be same as expectedSize", expectedSize, goblin.getSize());
-    assertEquals("Goblin's visibility must be same as expectedVisibility", expectedVisibility,
-        goblin.getVisibility());
+    assertEquals(expectedName, goblin.toString(), "Goblin's name must be same as expectedName");
+    assertEquals(expectedSize, goblin.getSize(), "Goblin's size must be same as expectedSize");
+    assertEquals(expectedVisibility, goblin.getVisibility(),
+            "Goblin's visibility must be same as expectedVisibility");
   }
 }

--- a/composite/pom.xml
+++ b/composite/pom.xml
@@ -34,8 +34,13 @@
   <artifactId>composite</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/composite/src/test/java/com/iluwatar/composite/AppTest.java
+++ b/composite/src/test/java/com/iluwatar/composite/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.composite;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * 

--- a/composite/src/test/java/com/iluwatar/composite/MessengerTest.java
+++ b/composite/src/test/java/com/iluwatar/composite/MessengerTest.java
@@ -22,15 +22,15 @@
  */
 package com.iluwatar.composite;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Date: 12/11/15 - 8:12 PM
@@ -52,7 +52,7 @@ public class MessengerTest {
   /**
    * Inject the mocked std-out {@link PrintStream} into the {@link System} class before each test
    */
-  @Before
+  @BeforeEach
   public void setUp() {
     this.stdOutBuffer = new ByteArrayOutputStream();
     System.setOut(new PrintStream(stdOutBuffer));
@@ -61,7 +61,7 @@ public class MessengerTest {
   /**
    * Removed the mocked std-out {@link PrintStream} again from the {@link System} class
    */
-  @After
+  @AfterEach
   public void tearDown() {
     System.setOut(realStdOut);
   }

--- a/converter/pom.xml
+++ b/converter/pom.xml
@@ -34,8 +34,13 @@
     <modelVersion>4.0.0</modelVersion>
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/converter/src/test/java/com/iluwatar/converter/AppTest.java
+++ b/converter/src/test/java/com/iluwatar/converter/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.converter;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * App running test

--- a/converter/src/test/java/com/iluwatar/converter/ConverterTest.java
+++ b/converter/src/test/java/com/iluwatar/converter/ConverterTest.java
@@ -23,13 +23,13 @@
 package com.iluwatar.converter;
 
 import com.google.common.collect.Lists;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests for {@link Converter}
@@ -41,7 +41,8 @@ public class ConverterTest {
   /**
    * Tests whether a converter created of opposite functions holds equality as a bijection.
    */
-  @Test public void testConversionsStartingFromDomain() {
+  @Test
+  public void testConversionsStartingFromDomain() {
     User u1 = new User("Tom", "Hanks", true, "tom@hanks.com");
     User u2 = userConverter.convertFromDto(userConverter.convertFromEntity(u1));
     assertEquals(u1, u2);
@@ -50,7 +51,8 @@ public class ConverterTest {
   /**
    * Tests whether a converter created of opposite functions holds equality as a bijection.
    */
-  @Test public void testConversionsStartingFromDto() {
+  @Test
+  public void testConversionsStartingFromDto() {
     UserDto u1 = new UserDto("Tom", "Hanks", true, "tom@hanks.com");
     UserDto u2 = userConverter.convertFromEntity(userConverter.convertFromDto(u1));
     assertEquals(u1, u2);
@@ -60,7 +62,8 @@ public class ConverterTest {
    * Tests the custom users converter. Thanks to Java8 lambdas, converter can be easily and
    * cleanly instantiated allowing various different conversion strategies to be implemented.
    */
-  @Test public void testCustomConverter() {
+  @Test
+  public void testCustomConverter() {
     Converter<UserDto, User> converter = new Converter<>(
         userDto -> new User(userDto.getFirstName(), userDto.getLastName(), userDto.isActive(),
         String.valueOf(new Random().nextInt())),
@@ -75,7 +78,8 @@ public class ConverterTest {
    * Test whether converting a collection of Users to DTO Users and then converting them back to domain
    * users returns an equal collection.
    */
-  @Test public void testCollectionConversion() {
+  @Test
+  public void testCollectionConversion() {
     ArrayList<User> users = Lists.newArrayList(new User("Camile", "Tough", false, "124sad"),
         new User("Marti", "Luther", true, "42309fd"), new User("Kate", "Smith", true, "if0243"));
     List<User> fromDtos = userConverter.createFromDtos(userConverter.createFromEntities(users));

--- a/cqrs/pom.xml
+++ b/cqrs/pom.xml
@@ -26,8 +26,13 @@
 	<artifactId>cqrs</artifactId>
 	<dependencies>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/cqrs/src/test/java/com/iluwatar/cqrs/IntegrationTest.java
+++ b/cqrs/src/test/java/com/iluwatar/cqrs/IntegrationTest.java
@@ -22,14 +22,8 @@
  */
 package com.iluwatar.cqrs;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import java.math.BigInteger;
 import java.util.List;
-
-import org.junit.BeforeClass;
-import org.junit.Test;
 
 import com.iluwatar.cqrs.commandes.CommandServiceImpl;
 import com.iluwatar.cqrs.commandes.ICommandService;
@@ -37,6 +31,11 @@ import com.iluwatar.cqrs.dto.Author;
 import com.iluwatar.cqrs.dto.Book;
 import com.iluwatar.cqrs.queries.IQueryService;
 import com.iluwatar.cqrs.queries.QueryServiceImpl;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Integration test of IQueryService and ICommandService with h2 data
@@ -47,14 +46,11 @@ public class IntegrationTest {
   private static IQueryService queryService;
   private static ICommandService commandService;
 
-  @BeforeClass
-  public static void initialize() {
+  @BeforeAll
+  public static void initializeAndPopulateDatabase() {
     commandService = new CommandServiceImpl();
     queryService = new QueryServiceImpl();
-  }
 
-  @BeforeClass
-  public static void populateDatabase() {
     // create first author1
     commandService.authorCreated("username1", "name1", "email1");
 
@@ -94,7 +90,7 @@ public class IntegrationTest {
   public void testGetBook() {
     Book book = queryService.getBook("title1");
     assertEquals("title1", book.getTitle());
-    assertEquals(10, book.getPrice(), 0);
+    assertEquals(10, book.getPrice(), 0.01);
   }
 
   @Test

--- a/dao/pom.xml
+++ b/dao/pom.xml
@@ -36,8 +36,13 @@
 
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -48,10 +53,6 @@
         <groupId>com.h2database</groupId>
         <artifactId>h2</artifactId>
       </dependency>
-    <dependency>
-      <groupId>de.bechte.junit</groupId>
-      <artifactId>junit-hierarchicalcontextrunner</artifactId>
-    </dependency>
     <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>

--- a/dao/src/test/java/com/iluwatar/dao/AppTest.java
+++ b/dao/src/test/java/com/iluwatar/dao/AppTest.java
@@ -23,7 +23,7 @@
 
 package com.iluwatar.dao;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests that DAO example runs without errors.

--- a/dao/src/test/java/com/iluwatar/dao/CustomerTest.java
+++ b/dao/src/test/java/com/iluwatar/dao/CustomerTest.java
@@ -23,11 +23,11 @@
 
 package com.iluwatar.dao;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests {@link Customer}.
@@ -39,7 +39,7 @@ public class CustomerTest {
   private static final String FIRSTNAME = "Winston";
   private static final String LASTNAME = "Churchill";
 
-  @Before
+  @BeforeEach
   public void setUp() {
     customer = new Customer(ID, FIRSTNAME, LASTNAME);
   }

--- a/dao/src/test/java/com/iluwatar/dao/DbCustomerDaoTest.java
+++ b/dao/src/test/java/com/iluwatar/dao/DbCustomerDaoTest.java
@@ -22,38 +22,32 @@
  */
 package com.iluwatar.dao;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeTrue;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
+import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.stream.Stream;
 
-import javax.sql.DataSource;
-
-import org.h2.jdbcx.JdbcDataSource;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
-import org.mockito.Mockito;
-
-import de.bechte.junit.runners.context.HierarchicalContextRunner;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 
 /**
  * Tests {@link DbCustomerDao}.
  */
-@RunWith(HierarchicalContextRunner.class)
 public class DbCustomerDaoTest {
 
   private static final String DB_URL = "jdbc:h2:~/dao";
@@ -64,7 +58,7 @@ public class DbCustomerDaoTest {
    * Creates customers schema.
    * @throws SQLException if there is any error while creating schema.
    */
-  @Before
+  @BeforeEach
   public void createSchema() throws SQLException {
     try (Connection connection = DriverManager.getConnection(DB_URL);
         Statement statement = connection.createStatement()) {
@@ -75,13 +69,14 @@ public class DbCustomerDaoTest {
   /**
    * Represents the scenario where DB connectivity is present.
    */
+  @Nested
   public class ConnectionSuccess {
 
     /**
      * Setup for connection success scenario.
      * @throws Exception if any error occurs.
      */
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
       JdbcDataSource dataSource = new JdbcDataSource();
       dataSource.setURL(DB_URL);
@@ -93,6 +88,7 @@ public class DbCustomerDaoTest {
     /**
      * Represents the scenario when DAO operations are being performed on a non existing customer.
      */
+    @Nested
     public class NonExistingCustomer {
 
       @Test
@@ -141,6 +137,7 @@ public class DbCustomerDaoTest {
      * customer.
      *
      */
+    @Nested
     public class ExistingCustomer {
 
       @Test
@@ -184,20 +181,21 @@ public class DbCustomerDaoTest {
    * DB service unavailable.
    * 
    */
+  @Nested
   public class ConnectivityIssue {
     
     private static final String EXCEPTION_CAUSE = "Connection not available";
-    @Rule public ExpectedException exception = ExpectedException.none();
+    //@Rule public ExpectedException exception = ExpectedException.none();
     
     /**
      * setup a connection failure scenario.
      * @throws SQLException if any error occurs.
      */
-    @Before
+    @BeforeEach
     public void setUp() throws SQLException {
       dao = new DbCustomerDao(mockedDatasource());
-      exception.expect(Exception.class);
-      exception.expectMessage(EXCEPTION_CAUSE);
+      //exception.expect(Exception.class);
+     //exception.expectMessage(EXCEPTION_CAUSE);
     }
     
     private DataSource mockedDatasource() throws SQLException {
@@ -210,31 +208,40 @@ public class DbCustomerDaoTest {
     }
 
     @Test
-    public void addingACustomerFailsWithExceptionAsFeedbackToClient() throws Exception {
-      dao.add(new Customer(2, "Bernard", "Montgomery"));
+    public void addingACustomerFailsWithExceptionAsFeedbackToClient() {
+      assertThrows(Exception.class, () -> {
+        dao.add(new Customer(2, "Bernard", "Montgomery"));
+      });
     }
     
     @Test
-    public void deletingACustomerFailsWithExceptionAsFeedbackToTheClient() throws Exception {
-      dao.delete(existingCustomer);
+    public void deletingACustomerFailsWithExceptionAsFeedbackToTheClient() {
+      assertThrows(Exception.class, () -> {
+        dao.delete(existingCustomer);
+      });
     }
     
     @Test
-    public void updatingACustomerFailsWithFeedbackToTheClient() throws Exception {
+    public void updatingACustomerFailsWithFeedbackToTheClient() {
       final String newFirstname = "Bernard";
       final String newLastname = "Montgomery";
-      
-      dao.update(new Customer(existingCustomer.getId(), newFirstname, newLastname));
+      assertThrows(Exception.class, () -> {
+        dao.update(new Customer(existingCustomer.getId(), newFirstname, newLastname));
+      });
     }
     
     @Test
-    public void retrievingACustomerByIdFailsWithExceptionAsFeedbackToClient() throws Exception {
-      dao.getById(existingCustomer.getId());
+    public void retrievingACustomerByIdFailsWithExceptionAsFeedbackToClient() {
+      assertThrows(Exception.class, () -> {
+        dao.getById(existingCustomer.getId());
+      });
     }
     
     @Test
-    public void retrievingAllCustomersFailsWithExceptionAsFeedbackToClient() throws Exception {
-      dao.getAll();
+    public void retrievingAllCustomersFailsWithExceptionAsFeedbackToClient() {
+      assertThrows(Exception.class, () -> {
+        dao.getAll();
+      });
     }
 
   }
@@ -243,7 +250,7 @@ public class DbCustomerDaoTest {
    * Delete customer schema for fresh setup per test.
    * @throws SQLException if any error occurs.
    */
-  @After
+  @AfterEach
   public void deleteSchema() throws SQLException {
     try (Connection connection = DriverManager.getConnection(DB_URL);
         Statement statement = connection.createStatement()) {

--- a/dao/src/test/java/com/iluwatar/dao/InMemoryCustomerDaoTest.java
+++ b/dao/src/test/java/com/iluwatar/dao/InMemoryCustomerDaoTest.java
@@ -23,31 +23,27 @@
 
 package com.iluwatar.dao;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeTrue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
-import de.bechte.junit.runners.context.HierarchicalContextRunner;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * Tests {@link InMemoryCustomerDao}.
  */
-@RunWith(HierarchicalContextRunner.class)
 public class InMemoryCustomerDaoTest {
 
   private InMemoryCustomerDao dao;
   private static final Customer CUSTOMER = new Customer(1, "Freddy", "Krueger");
 
-  @Before
+  @BeforeEach
   public void setUp() {
     dao = new InMemoryCustomerDao();
     assertTrue(dao.add(CUSTOMER));
@@ -57,6 +53,7 @@ public class InMemoryCustomerDaoTest {
    * Represents the scenario when the DAO operations are being performed on a non existent 
    * customer.  
    */
+  @Nested
   public class NonExistingCustomer {
 
     @Test
@@ -104,6 +101,7 @@ public class InMemoryCustomerDaoTest {
    * Represents the scenario when the DAO operations are being performed on an already existing
    * customer.
    */
+  @Nested
   public class ExistingCustomer {
 
     @Test

--- a/data-bus/pom.xml
+++ b/data-bus/pom.xml
@@ -38,8 +38,13 @@
     <artifactId>data-bus</artifactId>
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/data-bus/src/test/java/com/iluwatar/databus/DataBusTest.java
+++ b/data-bus/src/test/java/com/iluwatar/databus/DataBusTest.java
@@ -22,8 +22,8 @@
  */
 package com.iluwatar.databus;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -43,7 +43,7 @@ public class DataBusTest {
   @Mock
   private DataType event;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     MockitoAnnotations.initMocks(this);
   }

--- a/data-bus/src/test/java/com/iluwatar/databus/members/MessageCollectorMemberTest.java
+++ b/data-bus/src/test/java/com/iluwatar/databus/members/MessageCollectorMemberTest.java
@@ -24,10 +24,12 @@ package com.iluwatar.databus.members;
 
 import com.iluwatar.databus.data.MessageData;
 import com.iluwatar.databus.data.StartingData;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for {@link MessageCollectorMember}.
@@ -45,7 +47,7 @@ public class MessageCollectorMemberTest {
     //when
     collector.accept(messageData);
     //then
-    Assert.assertTrue(collector.getMessages().contains(message));
+    assertTrue(collector.getMessages().contains(message));
   }
 
   @Test
@@ -56,7 +58,7 @@ public class MessageCollectorMemberTest {
     //when
     collector.accept(startingData);
     //then
-    Assert.assertEquals(0, collector.getMessages().size());
+    assertEquals(0, collector.getMessages().size());
   }
 
 }

--- a/data-bus/src/test/java/com/iluwatar/databus/members/StatusMemberTest.java
+++ b/data-bus/src/test/java/com/iluwatar/databus/members/StatusMemberTest.java
@@ -26,11 +26,13 @@ import com.iluwatar.databus.DataBus;
 import com.iluwatar.databus.data.MessageData;
 import com.iluwatar.databus.data.StartingData;
 import com.iluwatar.databus.data.StoppingData;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
 import java.time.Month;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Tests for {@link StatusMember}.
@@ -48,7 +50,7 @@ public class StatusMemberTest {
     //when
     statusMember.accept(startingData);
     //then
-    Assert.assertEquals(startTime, statusMember.getStarted());
+    assertEquals(startTime, statusMember.getStarted());
   }
 
   @Test
@@ -61,7 +63,7 @@ public class StatusMemberTest {
     //when
     statusMember.accept(stoppingData);
     //then
-    Assert.assertEquals(stop, statusMember.getStopped());
+    assertEquals(stop, statusMember.getStopped());
   }
 
   @Test
@@ -72,8 +74,8 @@ public class StatusMemberTest {
     //when
     statusMember.accept(messageData);
     //then
-    Assert.assertNull(statusMember.getStarted());
-    Assert.assertNull(statusMember.getStopped());
+    assertNull(statusMember.getStarted());
+    assertNull(statusMember.getStopped());
   }
 
 }

--- a/data-mapper/pom.xml
+++ b/data-mapper/pom.xml
@@ -33,8 +33,13 @@
 	<artifactId>data-mapper</artifactId>
 	<dependencies>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/data-mapper/src/test/java/com/iluwatar/datamapper/AppTest.java
+++ b/data-mapper/src/test/java/com/iluwatar/datamapper/AppTest.java
@@ -18,8 +18,7 @@
  */
 package com.iluwatar.datamapper;
 
-import com.iluwatar.datamapper.App;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests that Data-Mapper example runs without errors.

--- a/data-mapper/src/test/java/com/iluwatar/datamapper/DataMapperTest.java
+++ b/data-mapper/src/test/java/com/iluwatar/datamapper/DataMapperTest.java
@@ -18,13 +18,9 @@
  */
 package com.iluwatar.datamapper;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Test;
-
-import com.iluwatar.datamapper.Student;
-import com.iluwatar.datamapper.StudentDataMapper;
-import com.iluwatar.datamapper.StudentDataMapperImpl;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * The Data Mapper (DM) is a layer of software that separates the in-memory objects from the

--- a/data-mapper/src/test/java/com/iluwatar/datamapper/StudentTest.java
+++ b/data-mapper/src/test/java/com/iluwatar/datamapper/StudentTest.java
@@ -18,10 +18,10 @@
  */
 package com.iluwatar.datamapper;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests {@link Student}.

--- a/data-transfer-object/pom.xml
+++ b/data-transfer-object/pom.xml
@@ -33,8 +33,13 @@
     <artifactId>data-transfer-object</artifactId>
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/data-transfer-object/src/test/java/com/iluwatar/datatransfer/CustomerResourceTest.java
+++ b/data-transfer-object/src/test/java/com/iluwatar/datatransfer/CustomerResourceTest.java
@@ -24,12 +24,12 @@
 
 package com.iluwatar.datatransfer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * tests {@link CustomerResource}.

--- a/decorator/pom.xml
+++ b/decorator/pom.xml
@@ -34,8 +34,13 @@
   <artifactId>decorator</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/decorator/src/test/java/com/iluwatar/decorator/AppTest.java
+++ b/decorator/src/test/java/com/iluwatar/decorator/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.decorator;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * 

--- a/decorator/src/test/java/com/iluwatar/decorator/ClubbedTrollTest.java
+++ b/decorator/src/test/java/com/iluwatar/decorator/ClubbedTrollTest.java
@@ -22,10 +22,12 @@
  */
 package com.iluwatar.decorator;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
 
 /**

--- a/decorator/src/test/java/com/iluwatar/decorator/SimpleTrollTest.java
+++ b/decorator/src/test/java/com/iluwatar/decorator/SimpleTrollTest.java
@@ -25,15 +25,15 @@ package com.iluwatar.decorator;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.AppenderBase;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 
 import java.util.LinkedList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests for {@link SimpleTroll}
@@ -42,12 +42,12 @@ public class SimpleTrollTest {
 
   private InMemoryAppender appender;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     appender = new InMemoryAppender(SimpleTroll.class);
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     appender.stop();
   }

--- a/delegation/pom.xml
+++ b/delegation/pom.xml
@@ -38,13 +38,13 @@
 
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.stefanbirkner</groupId>
-            <artifactId>system-rules</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/delegation/src/test/java/com/iluwatar/delegation/simple/AppTest.java
+++ b/delegation/src/test/java/com/iluwatar/delegation/simple/AppTest.java
@@ -22,7 +22,8 @@
  */
 package com.iluwatar.delegation.simple;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
 /**
  * Application Test Entry
  */

--- a/delegation/src/test/java/com/iluwatar/delegation/simple/DelegateTest.java
+++ b/delegation/src/test/java/com/iluwatar/delegation/simple/DelegateTest.java
@@ -22,20 +22,21 @@
  */
 package com.iluwatar.delegation.simple;
 
-import static org.junit.Assert.assertEquals;
-
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.AppenderBase;
 import com.iluwatar.delegation.simple.printers.CanonPrinter;
 import com.iluwatar.delegation.simple.printers.EpsonPrinter;
 import com.iluwatar.delegation.simple.printers.HpPrinter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
 import java.util.LinkedList;
 import java.util.List;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test for Delegation Pattern
@@ -44,12 +45,12 @@ public class DelegateTest {
 
   private InMemoryAppender appender;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     appender = new InMemoryAppender();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     appender.stop();
   }

--- a/dependency-injection/pom.xml
+++ b/dependency-injection/pom.xml
@@ -34,13 +34,13 @@
   <artifactId>dependency-injection</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/dependency-injection/src/test/java/com/iluwatar/dependency/injection/AdvancedSorceressTest.java
+++ b/dependency-injection/src/test/java/com/iluwatar/dependency/injection/AdvancedSorceressTest.java
@@ -23,11 +23,12 @@
 package com.iluwatar.dependency.injection;
 
 import com.iluwatar.dependency.injection.utils.InMemoryAppender;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 
 /**
  * Date: 28/04/17 - 7:40 AM
@@ -39,12 +40,12 @@ public class AdvancedSorceressTest {
 
   private InMemoryAppender appender;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     appender = new InMemoryAppender(Tobacco.class);
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     appender.stop();
   }

--- a/dependency-injection/src/test/java/com/iluwatar/dependency/injection/AdvancedWizardTest.java
+++ b/dependency-injection/src/test/java/com/iluwatar/dependency/injection/AdvancedWizardTest.java
@@ -23,11 +23,12 @@
 package com.iluwatar.dependency.injection;
 
 import com.iluwatar.dependency.injection.utils.InMemoryAppender;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 
 /**
  * Date: 12/10/15 - 8:40 PM
@@ -38,12 +39,12 @@ public class AdvancedWizardTest {
 
   private InMemoryAppender appender;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     appender = new InMemoryAppender(Tobacco.class);
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     appender.stop();
   }

--- a/dependency-injection/src/test/java/com/iluwatar/dependency/injection/AppTest.java
+++ b/dependency-injection/src/test/java/com/iluwatar/dependency/injection/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.dependency.injection;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * 

--- a/dependency-injection/src/test/java/com/iluwatar/dependency/injection/GuiceWizardTest.java
+++ b/dependency-injection/src/test/java/com/iluwatar/dependency/injection/GuiceWizardTest.java
@@ -26,11 +26,11 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.iluwatar.dependency.injection.utils.InMemoryAppender;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Date: 12/10/15 - 8:57 PM
@@ -41,12 +41,12 @@ public class GuiceWizardTest {
 
   private InMemoryAppender appender;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     appender = new InMemoryAppender(Tobacco.class);
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     appender.stop();
   }

--- a/dependency-injection/src/test/java/com/iluwatar/dependency/injection/SimpleWizardTest.java
+++ b/dependency-injection/src/test/java/com/iluwatar/dependency/injection/SimpleWizardTest.java
@@ -23,11 +23,11 @@
 package com.iluwatar.dependency.injection;
 
 import com.iluwatar.dependency.injection.utils.InMemoryAppender;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Date: 12/10/15 - 8:26 PM
@@ -38,12 +38,12 @@ public class SimpleWizardTest {
 
   private InMemoryAppender appender;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     appender = new InMemoryAppender(Tobacco.class);
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     appender.stop();
   }

--- a/double-checked-locking/pom.xml
+++ b/double-checked-locking/pom.xml
@@ -32,8 +32,13 @@
   <artifactId>double-checked-locking</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/double-checked-locking/src/test/java/com/iluwatar/doublechecked/locking/AppTest.java
+++ b/double-checked-locking/src/test/java/com/iluwatar/doublechecked/locking/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.doublechecked.locking;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * 

--- a/double-dispatch/pom.xml
+++ b/double-dispatch/pom.xml
@@ -34,8 +34,13 @@
   <artifactId>double-dispatch</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/double-dispatch/src/test/java/com/iluwatar/doubledispatch/AppTest.java
+++ b/double-dispatch/src/test/java/com/iluwatar/doubledispatch/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.doubledispatch;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * 

--- a/double-dispatch/src/test/java/com/iluwatar/doubledispatch/CollisionTest.java
+++ b/double-dispatch/src/test/java/com/iluwatar/doubledispatch/CollisionTest.java
@@ -22,9 +22,9 @@
  */
 package com.iluwatar.doubledispatch;
 
-import static org.junit.Assert.assertEquals;
-
 import java.util.Objects;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Date: 12/10/15 - 8:37 PM
@@ -86,7 +86,7 @@ public abstract class CollisionTest<O extends GameObject> {
         ? "Expected [" + targetName + "] to be on fire after colliding with [" + otherName + "] but it was not!"
         : "Expected [" + targetName + "] not to be on fire after colliding with [" + otherName + "] but it was!";
 
-    assertEquals(errorMessage, expectTargetOnFire, target.isOnFire());
+    assertEquals(expectTargetOnFire, target.isOnFire(), errorMessage);
   }
 
   /**
@@ -105,7 +105,7 @@ public abstract class CollisionTest<O extends GameObject> {
         ? "Expected [" + targetName + "] to be damaged after colliding with [" + otherName + "] but it was not!"
         : "Expected [" + targetName + "] not to be damaged after colliding with [" + otherName + "] but it was!";
 
-    assertEquals(errorMessage, expectedDamage, target.isDamaged());
+    assertEquals(expectedDamage, target.isDamaged(), errorMessage);
   }
 
 }

--- a/double-dispatch/src/test/java/com/iluwatar/doubledispatch/FlamingAsteroidTest.java
+++ b/double-dispatch/src/test/java/com/iluwatar/doubledispatch/FlamingAsteroidTest.java
@@ -22,11 +22,11 @@
  */
 package com.iluwatar.doubledispatch;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Date: 12/10/15 - 11:31 PM

--- a/double-dispatch/src/test/java/com/iluwatar/doubledispatch/MeteoroidTest.java
+++ b/double-dispatch/src/test/java/com/iluwatar/doubledispatch/MeteoroidTest.java
@@ -22,10 +22,10 @@
  */
 package com.iluwatar.doubledispatch;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * Date: 12/10/15 - 11:31 PM

--- a/double-dispatch/src/test/java/com/iluwatar/doubledispatch/RectangleTest.java
+++ b/double-dispatch/src/test/java/com/iluwatar/doubledispatch/RectangleTest.java
@@ -22,11 +22,11 @@
  */
 package com.iluwatar.doubledispatch;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static junit.framework.TestCase.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit test for Rectangle

--- a/double-dispatch/src/test/java/com/iluwatar/doubledispatch/SpaceStationIssTest.java
+++ b/double-dispatch/src/test/java/com/iluwatar/doubledispatch/SpaceStationIssTest.java
@@ -22,10 +22,10 @@
  */
 package com.iluwatar.doubledispatch;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * Date: 12/10/15 - 11:31 PM

--- a/double-dispatch/src/test/java/com/iluwatar/doubledispatch/SpaceStationMirTest.java
+++ b/double-dispatch/src/test/java/com/iluwatar/doubledispatch/SpaceStationMirTest.java
@@ -22,10 +22,10 @@
  */
 package com.iluwatar.doubledispatch;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * Date: 12/10/15 - 11:31 PM

--- a/eip-aggregator/pom.xml
+++ b/eip-aggregator/pom.xml
@@ -49,6 +49,21 @@
 
         <!-- Testing -->
         <dependency>
+            <groupId>com.github.sbrannen</groupId>
+            <artifactId>spring-test-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
         </dependency>

--- a/eip-aggregator/src/test/java/com/iluwatar/eip/aggregator/AppTest.java
+++ b/eip-aggregator/src/test/java/com/iluwatar/eip/aggregator/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.eip.aggregator;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test for App class

--- a/eip-aggregator/src/test/java/com/iluwatar/eip/aggregator/routes/AggregatorRouteTest.java
+++ b/eip-aggregator/src/test/java/com/iluwatar/eip/aggregator/routes/AggregatorRouteTest.java
@@ -25,16 +25,16 @@ package com.iluwatar.eip.aggregator.routes;
 import org.apache.camel.EndpointInject;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.component.mock.MockEndpoint;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test class for <i>AggregatorRoute</i>.
@@ -43,7 +43,7 @@ import static org.junit.Assert.assertEquals;
  * original endpoint names to mocks.
  * </p>
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringApplicationConfiguration(classes = AggregatorRouteTest.class)
 @ActiveProfiles("test")
 @EnableAutoConfiguration

--- a/eip-aggregator/src/test/java/com/iluwatar/eip/aggregator/routes/MessageAggregationStrategyTest.java
+++ b/eip-aggregator/src/test/java/com/iluwatar/eip/aggregator/routes/MessageAggregationStrategyTest.java
@@ -25,9 +25,9 @@ package com.iluwatar.eip.aggregator.routes;
 import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
 import org.apache.camel.impl.DefaultExchange;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests MessageAggregationStrategy

--- a/eip-splitter/pom.xml
+++ b/eip-splitter/pom.xml
@@ -49,6 +49,21 @@
 
         <!-- Testing -->
         <dependency>
+            <groupId>com.github.sbrannen</groupId>
+            <artifactId>spring-test-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
         </dependency>

--- a/eip-splitter/src/test/java/com/iluwatar/eip/splitter/AppTest.java
+++ b/eip-splitter/src/test/java/com/iluwatar/eip/splitter/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.eip.splitter;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test for App class

--- a/eip-splitter/src/test/java/com/iluwatar/eip/splitter/routes/SplitterRouteTest.java
+++ b/eip-splitter/src/test/java/com/iluwatar/eip/splitter/routes/SplitterRouteTest.java
@@ -23,19 +23,16 @@
 package com.iluwatar.eip.splitter.routes;
 
 import org.apache.camel.EndpointInject;
-import org.apache.camel.Message;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.component.mock.MockEndpoint;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-
-import static org.junit.Assert.assertEquals;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 /**
  * Test class for <i>SplitterRoute</i>.
@@ -44,7 +41,7 @@ import static org.junit.Assert.assertEquals;
  * original endpoint names to mocks.
  * </p>
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringApplicationConfiguration(classes = SplitterRouteTest.class)
 @ActiveProfiles("test")
 @EnableAutoConfiguration

--- a/eip-wire-tap/pom.xml
+++ b/eip-wire-tap/pom.xml
@@ -49,6 +49,21 @@
 
         <!-- Testing -->
         <dependency>
+            <groupId>com.github.sbrannen</groupId>
+            <artifactId>spring-test-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
         </dependency>

--- a/eip-wire-tap/src/test/java/com/iluwatar/eip/wiretap/AppTest.java
+++ b/eip-wire-tap/src/test/java/com/iluwatar/eip/wiretap/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.eip.wiretap;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test for App class

--- a/eip-wire-tap/src/test/java/com/iluwatar/eip/wiretap/routes/WireTapRouteTest.java
+++ b/eip-wire-tap/src/test/java/com/iluwatar/eip/wiretap/routes/WireTapRouteTest.java
@@ -26,16 +26,16 @@ import org.apache.camel.EndpointInject;
 import org.apache.camel.Message;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.component.mock.MockEndpoint;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test class for <i>WireTapRoute</i>.
@@ -44,7 +44,7 @@ import static org.junit.Assert.assertEquals;
  * original endpoint names to mocks.
  * </p>
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringApplicationConfiguration(classes = WireTapRouteTest.class)
 @ActiveProfiles("test")
 @EnableAutoConfiguration

--- a/event-aggregator/pom.xml
+++ b/event-aggregator/pom.xml
@@ -33,8 +33,13 @@
 	<artifactId>event-aggregator</artifactId>
 	<dependencies>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/event-aggregator/src/test/java/com/iluwatar/event/aggregator/AppTest.java
+++ b/event-aggregator/src/test/java/com/iluwatar/event/aggregator/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.event.aggregator;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * 

--- a/event-aggregator/src/test/java/com/iluwatar/event/aggregator/EventEmitterTest.java
+++ b/event-aggregator/src/test/java/com/iluwatar/event/aggregator/EventEmitterTest.java
@@ -22,6 +22,8 @@
  */
 package com.iluwatar.event.aggregator;
 
+import org.junit.jupiter.api.Test;
+
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -32,7 +34,6 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import org.junit.Test;
 
 /**
  * Date: 12/12/15 - 10:58 PM

--- a/event-aggregator/src/test/java/com/iluwatar/event/aggregator/EventTest.java
+++ b/event-aggregator/src/test/java/com/iluwatar/event/aggregator/EventTest.java
@@ -22,10 +22,10 @@
  */
 package com.iluwatar.event.aggregator;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Date: 12/12/15 - 2:52 PM

--- a/event-aggregator/src/test/java/com/iluwatar/event/aggregator/KingJoffreyTest.java
+++ b/event-aggregator/src/test/java/com/iluwatar/event/aggregator/KingJoffreyTest.java
@@ -25,15 +25,15 @@ package com.iluwatar.event.aggregator;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.AppenderBase;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 
 import java.util.LinkedList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Date: 12/12/15 - 3:04 PM
@@ -44,12 +44,12 @@ public class KingJoffreyTest {
 
   private InMemoryAppender appender;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     appender = new InMemoryAppender(KingJoffrey.class);
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     appender.stop();
   }

--- a/event-aggregator/src/test/java/com/iluwatar/event/aggregator/KingsHandTest.java
+++ b/event-aggregator/src/test/java/com/iluwatar/event/aggregator/KingsHandTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.event.aggregator;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;

--- a/event-aggregator/src/test/java/com/iluwatar/event/aggregator/WeekdayTest.java
+++ b/event-aggregator/src/test/java/com/iluwatar/event/aggregator/WeekdayTest.java
@@ -22,10 +22,10 @@
  */
 package com.iluwatar.event.aggregator;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Date: 12/12/15 - 2:12 PM

--- a/event-asynchronous/pom.xml
+++ b/event-asynchronous/pom.xml
@@ -34,8 +34,13 @@
   <artifactId>event-asynchronous</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/event-asynchronous/src/test/java/com/iluwatar/event/asynchronous/AppTest.java
+++ b/event-asynchronous/src/test/java/com/iluwatar/event/asynchronous/AppTest.java
@@ -16,9 +16,9 @@
  */
 package com.iluwatar.event.asynchronous;
 
-import java.io.IOException;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Test;
+import java.io.IOException;
 
 /**
  * Tests that EventAsynchronous example runs without errors.

--- a/event-asynchronous/src/test/java/com/iluwatar/event/asynchronous/EventAsynchronousTest.java
+++ b/event-asynchronous/src/test/java/com/iluwatar/event/asynchronous/EventAsynchronousTest.java
@@ -16,12 +16,13 @@
  */
 package com.iluwatar.event.asynchronous;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  *
@@ -33,7 +34,7 @@ public class EventAsynchronousTest {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(EventAsynchronousTest.class);
 
-  @Before
+  @BeforeEach
   public void setUp() {
     app = new App();
   }
@@ -71,17 +72,19 @@ public class EventAsynchronousTest {
     }
   }
 
-  @Test(expected = InvalidOperationException.class)
+  @Test
   public void testUnsuccessfulSynchronousEvent() throws InvalidOperationException {
-    EventManager eventManager = new EventManager();
-    try {
-      int sEventId = eventManager.create(60);
-      eventManager.start(sEventId);
-      sEventId = eventManager.create(60);
-      eventManager.start(sEventId);
-    } catch (MaxNumOfEventsAllowedException | LongRunningEventException | EventDoesNotExistException e) {
-      LOGGER.error(e.getMessage());
-    }
+    assertThrows(InvalidOperationException.class, () -> {
+      EventManager eventManager = new EventManager();
+      try {
+        int sEventId = eventManager.create(60);
+        eventManager.start(sEventId);
+        sEventId = eventManager.create(60);
+        eventManager.start(sEventId);
+      } catch (MaxNumOfEventsAllowedException | LongRunningEventException | EventDoesNotExistException e) {
+        LOGGER.error(e.getMessage());
+      }
+    });
   }
 
   @Test

--- a/event-driven-architecture/pom.xml
+++ b/event-driven-architecture/pom.xml
@@ -38,8 +38,13 @@
 
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/event-driven-architecture/src/test/java/com/iluwatar/eda/AppTest.java
+++ b/event-driven-architecture/src/test/java/com/iluwatar/eda/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.eda;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 

--- a/event-driven-architecture/src/test/java/com/iluwatar/eda/event/UserCreatedEventTest.java
+++ b/event-driven-architecture/src/test/java/com/iluwatar/eda/event/UserCreatedEventTest.java
@@ -23,10 +23,9 @@
 package com.iluwatar.eda.event;
 
 import com.iluwatar.eda.model.User;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * {@link UserCreatedEventTest} tests and verifies {@link AbstractEvent} behaviour.

--- a/event-driven-architecture/src/test/java/com/iluwatar/eda/framework/EventDispatcherTest.java
+++ b/event-driven-architecture/src/test/java/com/iluwatar/eda/framework/EventDispatcherTest.java
@@ -27,8 +27,7 @@ import com.iluwatar.eda.event.UserUpdatedEvent;
 import com.iluwatar.eda.handler.UserCreatedEventHandler;
 import com.iluwatar.eda.handler.UserUpdatedEventHandler;
 import com.iluwatar.eda.model.User;
-
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;

--- a/event-queue/pom.xml
+++ b/event-queue/pom.xml
@@ -35,8 +35,13 @@
   <artifactId>event-queue</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/event-queue/src/test/java/com/iluwatar/event/queue/AudioTest.java
+++ b/event-queue/src/test/java/com/iluwatar/event/queue/AudioTest.java
@@ -22,13 +22,15 @@
  */
 
 package com.iluwatar.event.queue;
-import static org.junit.Assert.*;
 
-import java.io.IOException;
+import org.junit.jupiter.api.Test;
 
 import javax.sound.sampled.UnsupportedAudioFileException;
+import java.io.IOException;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 
 /**
  * Testing the Audio service of the Queue
@@ -53,7 +55,7 @@ public class AudioTest {
     // test that service is finished
     assertFalse(!Audio.isServiceRunning());
   }
-  
+
   /**
    * Test here that the Queue
    * @throws UnsupportedAudioFileException when the audio file is not supported 

--- a/event-sourcing/pom.xml
+++ b/event-sourcing/pom.xml
@@ -35,8 +35,13 @@
   <artifactId>event-sourcing</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->

--- a/event-sourcing/src/test/java/IntegrationTest.java
+++ b/event-sourcing/src/test/java/IntegrationTest.java
@@ -21,20 +21,21 @@
  * THE SOFTWARE.
  */
 
-import static com.iluwatar.event.sourcing.app.App.ACCOUNT_OF_DAENERYS;
-import static com.iluwatar.event.sourcing.app.App.ACCOUNT_OF_JON;
-
 import com.iluwatar.event.sourcing.domain.Account;
 import com.iluwatar.event.sourcing.event.AccountCreateEvent;
 import com.iluwatar.event.sourcing.event.MoneyDepositEvent;
 import com.iluwatar.event.sourcing.event.MoneyTransferEvent;
 import com.iluwatar.event.sourcing.processor.DomainEventProcessor;
 import com.iluwatar.event.sourcing.state.AccountAggregate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import java.math.BigDecimal;
 import java.util.Date;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+
+import static com.iluwatar.event.sourcing.app.App.ACCOUNT_OF_DAENERYS;
+import static com.iluwatar.event.sourcing.app.App.ACCOUNT_OF_JON;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Intergartion Test for Event Sourcing state recovery
@@ -51,7 +52,7 @@ public class IntegrationTest {
   /**
    * Initialize.
    */
-  @Before
+  @BeforeEach
   public void initialize() {
     eventProcessor = new DomainEventProcessor();
   }
@@ -90,10 +91,9 @@ public class IntegrationTest {
     Account accountOfDaenerysAfterShotDown = AccountAggregate.getAccount(ACCOUNT_OF_DAENERYS);
     Account accountOfJonAfterShotDown = AccountAggregate.getAccount(ACCOUNT_OF_JON);
 
-    Assert.assertEquals(accountOfDaenerysBeforeShotDown.getMoney(),
+    assertEquals(accountOfDaenerysBeforeShotDown.getMoney(),
         accountOfDaenerysAfterShotDown.getMoney());
-    Assert
-        .assertEquals(accountOfJonBeforeShotDown.getMoney(), accountOfJonAfterShotDown.getMoney());
+    assertEquals(accountOfJonBeforeShotDown.getMoney(), accountOfJonAfterShotDown.getMoney());
   }
 
 }

--- a/execute-around/pom.xml
+++ b/execute-around/pom.xml
@@ -34,8 +34,18 @@
   <artifactId>execute-around</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-migrationsupport</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/execute-around/src/test/java/com/iluwatar/execute/around/AppTest.java
+++ b/execute-around/src/test/java/com/iluwatar/execute/around/AppTest.java
@@ -22,9 +22,9 @@
  */
 package com.iluwatar.execute.around;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -42,8 +42,8 @@ public class AppTest {
     App.main(args);
   }
 
-  @Before
-  @After
+  @BeforeEach
+  @AfterEach
   public void cleanup() {
     File file = new File("testfile.txt");
     file.delete();

--- a/execute-around/src/test/java/com/iluwatar/execute/around/SimpleFileWriterTest.java
+++ b/execute-around/src/test/java/com/iluwatar/execute/around/SimpleFileWriterTest.java
@@ -22,23 +22,26 @@
  */
 package com.iluwatar.execute.around;
 
-import org.junit.Assert;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Date: 12/12/15 - 3:21 PM
  *
  * @author Jeroen Meulemeester
  */
+@EnableRuleMigrationSupport
 public class SimpleFileWriterTest {
 
   /**
@@ -53,7 +56,7 @@ public class SimpleFileWriterTest {
   @Test
   public void testWriterNotNull() throws Exception {
     final File temporaryFile = this.testFolder.newFile();
-    new SimpleFileWriter(temporaryFile.getPath(), Assert::assertNotNull);
+    new SimpleFileWriter(temporaryFile.getPath(), Assertions::assertNotNull);
   }
 
   /**
@@ -64,7 +67,7 @@ public class SimpleFileWriterTest {
     final File nonExistingFile = new File(this.testFolder.getRoot(), "non-existing-file");
     assertFalse(nonExistingFile.exists());
 
-    new SimpleFileWriter(nonExistingFile.getPath(), Assert::assertNotNull);
+    new SimpleFileWriter(nonExistingFile.getPath(), Assertions::assertNotNull);
     assertTrue(nonExistingFile.exists());
   }
 
@@ -85,11 +88,13 @@ public class SimpleFileWriterTest {
   /**
    * Verify if an {@link IOException} during the write ripples through
    */
-  @Test(expected = IOException.class)
+  @Test
   public void testIoException() throws Exception {
-    final File temporaryFile = this.testFolder.newFile();
-    new SimpleFileWriter(temporaryFile.getPath(), writer -> {
-      throw new IOException("");
+    assertThrows(IOException.class, () -> {
+      final File temporaryFile = this.testFolder.newFile();
+      new SimpleFileWriter(temporaryFile.getPath(), writer -> {
+        throw new IOException("");
+      });
     });
   }
 

--- a/extension-objects/pom.xml
+++ b/extension-objects/pom.xml
@@ -36,8 +36,13 @@
   <artifactId>extension-objects</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/extension-objects/src/test/java/AppTest.java
+++ b/extension-objects/src/test/java/AppTest.java
@@ -20,7 +20,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 /**
  * Created by Srdjan on 03-May-17.

--- a/extension-objects/src/test/java/concreteextensions/CommanderTest.java
+++ b/extension-objects/src/test/java/concreteextensions/CommanderTest.java
@@ -22,7 +22,7 @@
  */
 package concreteextensions;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import units.CommanderUnit;
 
 /**

--- a/extension-objects/src/test/java/concreteextensions/SergeantTest.java
+++ b/extension-objects/src/test/java/concreteextensions/SergeantTest.java
@@ -22,7 +22,7 @@
  */
 package concreteextensions;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import units.SergeantUnit;
 
 /**

--- a/extension-objects/src/test/java/concreteextensions/SoldierTest.java
+++ b/extension-objects/src/test/java/concreteextensions/SoldierTest.java
@@ -22,7 +22,7 @@
  */
 package concreteextensions;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import units.SoldierUnit;
 
 /**

--- a/extension-objects/src/test/java/units/CommanderUnitTest.java
+++ b/extension-objects/src/test/java/units/CommanderUnitTest.java
@@ -23,10 +23,10 @@
 package units;
 
 import abstractextensions.CommanderExtension;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Created by Srdjan on 03-May-17.

--- a/extension-objects/src/test/java/units/SergeantUnitTest.java
+++ b/extension-objects/src/test/java/units/SergeantUnitTest.java
@@ -23,10 +23,10 @@
 package units;
 
 import abstractextensions.SergeantExtension;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Created by Srdjan on 03-May-17.

--- a/extension-objects/src/test/java/units/SoldierUnitTest.java
+++ b/extension-objects/src/test/java/units/SoldierUnitTest.java
@@ -23,10 +23,10 @@
 package units;
 
 import abstractextensions.SoldierExtension;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Created by Srdjan on 03-May-17.

--- a/extension-objects/src/test/java/units/UnitTest.java
+++ b/extension-objects/src/test/java/units/UnitTest.java
@@ -22,10 +22,10 @@
  */
 package units;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Created by Srdjan on 03-May-17.

--- a/facade/pom.xml
+++ b/facade/pom.xml
@@ -34,13 +34,13 @@
   <artifactId>facade</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/facade/src/test/java/com/iluwatar/facade/AppTest.java
+++ b/facade/src/test/java/com/iluwatar/facade/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.facade;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * 

--- a/facade/src/test/java/com/iluwatar/facade/DwarvenGoldmineFacadeTest.java
+++ b/facade/src/test/java/com/iluwatar/facade/DwarvenGoldmineFacadeTest.java
@@ -25,16 +25,16 @@ package com.iluwatar.facade;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.AppenderBase;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 
 import java.util.LinkedList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Date: 12/9/15 - 9:40 PM
@@ -45,12 +45,12 @@ public class DwarvenGoldmineFacadeTest {
 
   private InMemoryAppender appender;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     appender = new InMemoryAppender();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     appender.stop();
   }

--- a/factory-kit/pom.xml
+++ b/factory-kit/pom.xml
@@ -35,13 +35,13 @@
     <artifactId>factory-kit</artifactId>
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/factory-kit/src/test/java/com/iluwatar/factorykit/app/AppTest.java
+++ b/factory-kit/src/test/java/com/iluwatar/factorykit/app/AppTest.java
@@ -23,7 +23,7 @@
 package com.iluwatar.factorykit.app;
 
 import com.iluwatar.factorykit.App;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Application Test Entrypoint

--- a/factory-kit/src/test/java/com/iluwatar/factorykit/factorykit/FactoryKitTest.java
+++ b/factory-kit/src/test/java/com/iluwatar/factorykit/factorykit/FactoryKitTest.java
@@ -22,24 +22,25 @@
  */
 package com.iluwatar.factorykit.factorykit;
 
-import static org.junit.Assert.assertTrue;
-
 import com.iluwatar.factorykit.Axe;
 import com.iluwatar.factorykit.Spear;
 import com.iluwatar.factorykit.Sword;
 import com.iluwatar.factorykit.Weapon;
 import com.iluwatar.factorykit.WeaponFactory;
 import com.iluwatar.factorykit.WeaponType;
-import org.junit.Before;
-import org.junit.Test;
-/**
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+  /**
  *  Test Factory Kit Pattern
  */
 public class FactoryKitTest {
 
   private WeaponFactory factory;
 
-  @Before
+  @BeforeEach
   public void init() {
     factory = WeaponFactory.factory(builder -> {
       builder.add(WeaponType.SPEAR, Spear::new);
@@ -83,6 +84,6 @@ public class FactoryKitTest {
    * @param clazz  expected class of the weapon
    */
   private void verifyWeapon(Weapon weapon, Class clazz) {
-    assertTrue("Weapon must be an object of: " + clazz.getName(), clazz.isInstance(weapon));
+    assertTrue(clazz.isInstance(weapon), "Weapon must be an object of: " + clazz.getName());
   }
 }

--- a/factory-method/pom.xml
+++ b/factory-method/pom.xml
@@ -34,13 +34,13 @@
   <artifactId>factory-method</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/factory-method/src/test/java/com/iluwatar/factory/method/AppTest.java
+++ b/factory-method/src/test/java/com/iluwatar/factory/method/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.factory.method;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 

--- a/factory-method/src/test/java/com/iluwatar/factory/method/FactoryMethodTest.java
+++ b/factory-method/src/test/java/com/iluwatar/factory/method/FactoryMethodTest.java
@@ -22,10 +22,10 @@
  */
 package com.iluwatar.factory.method;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * The Factory Method is a creational design pattern which uses factory methods to deal with the
@@ -94,8 +94,7 @@ public class FactoryMethodTest {
    * @param clazz expected class of the weapon
    */
   private void verifyWeapon(Weapon weapon, WeaponType expectedWeaponType, Class<?> clazz) {
-    assertTrue("Weapon must be an object of: " + clazz.getName(), clazz.isInstance(weapon));
-    assertEquals("Weapon must be of weaponType: " + expectedWeaponType, expectedWeaponType,
-        weapon.getWeaponType());
+    assertTrue(clazz.isInstance(weapon), "Weapon must be an object of: " + clazz.getName());
+    assertEquals(expectedWeaponType, weapon.getWeaponType(), "Weapon must be of weaponType: " + expectedWeaponType);
   }
 }

--- a/feature-toggle/pom.xml
+++ b/feature-toggle/pom.xml
@@ -39,10 +39,14 @@
 
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/feature-toggle/src/test/java/com/iluwatar/featuretoggle/pattern/propertiesversion/PropertiesFeatureToggleVersionTest.java
+++ b/feature-toggle/src/test/java/com/iluwatar/featuretoggle/pattern/propertiesversion/PropertiesFeatureToggleVersionTest.java
@@ -23,30 +23,36 @@
 
 package com.iluwatar.featuretoggle.pattern.propertiesversion;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 import com.iluwatar.featuretoggle.pattern.Service;
 import com.iluwatar.featuretoggle.user.User;
+import org.junit.jupiter.api.Test;
+
 import java.util.Properties;
-import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test Properties Toggle
  */
 public class PropertiesFeatureToggleVersionTest {
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testNullPropertiesPassed() throws Exception {
-    new PropertiesFeatureToggleVersion(null);
+    assertThrows(IllegalArgumentException.class, () -> {
+      new PropertiesFeatureToggleVersion(null);
+    });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testNonBooleanProperty() throws Exception {
-    final Properties properties = new Properties();
-    properties.setProperty("enhancedWelcome", "Something");
-    new PropertiesFeatureToggleVersion(properties);
+    assertThrows(IllegalArgumentException.class, () -> {
+      final Properties properties = new Properties();
+      properties.setProperty("enhancedWelcome", "Something");
+      new PropertiesFeatureToggleVersion(properties);
+    });
   }
 
   @Test

--- a/feature-toggle/src/test/java/com/iluwatar/featuretoggle/pattern/tieredversion/TieredFeatureToggleVersionTest.java
+++ b/feature-toggle/src/test/java/com/iluwatar/featuretoggle/pattern/tieredversion/TieredFeatureToggleVersionTest.java
@@ -22,14 +22,14 @@
  */
 package com.iluwatar.featuretoggle.pattern.tieredversion;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import com.iluwatar.featuretoggle.pattern.Service;
 import com.iluwatar.featuretoggle.user.User;
 import com.iluwatar.featuretoggle.user.UserGroup;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test Tiered Feature Toggle
@@ -40,7 +40,7 @@ public class TieredFeatureToggleVersionTest {
   final User freeUser = new User("Alan Defect");
   final Service service = new TieredFeatureToggleVersion();
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     UserGroup.addUserToPaidGroup(paidUser);
     UserGroup.addUserToFreeGroup(freeUser);

--- a/feature-toggle/src/test/java/com/iluwatar/featuretoggle/user/UserGroupTest.java
+++ b/feature-toggle/src/test/java/com/iluwatar/featuretoggle/user/UserGroupTest.java
@@ -22,10 +22,11 @@
  */
 package com.iluwatar.featuretoggle.user;
 
-import static junit.framework.TestCase.assertFalse;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test User Group specific feature
@@ -46,17 +47,21 @@ public class UserGroupTest {
     assertTrue(UserGroup.isPaid(user));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testAddUserToPaidWhenOnFree() throws Exception {
     User user = new User("Paid User");
     UserGroup.addUserToFreeGroup(user);
-    UserGroup.addUserToPaidGroup(user);
+    assertThrows(IllegalArgumentException.class, () -> {
+      UserGroup.addUserToPaidGroup(user);
+    });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testAddUserToFreeWhenOnPaid() throws Exception {
     User user = new User("Free User");
     UserGroup.addUserToPaidGroup(user);
-    UserGroup.addUserToFreeGroup(user);
+    assertThrows(IllegalArgumentException.class, () -> {
+      UserGroup.addUserToFreeGroup(user);
+    });
   }
 }

--- a/fluentinterface/pom.xml
+++ b/fluentinterface/pom.xml
@@ -36,8 +36,13 @@
     <artifactId>fluentinterface</artifactId>
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/fluentinterface/src/test/java/com/iluwatar/fluentinterface/app/AppTest.java
+++ b/fluentinterface/src/test/java/com/iluwatar/fluentinterface/app/AppTest.java
@@ -22,7 +22,8 @@
  */
 package com.iluwatar.fluentinterface.app;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
 /**
  * Application Test Entry
  */

--- a/fluentinterface/src/test/java/com/iluwatar/fluentinterface/fluentiterable/FluentIterableTest.java
+++ b/fluentinterface/src/test/java/com/iluwatar/fluentinterface/fluentiterable/FluentIterableTest.java
@@ -22,13 +22,23 @@
  */
 package com.iluwatar.fluentinterface.fluentiterable;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Spliterator;
 import java.util.function.Consumer;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 /**
  * Date: 12/12/15 - 7:00 PM
@@ -56,7 +66,7 @@ public abstract class FluentIterableTest {
 
   @Test
   public void testFirstEmptyCollection() throws Exception {
-    final List<Integer> integers = Collections.<Integer>emptyList();
+    final List<Integer> integers = Collections.emptyList();
     final Optional<Integer> first = createFluentIterable(integers).first();
     assertNotNull(first);
     assertFalse(first.isPresent());

--- a/flux/pom.xml
+++ b/flux/pom.xml
@@ -34,8 +34,13 @@
   <artifactId>flux</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/flux/src/test/java/com/iluwatar/flux/action/ContentTest.java
+++ b/flux/src/test/java/com/iluwatar/flux/action/ContentTest.java
@@ -22,10 +22,10 @@
  */
 package com.iluwatar.flux.action;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Date: 12/12/15 - 10:11 PM

--- a/flux/src/test/java/com/iluwatar/flux/action/MenuItemTest.java
+++ b/flux/src/test/java/com/iluwatar/flux/action/MenuItemTest.java
@@ -22,10 +22,10 @@
  */
 package com.iluwatar.flux.action;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Date: 12/12/15 - 10:15 PM

--- a/flux/src/test/java/com/iluwatar/flux/app/AppTest.java
+++ b/flux/src/test/java/com/iluwatar/flux/app/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.flux.app;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * 

--- a/flux/src/test/java/com/iluwatar/flux/dispatcher/DispatcherTest.java
+++ b/flux/src/test/java/com/iluwatar/flux/dispatcher/DispatcherTest.java
@@ -29,8 +29,8 @@ import com.iluwatar.flux.action.ContentAction;
 import com.iluwatar.flux.action.MenuAction;
 import com.iluwatar.flux.action.MenuItem;
 import com.iluwatar.flux.store.Store;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.lang.reflect.Constructor;
@@ -38,9 +38,9 @@ import java.lang.reflect.Field;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -58,7 +58,7 @@ public class DispatcherTest {
    * Replace the instance with a fresh one before each test to make sure test cases have no
    * influence on each other.
    */
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     final Constructor<Dispatcher> constructor;
     constructor = Dispatcher.class.getDeclaredConstructor();

--- a/flux/src/test/java/com/iluwatar/flux/store/ContentStoreTest.java
+++ b/flux/src/test/java/com/iluwatar/flux/store/ContentStoreTest.java
@@ -27,9 +27,9 @@ import com.iluwatar.flux.action.ContentAction;
 import com.iluwatar.flux.action.MenuAction;
 import com.iluwatar.flux.action.MenuItem;
 import com.iluwatar.flux.view.View;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;

--- a/flux/src/test/java/com/iluwatar/flux/store/MenuStoreTest.java
+++ b/flux/src/test/java/com/iluwatar/flux/store/MenuStoreTest.java
@@ -27,9 +27,9 @@ import com.iluwatar.flux.action.ContentAction;
 import com.iluwatar.flux.action.MenuAction;
 import com.iluwatar.flux.action.MenuItem;
 import com.iluwatar.flux.view.View;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;

--- a/flux/src/test/java/com/iluwatar/flux/view/ContentViewTest.java
+++ b/flux/src/test/java/com/iluwatar/flux/view/ContentViewTest.java
@@ -24,7 +24,7 @@ package com.iluwatar.flux.view;
 
 import com.iluwatar.flux.action.Content;
 import com.iluwatar.flux.store.ContentStore;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;

--- a/flux/src/test/java/com/iluwatar/flux/view/MenuViewTest.java
+++ b/flux/src/test/java/com/iluwatar/flux/view/MenuViewTest.java
@@ -27,7 +27,7 @@ import com.iluwatar.flux.action.MenuItem;
 import com.iluwatar.flux.dispatcher.Dispatcher;
 import com.iluwatar.flux.store.MenuStore;
 import com.iluwatar.flux.store.Store;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;

--- a/flyweight/pom.xml
+++ b/flyweight/pom.xml
@@ -34,8 +34,13 @@
   <artifactId>flyweight</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/flyweight/src/test/java/com/iluwatar/flyweight/AlchemistShopTest.java
+++ b/flyweight/src/test/java/com/iluwatar/flyweight/AlchemistShopTest.java
@@ -22,13 +22,13 @@
  */
 package com.iluwatar.flyweight;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Date: 12/12/15 - 10:54 PM

--- a/flyweight/src/test/java/com/iluwatar/flyweight/AppTest.java
+++ b/flyweight/src/test/java/com/iluwatar/flyweight/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.flyweight;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * 

--- a/front-controller/pom.xml
+++ b/front-controller/pom.xml
@@ -35,8 +35,18 @@
 	<artifactId>front-controller</artifactId>
 	<dependencies>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-params</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/front-controller/src/test/java/com/iluwatar/front/controller/AppTest.java
+++ b/front-controller/src/test/java/com/iluwatar/front/controller/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.front.controller;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * 

--- a/front-controller/src/test/java/com/iluwatar/front/controller/ApplicationExceptionTest.java
+++ b/front-controller/src/test/java/com/iluwatar/front/controller/ApplicationExceptionTest.java
@@ -22,9 +22,9 @@
  */
 package com.iluwatar.front.controller;
 
-import static org.junit.Assert.assertSame;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * Date: 12/13/15 - 1:35 PM

--- a/front-controller/src/test/java/com/iluwatar/front/controller/CommandTest.java
+++ b/front-controller/src/test/java/com/iluwatar/front/controller/CommandTest.java
@@ -23,40 +23,36 @@
 package com.iluwatar.front.controller;
 
 import com.iluwatar.front.controller.utils.InMemoryAppender;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Date: 12/13/15 - 1:39 PM
  *
  * @author Jeroen Meulemeester
  */
-@RunWith(Parameterized.class)
 public class CommandTest {
 
   private InMemoryAppender appender;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     appender = new InMemoryAppender();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     appender.stop();
   }
 
-  @Parameters
-  public static List<Object[]> data() {
+  static List<Object[]> dataProvider() {
     final List<Object[]> parameters = new ArrayList<>();
     parameters.add(new Object[]{"Archer", "Displaying archers"});
     parameters.add(new Object[]{"Catapult", "Displaying catapults"});
@@ -65,28 +61,12 @@ public class CommandTest {
   }
 
   /**
-   * The view that's been tested
-   */
-  private final String request;
-
-  /**
-   * The expected display message
-   */
-  private final String displayMessage;
-
-  /**
-   * Create a new instance of the {@link CommandTest} with the given view and expected message
-   *
    * @param request        The request that's been tested
    * @param displayMessage The expected display message
    */
-  public CommandTest(final String request, final String displayMessage) {
-    this.displayMessage = displayMessage;
-    this.request = request;
-  }
-
-  @Test
-  public void testDisplay() {
+  @ParameterizedTest
+  @MethodSource("dataProvider")
+  public void testDisplay(String request, String displayMessage) {
     final FrontController frontController = new FrontController();
     assertEquals(0, appender.getLogSize());
     frontController.handleRequest(request);

--- a/front-controller/src/test/java/com/iluwatar/front/controller/FrontControllerTest.java
+++ b/front-controller/src/test/java/com/iluwatar/front/controller/FrontControllerTest.java
@@ -23,40 +23,36 @@
 package com.iluwatar.front.controller;
 
 import com.iluwatar.front.controller.utils.InMemoryAppender;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Date: 12/13/15 - 1:39 PM
  *
  * @author Jeroen Meulemeester
  */
-@RunWith(Parameterized.class)
 public class FrontControllerTest {
 
   private InMemoryAppender appender;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     appender = new InMemoryAppender();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     appender.stop();
   }
 
-  @Parameters
-  public static List<Object[]> data() {
+  static List<Object[]> dataProvider() {
     final List<Object[]> parameters = new ArrayList<>();
     parameters.add(new Object[]{new ArcherCommand(), "Displaying archers"});
     parameters.add(new Object[]{new CatapultCommand(), "Displaying catapults"});
@@ -65,30 +61,14 @@ public class FrontControllerTest {
   }
 
   /**
-   * The view that's been tested
-   */
-  private final Command command;
-
-  /**
-   * The expected display message
-   */
-  private final String displayMessage;
-
-  /**
-   * Create a new instance of the {@link FrontControllerTest} with the given view and expected message
-   *
    * @param command        The command that's been tested
    * @param displayMessage The expected display message
    */
-  public FrontControllerTest(final Command command, final String displayMessage) {
-    this.displayMessage = displayMessage;
-    this.command = command;
-  }
-
-  @Test
-  public void testDisplay() {
+  @ParameterizedTest
+  @MethodSource("dataProvider")
+  public void testDisplay(Command command, String displayMessage) {
     assertEquals(0, appender.getLogSize());
-    this.command.process();
+    command.process();
     assertEquals(displayMessage, appender.getLastMessage());
     assertEquals(1, appender.getLogSize());
   }

--- a/front-controller/src/test/java/com/iluwatar/front/controller/ViewTest.java
+++ b/front-controller/src/test/java/com/iluwatar/front/controller/ViewTest.java
@@ -23,40 +23,36 @@
 package com.iluwatar.front.controller;
 
 import com.iluwatar.front.controller.utils.InMemoryAppender;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Date: 12/13/15 - 1:39 PM
  *
  * @author Jeroen Meulemeester
  */
-@RunWith(Parameterized.class)
 public class ViewTest {
 
   private InMemoryAppender appender;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     appender = new InMemoryAppender();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     appender.stop();
   }
 
-  @Parameters
-  public static List<Object[]> data() {
+  static List<Object[]> dataProvider() {
     final List<Object[]> parameters = new ArrayList<>();
     parameters.add(new Object[]{new ArcherView(), "Displaying archers"});
     parameters.add(new Object[]{new CatapultView(), "Displaying catapults"});
@@ -65,30 +61,14 @@ public class ViewTest {
   }
 
   /**
-   * The view that's been tested
-   */
-  private final View view;
-
-  /**
-   * The expected display message
-   */
-  private final String displayMessage;
-
-  /**
-   * Create a new instance of the {@link ViewTest} with the given view and expected message
-   *
    * @param view           The view that's been tested
    * @param displayMessage The expected display message
    */
-  public ViewTest(final View view, final String displayMessage) {
-    this.displayMessage = displayMessage;
-    this.view = view;
-  }
-
-  @Test
-  public void testDisplay() {
+  @ParameterizedTest
+  @MethodSource("dataProvider")
+  public void testDisplay(View view, String displayMessage) {
     assertEquals(0, appender.getLogSize());
-    this.view.display();
+    view.display();
     assertEquals(displayMessage, appender.getLastMessage());
     assertEquals(1, appender.getLogSize());
   }

--- a/guarded-suspension/pom.xml
+++ b/guarded-suspension/pom.xml
@@ -36,8 +36,13 @@
   <artifactId>guarded-suspension</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/guarded-suspension/src/test/java/com/iluwatar/guarded/suspension/GuardedQueueTest.java
+++ b/guarded-suspension/src/test/java/com/iluwatar/guarded/suspension/GuardedQueueTest.java
@@ -22,12 +22,13 @@
  */
 package com.iluwatar.guarded.suspension;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test for Guarded Queue
@@ -47,15 +48,14 @@ public class GuardedQueueTest {
     } catch (InterruptedException e) {
       e.printStackTrace();
     }
-    Assert.assertEquals(Integer.valueOf(10), value);
+    assertEquals(Integer.valueOf(10), value);
   }
 
   @Test
   public void testPut() {
     GuardedQueue g = new GuardedQueue();
     g.put(12);
-    Assert.assertEquals(Integer.valueOf(12), g.get());
-
+    assertEquals(Integer.valueOf(12), g.get());
   }
 
 }

--- a/half-sync-half-async/pom.xml
+++ b/half-sync-half-async/pom.xml
@@ -34,8 +34,13 @@
   <artifactId>half-sync-half-async</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/half-sync-half-async/src/test/java/com/iluwatar/halfsynchalfasync/AppTest.java
+++ b/half-sync-half-async/src/test/java/com/iluwatar/halfsynchalfasync/AppTest.java
@@ -22,9 +22,9 @@
  */
 package com.iluwatar.halfsynchalfasync;
 
-import java.util.concurrent.ExecutionException;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Test;
+import java.util.concurrent.ExecutionException;
 
 /**
  * 

--- a/half-sync-half-async/src/test/java/com/iluwatar/halfsynchalfasync/AsynchronousServiceTest.java
+++ b/half-sync-half-async/src/test/java/com/iluwatar/halfsynchalfasync/AsynchronousServiceTest.java
@@ -22,14 +22,21 @@
  */
 package com.iluwatar.halfsynchalfasync;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 
 import java.io.IOException;
 import java.util.concurrent.LinkedBlockingQueue;
 
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 /**
  * Date: 12/12/15 - 11:15 PM

--- a/hexagonal/pom.xml
+++ b/hexagonal/pom.xml
@@ -35,8 +35,13 @@
   <artifactId>hexagonal</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/hexagonal/src/test/java/com/iluwatar/hexagonal/AppTest.java
+++ b/hexagonal/src/test/java/com/iluwatar/hexagonal/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.hexagonal;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit test for simple App.

--- a/hexagonal/src/test/java/com/iluwatar/hexagonal/banking/InMemoryBankTest.java
+++ b/hexagonal/src/test/java/com/iluwatar/hexagonal/banking/InMemoryBankTest.java
@@ -22,10 +22,10 @@
  */
 package com.iluwatar.hexagonal.banking;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * 

--- a/hexagonal/src/test/java/com/iluwatar/hexagonal/banking/MongoBankTest.java
+++ b/hexagonal/src/test/java/com/iluwatar/hexagonal/banking/MongoBankTest.java
@@ -24,16 +24,16 @@ package com.iluwatar.hexagonal.banking;
 
 import com.iluwatar.hexagonal.mongo.MongoConnectionPropertiesLoader;
 import com.mongodb.MongoClient;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests for Mongo banking adapter
  */
-@Ignore
+@Disabled
 public class MongoBankTest {
 
   private static final String TEST_DB = "lotteryDBTest";
@@ -41,7 +41,7 @@ public class MongoBankTest {
 
   private MongoBank mongoBank;
 
-  @Before
+  @BeforeEach
   public void init() {
     MongoConnectionPropertiesLoader.load();
     MongoClient mongoClient = new MongoClient(System.getProperty("mongo-host"),

--- a/hexagonal/src/test/java/com/iluwatar/hexagonal/database/InMemoryTicketRepositoryTest.java
+++ b/hexagonal/src/test/java/com/iluwatar/hexagonal/database/InMemoryTicketRepositoryTest.java
@@ -22,17 +22,16 @@
  */
 package com.iluwatar.hexagonal.database;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import java.util.Optional;
-
-import org.junit.Before;
-import org.junit.Test;
 
 import com.iluwatar.hexagonal.domain.LotteryTicket;
 import com.iluwatar.hexagonal.domain.LotteryTicketId;
 import com.iluwatar.hexagonal.test.LotteryTestUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * 
@@ -43,7 +42,7 @@ public class InMemoryTicketRepositoryTest {
 
   private final LotteryTicketRepository repository = new InMemoryTicketRepository();
   
-  @Before
+  @BeforeEach
   public void clear() {
     repository.deleteAll();
   }

--- a/hexagonal/src/test/java/com/iluwatar/hexagonal/database/MongoTicketRepositoryTest.java
+++ b/hexagonal/src/test/java/com/iluwatar/hexagonal/database/MongoTicketRepositoryTest.java
@@ -28,19 +28,19 @@ import com.iluwatar.hexagonal.domain.LotteryTicketId;
 import com.iluwatar.hexagonal.domain.PlayerDetails;
 import com.iluwatar.hexagonal.mongo.MongoConnectionPropertiesLoader;
 import com.mongodb.MongoClient;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for Mongo based ticket repository
  */
-@Ignore
+@Disabled
 public class MongoTicketRepositoryTest {
 
   private static final String TEST_DB = "lotteryTestDB";
@@ -49,7 +49,7 @@ public class MongoTicketRepositoryTest {
 
   private MongoTicketRepository repository;
 
-  @Before
+  @BeforeEach
   public void init() {
     MongoConnectionPropertiesLoader.load();
     MongoClient mongoClient = new MongoClient(System.getProperty("mongo-host"),

--- a/hexagonal/src/test/java/com/iluwatar/hexagonal/domain/LotteryNumbersTest.java
+++ b/hexagonal/src/test/java/com/iluwatar/hexagonal/domain/LotteryNumbersTest.java
@@ -22,14 +22,15 @@
  */
 package com.iluwatar.hexagonal.domain;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.HashSet;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * 
@@ -49,11 +50,13 @@ public class LotteryNumbersTest {
     assertTrue(numbers.getNumbers().contains(4));
   }
   
-  @Test(expected = UnsupportedOperationException.class)
+  @Test
   public void testNumbersCantBeModified() {
     LotteryNumbers numbers = LotteryNumbers.create(
             new HashSet<>(Arrays.asList(1, 2, 3, 4)));
-    numbers.getNumbers().add(5);
+    assertThrows(UnsupportedOperationException.class, () -> {
+      numbers.getNumbers().add(5);
+    });
   }
   
   @Test

--- a/hexagonal/src/test/java/com/iluwatar/hexagonal/domain/LotteryTest.java
+++ b/hexagonal/src/test/java/com/iluwatar/hexagonal/domain/LotteryTest.java
@@ -22,24 +22,23 @@
  */
 package com.iluwatar.hexagonal.domain;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import com.google.inject.Guice;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.iluwatar.hexagonal.banking.WireTransfers;
+import com.iluwatar.hexagonal.domain.LotteryTicketCheckResult.CheckResult;
+import com.iluwatar.hexagonal.module.LotteryTestingModule;
+import com.iluwatar.hexagonal.test.LotteryTestUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 
-import com.google.inject.Guice;
-import com.google.inject.Inject;
-import com.google.inject.Injector;
-import com.iluwatar.hexagonal.module.LotteryTestingModule;
-import org.junit.Before;
-import org.junit.Test;
-
-import com.iluwatar.hexagonal.banking.WireTransfers;
-import com.iluwatar.hexagonal.domain.LotteryTicketCheckResult.CheckResult;
-import com.iluwatar.hexagonal.test.LotteryTestUtils;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * 
@@ -60,7 +59,7 @@ public class LotteryTest {
     this.injector = Guice.createInjector(new LotteryTestingModule());
   }
 
-  @Before
+  @BeforeEach
   public void setup() {
     injector.injectMembers(this);
     // add funds to the test player's bank account

--- a/hexagonal/src/test/java/com/iluwatar/hexagonal/domain/LotteryTicketCheckResultTest.java
+++ b/hexagonal/src/test/java/com/iluwatar/hexagonal/domain/LotteryTicketCheckResultTest.java
@@ -22,12 +22,11 @@
  */
 package com.iluwatar.hexagonal.domain;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-
-import org.junit.Test;
-
 import com.iluwatar.hexagonal.domain.LotteryTicketCheckResult.CheckResult;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * 

--- a/hexagonal/src/test/java/com/iluwatar/hexagonal/domain/LotteryTicketIdTest.java
+++ b/hexagonal/src/test/java/com/iluwatar/hexagonal/domain/LotteryTicketIdTest.java
@@ -22,10 +22,10 @@
  */
 package com.iluwatar.hexagonal.domain;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for lottery ticket id

--- a/hexagonal/src/test/java/com/iluwatar/hexagonal/domain/LotteryTicketTest.java
+++ b/hexagonal/src/test/java/com/iluwatar/hexagonal/domain/LotteryTicketTest.java
@@ -22,13 +22,13 @@
  */
 package com.iluwatar.hexagonal.domain;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.HashSet;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * Test Lottery Tickets for equality

--- a/hexagonal/src/test/java/com/iluwatar/hexagonal/domain/PlayerDetailsTest.java
+++ b/hexagonal/src/test/java/com/iluwatar/hexagonal/domain/PlayerDetailsTest.java
@@ -22,10 +22,10 @@
  */
 package com.iluwatar.hexagonal.domain;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * 

--- a/hexagonal/src/test/java/com/iluwatar/hexagonal/eventlog/MongoEventLogTest.java
+++ b/hexagonal/src/test/java/com/iluwatar/hexagonal/eventlog/MongoEventLogTest.java
@@ -25,16 +25,16 @@ package com.iluwatar.hexagonal.eventlog;
 import com.iluwatar.hexagonal.domain.PlayerDetails;
 import com.iluwatar.hexagonal.mongo.MongoConnectionPropertiesLoader;
 import com.mongodb.MongoClient;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests for Mongo event log
  */
-@Ignore
+@Disabled
 public class MongoEventLogTest {
 
   private static final String TEST_DB = "lotteryDBTest";
@@ -42,7 +42,7 @@ public class MongoEventLogTest {
 
   private MongoEventLog mongoEventLog;
 
-  @Before
+  @BeforeEach
   public void init() {
     MongoConnectionPropertiesLoader.load();
     MongoClient mongoClient = new MongoClient(System.getProperty("mongo-host"),

--- a/intercepting-filter/pom.xml
+++ b/intercepting-filter/pom.xml
@@ -34,8 +34,18 @@
   <artifactId>intercepting-filter</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/intercepting-filter/src/test/java/com/iluwatar/intercepting/filter/AppTest.java
+++ b/intercepting-filter/src/test/java/com/iluwatar/intercepting/filter/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.intercepting.filter;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * 

--- a/intercepting-filter/src/test/java/com/iluwatar/intercepting/filter/FilterManagerTest.java
+++ b/intercepting-filter/src/test/java/com/iluwatar/intercepting/filter/FilterManagerTest.java
@@ -22,9 +22,9 @@
  */
 package com.iluwatar.intercepting.filter;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;

--- a/intercepting-filter/src/test/java/com/iluwatar/intercepting/filter/FilterTest.java
+++ b/intercepting-filter/src/test/java/com/iluwatar/intercepting/filter/FilterTest.java
@@ -22,25 +22,22 @@
  */
 package com.iluwatar.intercepting.filter;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static junit.framework.TestCase.assertSame;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * Date: 12/13/15 - 2:17 PM
  *
  * @author Jeroen Meulemeester
  */
-@RunWith(Parameterized.class)
 public class FilterTest {
 
   private static final Order PERFECT_ORDER = new Order("name", "12345678901", "addr", "dep", "order");
@@ -50,8 +47,7 @@ public class FilterTest {
   private static final Order WRONG_CONTACT = new Order("name", "", "addr", "dep", "order");
   private static final Order WRONG_NAME = new Order("", "12345678901", "addr", "dep", "order");
 
-  @Parameters
-  public static List<Object[]> getTestData() {
+  static List<Object[]> getTestData() {
     final List<Object[]> testData = new ArrayList<>();
     testData.add(new Object[]{new NameFilter(), PERFECT_ORDER, ""});
     testData.add(new Object[]{new NameFilter(), WRONG_NAME, "Invalid name!"});
@@ -91,30 +87,19 @@ public class FilterTest {
     return testData;
   }
 
-  private final Filter filter;
-  private final Order order;
-  private final String result;
-
-  /**
-   * Constructor
-   */
-  public FilterTest(Filter filter, Order order, String result) {
-    this.filter = filter;
-    this.order = order;
-    this.result = result;
-  }
-
-  @Test
-  public void testExecute() throws Exception {
-    final String result = this.filter.execute(this.order);
+  @ParameterizedTest
+  @MethodSource("getTestData")
+  public void testExecute(Filter filter, Order order, String expectedResult) throws Exception {
+    final String result = filter.execute(order);
     assertNotNull(result);
-    assertEquals(this.result, result.trim());
+    assertEquals(expectedResult, result.trim());
   }
 
-  @Test
-  public void testNext() throws Exception {
-    assertNull(this.filter.getNext());
-    assertSame(this.filter, this.filter.getLast());
+  @ParameterizedTest
+  @MethodSource("getTestData")
+  public void testNext(Filter filter) throws Exception {
+    assertNull(filter.getNext());
+    assertSame(filter, filter.getLast());
   }
 
 }

--- a/intercepting-filter/src/test/java/com/iluwatar/intercepting/filter/OrderTest.java
+++ b/intercepting-filter/src/test/java/com/iluwatar/intercepting/filter/OrderTest.java
@@ -22,9 +22,9 @@
  */
 package com.iluwatar.intercepting.filter;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Date: 12/13/15 - 2:57 PM

--- a/interpreter/pom.xml
+++ b/interpreter/pom.xml
@@ -34,8 +34,18 @@
   <artifactId>interpreter</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/interpreter/src/test/java/com/iluwatar/interpreter/AppTest.java
+++ b/interpreter/src/test/java/com/iluwatar/interpreter/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.interpreter;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * 

--- a/interpreter/src/test/java/com/iluwatar/interpreter/ExpressionTest.java
+++ b/interpreter/src/test/java/com/iluwatar/interpreter/ExpressionTest.java
@@ -22,15 +22,19 @@
  */
 package com.iluwatar.interpreter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.IntBinaryOperator;
+import java.util.stream.Stream;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Date: 12/14/15 - 11:48 AM
@@ -45,36 +49,21 @@ public abstract class ExpressionTest<E extends Expression> {
    * Generate inputs ranging from -10 to 10 for both input params and calculate the expected result
    *
    * @param resultCalc The function used to calculate the expected result
-   * @return A data set with test entries
+   * @return A stream with test entries
    */
-  static List<Object[]> prepareParameters(final IntBinaryOperator resultCalc) {
-    final List<Object[]> testData = new ArrayList<>();
+  static Stream<Arguments> prepareParameters(final IntBinaryOperator resultCalc) {
+    final List<Arguments> testData = new ArrayList<>();
     for (int i = -10; i < 10; i++) {
       for (int j = -10; j < 10; j++) {
-        testData.add(new Object[]{
-            new NumberExpression(i),
-            new NumberExpression(j),
-            resultCalc.applyAsInt(i, j)
-        });
+        testData.add(Arguments.of(
+                new NumberExpression(i),
+                new NumberExpression(j),
+                resultCalc.applyAsInt(i, j)
+        ));
       }
     }
-    return testData;
+    return testData.stream();
   }
-
-  /**
-   * The input used as first parameter during the test
-   */
-  private final NumberExpression first;
-
-  /**
-   * The input used as second parameter during the test
-   */
-  private final NumberExpression second;
-
-  /**
-   * The expected result of the calculation, taking the first and second parameter in account
-   */
-  private final int result;
 
   /**
    * The expected {@link E#toString()} response
@@ -89,47 +78,34 @@ public abstract class ExpressionTest<E extends Expression> {
   /**
    * Create a new test instance with the given parameters and expected results
    *
-   * @param first            The input used as first parameter during the test
-   * @param second           The input used as second parameter during the test
-   * @param result           The expected result of the tested expression
    * @param expectedToString The expected {@link E#toString()} response
    * @param factory          Factory, used to create a new test object instance
    */
-  ExpressionTest(final NumberExpression first, final NumberExpression second, final int result,
-                 final String expectedToString, final BiFunction<NumberExpression, NumberExpression, E> factory) {
-
-    this.first = first;
-    this.second = second;
-    this.result = result;
+  ExpressionTest(final String expectedToString,
+                 final BiFunction<NumberExpression, NumberExpression, E> factory
+  ) {
     this.expectedToString = expectedToString;
     this.factory = factory;
   }
 
   /**
-   * Get the first parameter
-   *
-   * @return The first parameter
-   */
-  final NumberExpression getFirst() {
-    return this.first;
-  }
-
-  /**
    * Verify if the expression calculates the correct result when calling {@link E#interpret()}
    */
-  @Test
-  public void testInterpret() {
-    final E expression = this.factory.apply(this.first, this.second);
+  @ParameterizedTest
+  @MethodSource("expressionProvider")
+  public void testInterpret(NumberExpression first, NumberExpression second, int result) {
+    final E expression = factory.apply(first, second);
     assertNotNull(expression);
-    assertEquals(this.result, expression.interpret());
+    assertEquals(result, expression.interpret());
   }
 
   /**
    * Verify if the expression has the expected {@link E#toString()} value
    */
-  @Test
-  public void testToString() {
-    final E expression = this.factory.apply(this.first, this.second);
+  @ParameterizedTest
+  @MethodSource("expressionProvider")
+  public void testToString(NumberExpression first, NumberExpression second) {
+    final E expression = factory.apply(first, second);
     assertNotNull(expression);
     assertEquals(expectedToString, expression.toString());
   }

--- a/interpreter/src/test/java/com/iluwatar/interpreter/MinusExpressionTest.java
+++ b/interpreter/src/test/java/com/iluwatar/interpreter/MinusExpressionTest.java
@@ -22,18 +22,15 @@
  */
 package com.iluwatar.interpreter;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.params.provider.Arguments;
 
-import java.util.List;
+import java.util.stream.Stream;
 
 /**
  * Date: 12/14/15 - 12:08 PM
  *
  * @author Jeroen Meulemeester
  */
-@RunWith(Parameterized.class)
 public class MinusExpressionTest extends ExpressionTest<MinusExpression> {
 
   /**
@@ -41,20 +38,15 @@ public class MinusExpressionTest extends ExpressionTest<MinusExpression> {
    *
    * @return The list of parameters used during this test
    */
-  @Parameters
-  public static List<Object[]> data() {
+  public static Stream<Arguments> expressionProvider() {
     return prepareParameters((f, s) -> f - s);
   }
 
   /**
    * Create a new test instance using the given test parameters and expected result
-   *
-   * @param first  The first expression parameter
-   * @param second The second expression parameter
-   * @param result The expected result
    */
-  public MinusExpressionTest(final NumberExpression first, final NumberExpression second, final int result) {
-    super(first, second, result, "-", MinusExpression::new);
+  public MinusExpressionTest() {
+    super("-", MinusExpression::new);
   }
 
 }

--- a/interpreter/src/test/java/com/iluwatar/interpreter/MultiplyExpressionTest.java
+++ b/interpreter/src/test/java/com/iluwatar/interpreter/MultiplyExpressionTest.java
@@ -22,18 +22,15 @@
  */
 package com.iluwatar.interpreter;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.params.provider.Arguments;
 
-import java.util.List;
+import java.util.stream.Stream;
 
 /**
  * Date: 12/14/15 - 12:08 PM
  *
  * @author Jeroen Meulemeester
  */
-@RunWith(Parameterized.class)
 public class MultiplyExpressionTest extends ExpressionTest<MultiplyExpression> {
 
   /**
@@ -41,20 +38,16 @@ public class MultiplyExpressionTest extends ExpressionTest<MultiplyExpression> {
    *
    * @return The list of parameters used during this test
    */
-  @Parameters
-  public static List<Object[]> data() {
+  public static Stream<Arguments> expressionProvider() {
     return prepareParameters((f, s) -> f * s);
   }
 
   /**
    * Create a new test instance using the given test parameters and expected result
    *
-   * @param first  The first expression parameter
-   * @param second The second expression parameter
-   * @param result The expected result
    */
-  public MultiplyExpressionTest(final NumberExpression first, final NumberExpression second, final int result) {
-    super(first, second, result, "*", MultiplyExpression::new);
+  public MultiplyExpressionTest() {
+    super("*", MultiplyExpression::new);
   }
 
 }

--- a/interpreter/src/test/java/com/iluwatar/interpreter/NumberExpressionTest.java
+++ b/interpreter/src/test/java/com/iluwatar/interpreter/NumberExpressionTest.java
@@ -22,21 +22,19 @@
  */
 package com.iluwatar.interpreter;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.List;
+import java.util.stream.Stream;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Date: 12/14/15 - 12:08 PM
  *
  * @author Jeroen Meulemeester
  */
-@RunWith(Parameterized.class)
 public class NumberExpressionTest extends ExpressionTest<NumberExpression> {
 
   /**
@@ -44,30 +42,26 @@ public class NumberExpressionTest extends ExpressionTest<NumberExpression> {
    *
    * @return The list of parameters used during this test
    */
-  @Parameters
-  public static List<Object[]> data() {
+  public static Stream<Arguments> expressionProvider() {
     return prepareParameters((f, s) -> f);
   }
 
   /**
    * Create a new test instance using the given test parameters and expected result
-   *
-   * @param first  The first expression parameter
-   * @param second The second expression parameter
-   * @param result The expected result
    */
-  public NumberExpressionTest(final NumberExpression first, final NumberExpression second, final int result) {
-    super(first, second, result, "number", (f, s) -> f);
+  public NumberExpressionTest() {
+    super("number", (f, s) -> f);
   }
 
   /**
    * Verify if the {@link NumberExpression#NumberExpression(String)} constructor works as expected
    */
-  @Test
-  public void testFromString() throws Exception {
-    final int expectedValue = getFirst().interpret();
-    final String testStingValue = String.valueOf(expectedValue);
-    final NumberExpression numberExpression = new NumberExpression(testStingValue);
+  @ParameterizedTest
+  @MethodSource("expressionProvider")
+  public void testFromString(NumberExpression first) throws Exception {
+    final int expectedValue = first.interpret();
+    final String testStringValue = String.valueOf(expectedValue);
+    final NumberExpression numberExpression = new NumberExpression(testStringValue);
     assertEquals(expectedValue, numberExpression.interpret());
   }
 

--- a/interpreter/src/test/java/com/iluwatar/interpreter/PlusExpressionTest.java
+++ b/interpreter/src/test/java/com/iluwatar/interpreter/PlusExpressionTest.java
@@ -22,18 +22,15 @@
  */
 package com.iluwatar.interpreter;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.params.provider.Arguments;
 
-import java.util.List;
+import java.util.stream.Stream;
 
 /**
  * Date: 12/14/15 - 12:08 PM
  *
  * @author Jeroen Meulemeester
  */
-@RunWith(Parameterized.class)
 public class PlusExpressionTest extends ExpressionTest<PlusExpression> {
 
   /**
@@ -41,20 +38,15 @@ public class PlusExpressionTest extends ExpressionTest<PlusExpression> {
    *
    * @return The list of parameters used during this test
    */
-  @Parameters
-  public static List<Object[]> data() {
+  public static Stream<Arguments> expressionProvider() {
     return prepareParameters((f, s) -> f + s);
   }
 
   /**
    * Create a new test instance using the given test parameters and expected result
-   *
-   * @param first  The first expression parameter
-   * @param second The second expression parameter
-   * @param result The expected result
    */
-  public PlusExpressionTest(final NumberExpression first, final NumberExpression second, final int result) {
-    super(first, second, result, "+", PlusExpression::new);
+  public PlusExpressionTest() {
+    super("+", PlusExpression::new);
   }
 
 }

--- a/iterator/pom.xml
+++ b/iterator/pom.xml
@@ -34,8 +34,18 @@
   <artifactId>iterator</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/iterator/src/test/java/com/iluwatar/iterator/AppTest.java
+++ b/iterator/src/test/java/com/iluwatar/iterator/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.iterator;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * 

--- a/iterator/src/test/java/com/iluwatar/iterator/TreasureChestTest.java
+++ b/iterator/src/test/java/com/iluwatar/iterator/TreasureChestTest.java
@@ -22,23 +22,21 @@
  */
 package com.iluwatar.iterator;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Date: 12/14/15 - 2:58 PM
  *
  * @author Jeroen Meulemeester
  */
-@RunWith(Parameterized.class)
 public class TreasureChestTest {
 
   /**
@@ -46,8 +44,7 @@ public class TreasureChestTest {
    *
    * @return The set of all expected items in the chest
    */
-  @Parameterized.Parameters
-  public static List<Object[]> data() {
+  public static List<Object[]> dataProvider() {
     final List<Object[]> parameters = new ArrayList<>();
     parameters.add(new Object[]{new Item(ItemType.POTION, "Potion of courage")});
     parameters.add(new Object[]{new Item(ItemType.RING, "Ring of shadows")});
@@ -63,24 +60,11 @@ public class TreasureChestTest {
   }
 
   /**
-   * One of the expected items in the chest
-   */
-  private final Item expectedItem;
-
-  /**
-   * Create a new test instance, test if the given expected item can be retrieved from the chest
-   *
-   * @param expectedItem One of the items that should be in the chest
-   */
-  public TreasureChestTest(final Item expectedItem) {
-    this.expectedItem = expectedItem;
-  }
-
-  /**
    * Test if the expected item can be retrieved from the chest using the {@link ItemIterator}
    */
-  @Test
-  public void testIterator() {
+  @ParameterizedTest
+  @MethodSource("dataProvider")
+  public void testIterator(Item expectedItem) {
     final TreasureChest chest = new TreasureChest();
     final ItemIterator iterator = chest.iterator(expectedItem.getType());
     assertNotNull(iterator);
@@ -88,16 +72,16 @@ public class TreasureChestTest {
     while (iterator.hasNext()) {
       final Item item = iterator.next();
       assertNotNull(item);
-      assertEquals(this.expectedItem.getType(), item.getType());
+      assertEquals(expectedItem.getType(), item.getType());
 
       final String name = item.toString();
       assertNotNull(name);
-      if (this.expectedItem.toString().equals(name)) {
+      if (expectedItem.toString().equals(name)) {
         return;
       }
     }
 
-    fail("Expected to find item [" + this.expectedItem + "] using iterator, but we didn't.");
+    fail("Expected to find item [" + expectedItem + "] using iterator, but we didn't.");
 
   }
 
@@ -105,8 +89,9 @@ public class TreasureChestTest {
    * Test if the expected item can be retrieved from the chest using the {@link
    * TreasureChest#getItems()} method
    */
-  @Test
-  public void testGetItems() throws Exception {
+  @ParameterizedTest
+  @MethodSource("dataProvider")
+  public void testGetItems(Item expectedItem) throws Exception {
     final TreasureChest chest = new TreasureChest();
     final List<Item> items = chest.getItems();
     assertNotNull(items);
@@ -116,14 +101,14 @@ public class TreasureChestTest {
       assertNotNull(item.getType());
       assertNotNull(item.toString());
 
-      final boolean sameType = this.expectedItem.getType() == item.getType();
-      final boolean sameName = this.expectedItem.toString().equals(item.toString());
+      final boolean sameType = expectedItem.getType() == item.getType();
+      final boolean sameName = expectedItem.toString().equals(item.toString());
       if (sameType && sameName) {
         return;
       }
     }
 
-    fail("Expected to find item [" + this.expectedItem + "] in the item list, but we didn't.");
+    fail("Expected to find item [" + expectedItem + "] in the item list, but we didn't.");
 
   }
 

--- a/layers/pom.xml
+++ b/layers/pom.xml
@@ -52,8 +52,13 @@
 			<artifactId>h2</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/layers/src/test/java/com/iluwatar/layers/AppTest.java
+++ b/layers/src/test/java/com/iluwatar/layers/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.layers;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * 

--- a/layers/src/test/java/com/iluwatar/layers/CakeBakingExceptionTest.java
+++ b/layers/src/test/java/com/iluwatar/layers/CakeBakingExceptionTest.java
@@ -22,10 +22,10 @@
  */
 package com.iluwatar.layers;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Date: 12/15/15 - 7:57 PM

--- a/layers/src/test/java/com/iluwatar/layers/CakeBakingServiceImplTest.java
+++ b/layers/src/test/java/com/iluwatar/layers/CakeBakingServiceImplTest.java
@@ -22,16 +22,17 @@
  */
 package com.iluwatar.layers;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Date: 12/15/15 - 9:55 PM
@@ -123,7 +124,7 @@ public class CakeBakingServiceImplTest {
 
   }
 
-  @Test(expected = CakeBakingException.class)
+  @Test
   public void testBakeCakeMissingTopping() throws CakeBakingException {
     final CakeBakingServiceImpl service = new CakeBakingServiceImpl();
 
@@ -133,10 +134,12 @@ public class CakeBakingServiceImplTest {
     service.saveNewLayer(layer2);
 
     final CakeToppingInfo missingTopping = new CakeToppingInfo("Topping1", 1000);
-    service.bakeNewCake(new CakeInfo(missingTopping, Arrays.asList(layer1, layer2)));
+    assertThrows(CakeBakingException.class, () -> {
+      service.bakeNewCake(new CakeInfo(missingTopping, Arrays.asList(layer1, layer2)));
+    });
   }
 
-  @Test(expected = CakeBakingException.class)
+  @Test
   public void testBakeCakeMissingLayer() throws CakeBakingException {
     final CakeBakingServiceImpl service = new CakeBakingServiceImpl();
 
@@ -151,11 +154,12 @@ public class CakeBakingServiceImplTest {
     service.saveNewLayer(layer1);
 
     final CakeLayerInfo missingLayer = new CakeLayerInfo("Layer2", 2000);
-    service.bakeNewCake(new CakeInfo(topping1, Arrays.asList(layer1, missingLayer)));
-
+    assertThrows(CakeBakingException.class, () -> {
+      service.bakeNewCake(new CakeInfo(topping1, Arrays.asList(layer1, missingLayer)));
+    });
   }
 
-  @Test(expected = CakeBakingException.class)
+  @Test
   public void testBakeCakesUsedLayer() throws CakeBakingException {
     final CakeBakingServiceImpl service = new CakeBakingServiceImpl();
 
@@ -174,8 +178,9 @@ public class CakeBakingServiceImplTest {
     service.saveNewLayer(layer2);
 
     service.bakeNewCake(new CakeInfo(topping1, Arrays.asList(layer1, layer2)));
-    service.bakeNewCake(new CakeInfo(topping2, Collections.singletonList(layer2)));
-
+    assertThrows(CakeBakingException.class, () -> {
+      service.bakeNewCake(new CakeInfo(topping2, Collections.singletonList(layer2)));
+    });
   }
 
 }

--- a/layers/src/test/java/com/iluwatar/layers/CakeTest.java
+++ b/layers/src/test/java/com/iluwatar/layers/CakeTest.java
@@ -22,15 +22,15 @@
  */
 package com.iluwatar.layers;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashSet;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Date: 12/15/15 - 8:02 PM

--- a/layers/src/test/java/com/iluwatar/layers/CakeViewImplTest.java
+++ b/layers/src/test/java/com/iluwatar/layers/CakeViewImplTest.java
@@ -25,17 +25,18 @@ package com.iluwatar.layers;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.AppenderBase;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Date: 12/15/15 - 10:04 PM
@@ -46,12 +47,12 @@ public class CakeViewImplTest {
 
   private InMemoryAppender appender;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     appender = new InMemoryAppender(CakeViewImpl.class);
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     appender.stop();
   }

--- a/lazy-loading/pom.xml
+++ b/lazy-loading/pom.xml
@@ -34,8 +34,13 @@
   <artifactId>lazy-loading</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/lazy-loading/src/test/java/com/iluwatar/lazy/loading/AbstractHolderTest.java
+++ b/lazy-loading/src/test/java/com/iluwatar/lazy/loading/AbstractHolderTest.java
@@ -22,11 +22,13 @@
  */
 package com.iluwatar.lazy.loading;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertSame;
-import static junit.framework.TestCase.assertNull;
+import static java.time.Duration.ofMillis;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTimeout;
 
 /**
  * Date: 12/19/15 - 11:58 AM
@@ -52,12 +54,14 @@ public abstract class AbstractHolderTest {
   /**
    * This test shows that the heavy field is not instantiated until the method getHeavy is called
    */
-  @Test(timeout = 3000)
+  @Test
   public void testGetHeavy() throws Exception {
-    assertNull(getInternalHeavyValue());
-    assertNotNull(getHeavy());
-    assertNotNull(getInternalHeavyValue());
-    assertSame(getHeavy(), getInternalHeavyValue());
+    assertTimeout(ofMillis(3000), () -> {
+      assertNull(getInternalHeavyValue());
+      assertNotNull(getHeavy());
+      assertNotNull(getInternalHeavyValue());
+      assertSame(getHeavy(), getInternalHeavyValue());
+    });
   }
 
 }

--- a/lazy-loading/src/test/java/com/iluwatar/lazy/loading/AppTest.java
+++ b/lazy-loading/src/test/java/com/iluwatar/lazy/loading/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.lazy.loading;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * 

--- a/marker/pom.xml
+++ b/marker/pom.xml
@@ -31,8 +31,19 @@
   <artifactId>marker</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+      <version>1.3</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/marker/src/test/java/AppTest.java
+++ b/marker/src/test/java/AppTest.java
@@ -20,7 +20,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 /**
  * Application test

--- a/marker/src/test/java/GuardTest.java
+++ b/marker/src/test/java/GuardTest.java
@@ -20,10 +20,11 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Guard test

--- a/marker/src/test/java/ThiefTest.java
+++ b/marker/src/test/java/ThiefTest.java
@@ -20,9 +20,10 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-import org.junit.Test;
 
-import static org.junit.Assert.assertFalse;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * Thief test

--- a/mediator/pom.xml
+++ b/mediator/pom.xml
@@ -34,8 +34,18 @@
   <artifactId>mediator</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/mediator/src/test/java/com/iluwatar/mediator/AppTest.java
+++ b/mediator/src/test/java/com/iluwatar/mediator/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.mediator;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * 

--- a/mediator/src/test/java/com/iluwatar/mediator/PartyImplTest.java
+++ b/mediator/src/test/java/com/iluwatar/mediator/PartyImplTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.mediator;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;

--- a/mediator/src/test/java/com/iluwatar/mediator/PartyMemberTest.java
+++ b/mediator/src/test/java/com/iluwatar/mediator/PartyMemberTest.java
@@ -25,11 +25,10 @@ package com.iluwatar.mediator;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.AppenderBase;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
@@ -38,7 +37,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Supplier;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -47,11 +46,9 @@ import static org.mockito.Mockito.verify;
  *
  * @author Jeroen Meulemeester
  */
-@RunWith(Parameterized.class)
 public class PartyMemberTest {
 
-  @Parameterized.Parameters
-  public static Collection<Supplier<PartyMember>[]> data() {
+  static Collection<Supplier<PartyMember>[]> dataProvider() {
     return Arrays.asList(
             new Supplier[]{Hobbit::new},
             new Supplier[]{Hunter::new},
@@ -60,28 +57,14 @@ public class PartyMemberTest {
     );
   }
 
-  /**
-   * The factory, used to create a new instance of the tested party member
-   */
-  private final Supplier<PartyMember> memberSupplier;
-
-  /**
-   * Create a new test instance, using the given {@link PartyMember} factory
-   *
-   * @param memberSupplier The party member factory
-   */
-  public PartyMemberTest(final Supplier<PartyMember> memberSupplier) {
-    this.memberSupplier = memberSupplier;
-  }
-
   private InMemoryAppender appender;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     appender = new InMemoryAppender(PartyMemberBase.class);
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     appender.stop();
   }
@@ -89,9 +72,10 @@ public class PartyMemberTest {
   /**
    * Verify if a party action triggers the correct output to the std-Out
    */
-  @Test
-  public void testPartyAction() {
-    final PartyMember member = this.memberSupplier.get();
+  @ParameterizedTest
+  @MethodSource("dataProvider")
+  public void testPartyAction(Supplier<PartyMember> memberSupplier) {
+    final PartyMember member = memberSupplier.get();
 
     for (final Action action : Action.values()) {
       member.partyAction(action);
@@ -104,9 +88,10 @@ public class PartyMemberTest {
   /**
    * Verify if a member action triggers the expected interactions with the party class
    */
-  @Test
-  public void testAct() {
-    final PartyMember member = this.memberSupplier.get();
+  @ParameterizedTest
+  @MethodSource("dataProvider")
+  public void testAct(Supplier<PartyMember> memberSupplier) {
+    final PartyMember member = memberSupplier.get();
 
     member.act(Action.GOLD);
     assertEquals(0, appender.getLogSize());
@@ -127,9 +112,10 @@ public class PartyMemberTest {
   /**
    * Verify if {@link PartyMember#toString()} generate the expected output
    */
-  @Test
-  public void testToString() throws Exception {
-    final PartyMember member = this.memberSupplier.get();
+  @ParameterizedTest
+  @MethodSource("dataProvider")
+  public void testToString(Supplier<PartyMember> memberSupplier) throws Exception {
+    final PartyMember member = memberSupplier.get();
     final Class<? extends PartyMember> memberClass = member.getClass();
     assertEquals(memberClass.getSimpleName(), member.toString());
   }

--- a/memento/pom.xml
+++ b/memento/pom.xml
@@ -34,8 +34,13 @@
   <artifactId>memento</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/memento/src/test/java/com/iluwatar/memento/AppTest.java
+++ b/memento/src/test/java/com/iluwatar/memento/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.memento;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * 

--- a/memento/src/test/java/com/iluwatar/memento/StarTest.java
+++ b/memento/src/test/java/com/iluwatar/memento/StarTest.java
@@ -22,9 +22,9 @@
  */
 package com.iluwatar.memento;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Date: 12/20/15 - 10:08 AM

--- a/message-channel/pom.xml
+++ b/message-channel/pom.xml
@@ -43,8 +43,13 @@
 			<artifactId>camel-stream</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/message-channel/src/test/java/com/iluwatar/message/channel/AppTest.java
+++ b/message-channel/src/test/java/com/iluwatar/message/channel/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.message.channel;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * 

--- a/model-view-controller/pom.xml
+++ b/model-view-controller/pom.xml
@@ -34,8 +34,13 @@
   <artifactId>model-view-controller</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/model-view-controller/src/test/java/com/iluwatar/model/view/controller/AppTest.java
+++ b/model-view-controller/src/test/java/com/iluwatar/model/view/controller/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.model.view.controller;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * 

--- a/model-view-controller/src/test/java/com/iluwatar/model/view/controller/GiantControllerTest.java
+++ b/model-view-controller/src/test/java/com/iluwatar/model/view/controller/GiantControllerTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.model.view.controller;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;

--- a/model-view-controller/src/test/java/com/iluwatar/model/view/controller/GiantModelTest.java
+++ b/model-view-controller/src/test/java/com/iluwatar/model/view/controller/GiantModelTest.java
@@ -22,9 +22,9 @@
  */
 package com.iluwatar.model.view.controller;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Date: 12/20/15 - 2:10 PM

--- a/model-view-controller/src/test/java/com/iluwatar/model/view/controller/GiantViewTest.java
+++ b/model-view-controller/src/test/java/com/iluwatar/model/view/controller/GiantViewTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.model.view.controller;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 
 import ch.qos.logback.classic.Logger;
@@ -30,9 +30,10 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.AppenderBase;
 import java.util.LinkedList;
 import java.util.List;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 
 /**
@@ -44,12 +45,12 @@ public class GiantViewTest {
 
   private InMemoryAppender appender;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     appender = new InMemoryAppender(GiantView.class);
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     appender.stop();
   }

--- a/model-view-presenter/pom.xml
+++ b/model-view-presenter/pom.xml
@@ -36,8 +36,13 @@
   <url>http://maven.apache.org</url>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/model-view-presenter/src/test/java/com/iluwatar/model/view/presenter/AppTest.java
+++ b/model-view-presenter/src/test/java/com/iluwatar/model/view/presenter/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.model.view.presenter;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * 

--- a/model-view-presenter/src/test/java/com/iluwatar/model/view/presenter/FileLoaderTest.java
+++ b/model-view-presenter/src/test/java/com/iluwatar/model/view/presenter/FileLoaderTest.java
@@ -22,9 +22,9 @@
  */
 package com.iluwatar.model.view.presenter;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Date: 12/21/15 - 12:12 PM

--- a/model-view-presenter/src/test/java/com/iluwatar/model/view/presenter/FileSelectorPresenterTest.java
+++ b/model-view-presenter/src/test/java/com/iluwatar/model/view/presenter/FileSelectorPresenterTest.java
@@ -22,13 +22,13 @@
  */
 package com.iluwatar.model.view.presenter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Before;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * This test case is responsible for testing our application by taking advantage of the
@@ -54,7 +54,7 @@ public class FileSelectorPresenterTest {
   /**
    * Initializes the components of the test case.
    */
-  @Before
+  @BeforeEach
   public void setUp() {
     this.stub = new FileSelectorStub();
     this.loader = new FileLoader();

--- a/module/pom.xml
+++ b/module/pom.xml
@@ -33,8 +33,13 @@
 	<artifactId>module</artifactId>
 	<dependencies>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/module/src/test/java/com/iluwatar/module/AppTest.java
+++ b/module/src/test/java/com/iluwatar/module/AppTest.java
@@ -18,11 +18,9 @@
  */
 package com.iluwatar.module;
 
+import org.junit.jupiter.api.Test;
+
 import java.io.FileNotFoundException;
-
-import com.iluwatar.module.App;
-
-import org.junit.Test;
 
 /**
  * Tests that Module example runs without errors.

--- a/module/src/test/java/com/iluwatar/module/FileLoggerModuleTest.java
+++ b/module/src/test/java/com/iluwatar/module/FileLoggerModuleTest.java
@@ -18,15 +18,15 @@
  */
 package com.iluwatar.module;
 
-import static org.junit.Assert.assertEquals;
+import org.apache.log4j.Logger;
+import org.junit.jupiter.api.Test;
 
 import java.io.BufferedReader;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
 
-import org.apache.log4j.Logger;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * The Module pattern can be considered a Creational pattern and a Structural pattern. It manages

--- a/monad/pom.xml
+++ b/monad/pom.xml
@@ -34,8 +34,13 @@
     <artifactId>monad</artifactId>
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/monad/src/test/java/com/iluwatar/monad/AppTest.java
+++ b/monad/src/test/java/com/iluwatar/monad/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.monad;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Application Test

--- a/monad/src/test/java/com/iluwatar/monad/MonadTest.java
+++ b/monad/src/test/java/com/iluwatar/monad/MonadTest.java
@@ -22,36 +22,34 @@
  */
 package com.iluwatar.monad;
 
-
-import junit.framework.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import java.util.Objects;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Test for Monad Pattern
  */
 public class MonadTest {
 
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
-
   @Test
   public void testForInvalidName() {
-    thrown.expect(IllegalStateException.class);
     User tom = new User(null, 21, Sex.MALE, "tom@foo.bar");
-    Validator.of(tom).validate(User::getName, Objects::nonNull, "name cannot be null").get();
+    assertThrows(IllegalStateException.class, () -> {
+      Validator.of(tom).validate(User::getName, Objects::nonNull, "name cannot be null").get();
+    });
   }
 
   @Test
   public void testForInvalidAge() {
-    thrown.expect(IllegalStateException.class);
     User john = new User("John", 17, Sex.MALE, "john@qwe.bar");
-    Validator.of(john).validate(User::getName, Objects::nonNull, "name cannot be null")
-        .validate(User::getAge, age -> age > 21, "user is underaged")
-        .get();
+    assertThrows(IllegalStateException.class, () -> {
+      Validator.of(john).validate(User::getName, Objects::nonNull, "name cannot be null")
+              .validate(User::getAge, age -> age > 21, "user is underaged")
+              .get();
+    });
   }
 
   @Test
@@ -62,6 +60,6 @@ public class MonadTest {
         .validate(User::getSex, sex -> sex == Sex.FEMALE, "user is not female")
         .validate(User::getEmail, email -> email.contains("@"), "email does not contain @ sign")
         .get();
-    Assert.assertSame(validated, sarah);
+    assertSame(validated, sarah);
   }
 }

--- a/monostate/pom.xml
+++ b/monostate/pom.xml
@@ -34,8 +34,13 @@
   <artifactId>monostate</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/monostate/src/test/java/com/iluwatar/monostate/AppTest.java
+++ b/monostate/src/test/java/com/iluwatar/monostate/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.monostate;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Application Test Entry

--- a/monostate/src/test/java/com/iluwatar/monostate/LoadBalancerTest.java
+++ b/monostate/src/test/java/com/iluwatar/monostate/LoadBalancerTest.java
@@ -22,11 +22,17 @@
  */
 package com.iluwatar.monostate;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
 
 /**
  * Date: 12/21/15 - 12:26 PM
@@ -41,9 +47,9 @@ public class LoadBalancerTest {
     final LoadBalancer secondBalancer = new LoadBalancer();
     firstBalancer.addServer(new Server("localhost", 8085, 6));
     // Both should have the same number of servers.
-    Assert.assertTrue(firstBalancer.getNoOfServers() == secondBalancer.getNoOfServers());
+    assertTrue(firstBalancer.getNoOfServers() == secondBalancer.getNoOfServers());
     // Both Should have the same LastServedId
-    Assert.assertTrue(firstBalancer.getLastServedId() == secondBalancer.getLastServedId());
+    assertTrue(firstBalancer.getLastServedId() == secondBalancer.getLastServedId());
   }
 
   @Test

--- a/multiton/pom.xml
+++ b/multiton/pom.xml
@@ -34,8 +34,13 @@
   <artifactId>multiton</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/multiton/src/test/java/com/iluwatar/multiton/AppTest.java
+++ b/multiton/src/test/java/com/iluwatar/multiton/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.multiton;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * 

--- a/multiton/src/test/java/com/iluwatar/multiton/NazgulTest.java
+++ b/multiton/src/test/java/com/iluwatar/multiton/NazgulTest.java
@@ -22,11 +22,11 @@
  */
 package com.iluwatar.multiton;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * Date: 12/22/15 - 22:28 AM

--- a/mute-idiom/pom.xml
+++ b/mute-idiom/pom.xml
@@ -26,8 +26,13 @@
 	<artifactId>mute-idiom</artifactId>
 	<dependencies>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/mute-idiom/src/test/java/com/iluwatar/mute/AppTest.java
+++ b/mute-idiom/src/test/java/com/iluwatar/mute/AppTest.java
@@ -23,7 +23,7 @@
 
 package com.iluwatar.mute;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests that Mute idiom example runs without errors.

--- a/mute-idiom/src/test/java/com/iluwatar/mute/MuteTest.java
+++ b/mute-idiom/src/test/java/com/iluwatar/mute/MuteTest.java
@@ -23,17 +23,16 @@
 
 package com.iluwatar.mute;
 
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test for the mute-idiom pattern
@@ -44,8 +43,6 @@ public class MuteTest {
 
   private static final String MESSAGE = "should not occur";
 
-  @Rule public ExpectedException exception = ExpectedException.none();
-
   @Test
   public void muteShouldRunTheCheckedRunnableAndNotThrowAnyExceptionIfCheckedRunnableDoesNotThrowAnyException() {
     Mute.mute(() -> methodNotThrowingAnyException());
@@ -53,10 +50,9 @@ public class MuteTest {
 
   @Test
   public void muteShouldRethrowUnexpectedExceptionAsAssertionError() throws Exception {
-    exception.expect(AssertionError.class);
-    exception.expectMessage(MESSAGE);
-
-    Mute.mute(() -> methodThrowingException());
+    assertThrows(AssertionError.class, () -> {
+      Mute.mute(() -> methodThrowingException());
+    });
   }
 
   @Test

--- a/mutex/pom.xml
+++ b/mutex/pom.xml
@@ -34,9 +34,14 @@
   <artifactId>mutex</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
-    </dependency> 
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/mutex/src/test/java/com/iluwatar/mutex/AppTest.java
+++ b/mutex/src/test/java/com/iluwatar/mutex/AppTest.java
@@ -22,7 +22,8 @@
  */
 package com.iluwatar.mutex;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
 import java.io.IOException;
 
 /**

--- a/mutex/src/test/java/com/iluwatar/mutex/JarTest.java
+++ b/mutex/src/test/java/com/iluwatar/mutex/JarTest.java
@@ -22,8 +22,10 @@
  */
 package com.iluwatar.mutex;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test case for taking beans from a Jar

--- a/mutex/src/test/java/com/iluwatar/mutex/MutexTest.java
+++ b/mutex/src/test/java/com/iluwatar/mutex/MutexTest.java
@@ -22,8 +22,11 @@
  */
 package com.iluwatar.mutex;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test case for acquiring and releasing a Mutex

--- a/naked-objects/dom/pom.xml
+++ b/naked-objects/dom/pom.xml
@@ -50,6 +50,12 @@
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
+
 		<!-- Bytecode libraries (for mocking) -->
 		<dependency>
 			<groupId>org.objenesis</groupId>

--- a/naked-objects/integtests/pom.xml
+++ b/naked-objects/integtests/pom.xml
@@ -80,6 +80,12 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>org.hsqldb</groupId>
 			<artifactId>hsqldb</artifactId>
 		</dependency>

--- a/naked-objects/webapp/pom.xml
+++ b/naked-objects/webapp/pom.xml
@@ -221,6 +221,18 @@
 			</exclusions>
 		</dependency>
 
+
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<profiles>

--- a/null-object/pom.xml
+++ b/null-object/pom.xml
@@ -34,13 +34,13 @@
   <artifactId>null-object</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/null-object/src/test/java/com/iluwatar/nullobject/AppTest.java
+++ b/null-object/src/test/java/com/iluwatar/nullobject/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.nullobject;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * 

--- a/null-object/src/test/java/com/iluwatar/nullobject/NullNodeTest.java
+++ b/null-object/src/test/java/com/iluwatar/nullobject/NullNodeTest.java
@@ -22,9 +22,12 @@
  */
 package com.iluwatar.nullobject;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * Date: 12/26/15 - 11:47 PM

--- a/null-object/src/test/java/com/iluwatar/nullobject/TreeTest.java
+++ b/null-object/src/test/java/com/iluwatar/nullobject/TreeTest.java
@@ -25,15 +25,18 @@ package com.iluwatar.nullobject;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.AppenderBase;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 
 import java.util.LinkedList;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Date: 12/26/15 - 11:44 PM
@@ -44,12 +47,12 @@ public class TreeTest {
 
   private InMemoryAppender appender;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     appender = new InMemoryAppender();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     appender.stop();
   }

--- a/object-mother/pom.xml
+++ b/object-mother/pom.xml
@@ -35,8 +35,13 @@
     <artifactId>object-mother</artifactId>
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/object-mother/src/test/java/com/iluwatar/objectmother/test/RoyaltyObjectMotherTest.java
+++ b/object-mother/src/test/java/com/iluwatar/objectmother/test/RoyaltyObjectMotherTest.java
@@ -22,16 +22,15 @@
  */
 package com.iluwatar.objectmother.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
-import org.junit.Test;
-
 import com.iluwatar.objectmother.King;
 import com.iluwatar.objectmother.Queen;
 import com.iluwatar.objectmother.Royalty;
 import com.iluwatar.objectmother.RoyaltyObjectMother;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test Generation of Royalty Types using the object-mother

--- a/object-pool/pom.xml
+++ b/object-pool/pom.xml
@@ -34,8 +34,13 @@
   <artifactId>object-pool</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/object-pool/src/test/java/com/iluwatar/object/pool/AppTest.java
+++ b/object-pool/src/test/java/com/iluwatar/object/pool/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.object.pool;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * 

--- a/object-pool/src/test/java/com/iluwatar/object/pool/OliphauntPoolTest.java
+++ b/object-pool/src/test/java/com/iluwatar/object/pool/OliphauntPoolTest.java
@@ -22,15 +22,17 @@
  */
 package com.iluwatar.object.pool;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static java.time.Duration.ofMillis;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTimeout;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Date: 12/27/15 - 1:05 AM
@@ -43,78 +45,80 @@ public class OliphauntPoolTest {
    * Use the same object 100 times subsequently. This should not take much time since the heavy
    * object instantiation is done only once. Verify if we get the same object each time.
    */
-  @Test(timeout = 5000)
+  @Test
   public void testSubsequentCheckinCheckout() {
-    final OliphauntPool pool = new OliphauntPool();
-    assertEquals(pool.toString(), "Pool available=0 inUse=0");
+    assertTimeout(ofMillis(5000), () -> {
+      final OliphauntPool pool = new OliphauntPool();
+      assertEquals(pool.toString(), "Pool available=0 inUse=0");
 
-    final Oliphaunt expectedOliphaunt = pool.checkOut();
-    assertEquals(pool.toString(), "Pool available=0 inUse=1");
-
-    pool.checkIn(expectedOliphaunt);
-    assertEquals(pool.toString(), "Pool available=1 inUse=0");
-
-    for (int i = 0; i < 100; i++) {
-      final Oliphaunt oliphaunt = pool.checkOut();
+      final Oliphaunt expectedOliphaunt = pool.checkOut();
       assertEquals(pool.toString(), "Pool available=0 inUse=1");
-      assertSame(expectedOliphaunt, oliphaunt);
-      assertEquals(expectedOliphaunt.getId(), oliphaunt.getId());
-      assertEquals(expectedOliphaunt.toString(), oliphaunt.toString());
 
-      pool.checkIn(oliphaunt);
+      pool.checkIn(expectedOliphaunt);
       assertEquals(pool.toString(), "Pool available=1 inUse=0");
-    }
 
+      for (int i = 0; i < 100; i++) {
+        final Oliphaunt oliphaunt = pool.checkOut();
+        assertEquals(pool.toString(), "Pool available=0 inUse=1");
+        assertSame(expectedOliphaunt, oliphaunt);
+        assertEquals(expectedOliphaunt.getId(), oliphaunt.getId());
+        assertEquals(expectedOliphaunt.toString(), oliphaunt.toString());
+
+        pool.checkIn(oliphaunt);
+        assertEquals(pool.toString(), "Pool available=1 inUse=0");
+      }
+    });
   }
 
   /**
    * Use the same object 100 times subsequently. This should not take much time since the heavy
    * object instantiation is done only once. Verify if we get the same object each time.
    */
-  @Test(timeout = 5000)
+  @Test
   public void testConcurrentCheckinCheckout() {
-    final OliphauntPool pool = new OliphauntPool();
-    assertEquals(pool.toString(), "Pool available=0 inUse=0");
+    assertTimeout(ofMillis(5000), () -> {
+      final OliphauntPool pool = new OliphauntPool();
+      assertEquals(pool.toString(), "Pool available=0 inUse=0");
 
-    final Oliphaunt firstOliphaunt = pool.checkOut();
-    assertEquals(pool.toString(), "Pool available=0 inUse=1");
+      final Oliphaunt firstOliphaunt = pool.checkOut();
+      assertEquals(pool.toString(), "Pool available=0 inUse=1");
 
-    final Oliphaunt secondOliphaunt = pool.checkOut();
-    assertEquals(pool.toString(), "Pool available=0 inUse=2");
+      final Oliphaunt secondOliphaunt = pool.checkOut();
+      assertEquals(pool.toString(), "Pool available=0 inUse=2");
 
-    assertNotSame(firstOliphaunt, secondOliphaunt);
-    assertEquals(firstOliphaunt.getId() + 1, secondOliphaunt.getId());
+      assertNotSame(firstOliphaunt, secondOliphaunt);
+      assertEquals(firstOliphaunt.getId() + 1, secondOliphaunt.getId());
 
-    // After checking in the second, we should get the same when checking out a new oliphaunt ...
-    pool.checkIn(secondOliphaunt);
-    assertEquals(pool.toString(), "Pool available=1 inUse=1");
+      // After checking in the second, we should get the same when checking out a new oliphaunt ...
+      pool.checkIn(secondOliphaunt);
+      assertEquals(pool.toString(), "Pool available=1 inUse=1");
 
-    final Oliphaunt oliphaunt3 = pool.checkOut();
-    assertEquals(pool.toString(), "Pool available=0 inUse=2");
-    assertSame(secondOliphaunt, oliphaunt3);
+      final Oliphaunt oliphaunt3 = pool.checkOut();
+      assertEquals(pool.toString(), "Pool available=0 inUse=2");
+      assertSame(secondOliphaunt, oliphaunt3);
 
-    // ... and the same applies for the first one
-    pool.checkIn(firstOliphaunt);
-    assertEquals(pool.toString(), "Pool available=1 inUse=1");
+      // ... and the same applies for the first one
+      pool.checkIn(firstOliphaunt);
+      assertEquals(pool.toString(), "Pool available=1 inUse=1");
 
-    final Oliphaunt oliphaunt4 = pool.checkOut();
-    assertEquals(pool.toString(), "Pool available=0 inUse=2");
-    assertSame(firstOliphaunt, oliphaunt4);
+      final Oliphaunt oliphaunt4 = pool.checkOut();
+      assertEquals(pool.toString(), "Pool available=0 inUse=2");
+      assertSame(firstOliphaunt, oliphaunt4);
 
-    // When both oliphaunt return to the pool, we should still get the same instances
-    pool.checkIn(firstOliphaunt);
-    assertEquals(pool.toString(), "Pool available=1 inUse=1");
+      // When both oliphaunt return to the pool, we should still get the same instances
+      pool.checkIn(firstOliphaunt);
+      assertEquals(pool.toString(), "Pool available=1 inUse=1");
 
-    pool.checkIn(secondOliphaunt);
-    assertEquals(pool.toString(), "Pool available=2 inUse=0");
+      pool.checkIn(secondOliphaunt);
+      assertEquals(pool.toString(), "Pool available=2 inUse=0");
 
-    // The order of the returned instances is not determined, so just put them in a list
-    // and verify if both expected instances are in there.
-    final List<Oliphaunt> oliphaunts = Arrays.asList(pool.checkOut(), pool.checkOut());
-    assertEquals(pool.toString(), "Pool available=0 inUse=2");
-    assertTrue(oliphaunts.contains(firstOliphaunt));
-    assertTrue(oliphaunts.contains(secondOliphaunt));
-
+      // The order of the returned instances is not determined, so just put them in a list
+      // and verify if both expected instances are in there.
+      final List<Oliphaunt> oliphaunts = Arrays.asList(pool.checkOut(), pool.checkOut());
+      assertEquals(pool.toString(), "Pool available=0 inUse=2");
+      assertTrue(oliphaunts.contains(firstOliphaunt));
+      assertTrue(oliphaunts.contains(secondOliphaunt));
+    });
   }
 
 

--- a/observer/pom.xml
+++ b/observer/pom.xml
@@ -34,8 +34,18 @@
   <artifactId>observer</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/observer/src/test/java/com/iluwatar/observer/AppTest.java
+++ b/observer/src/test/java/com/iluwatar/observer/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.observer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * 

--- a/observer/src/test/java/com/iluwatar/observer/HobbitsTest.java
+++ b/observer/src/test/java/com/iluwatar/observer/HobbitsTest.java
@@ -22,9 +22,6 @@
  */
 package com.iluwatar.observer;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -34,11 +31,9 @@ import java.util.List;
  *
  * @author Jeroen Meulemeester
  */
-@RunWith(Parameterized.class)
 public class HobbitsTest extends WeatherObserverTest<Hobbits> {
 
-  @Parameterized.Parameters
-  public static Collection<Object[]> data() {
+  static Collection<Object[]> dataProvider() {
     final List<Object[]> testData = new ArrayList<>();
     testData.add(new Object[]{WeatherType.SUNNY, "The happy hobbits bade in the warm sun."});
     testData.add(new Object[]{WeatherType.RAINY, "The hobbits look for cover from the rain."});
@@ -49,12 +44,9 @@ public class HobbitsTest extends WeatherObserverTest<Hobbits> {
 
   /**
    * Create a new test with the given weather and expected response
-   *
-   * @param weather  The weather that should be unleashed on the observer
-   * @param response The expected response from the observer
    */
-  public HobbitsTest(final WeatherType weather, final String response) {
-    super(weather, response, Hobbits::new);
+  public HobbitsTest() {
+    super(Hobbits::new);
   }
 
 }

--- a/observer/src/test/java/com/iluwatar/observer/OrcsTest.java
+++ b/observer/src/test/java/com/iluwatar/observer/OrcsTest.java
@@ -22,9 +22,6 @@
  */
 package com.iluwatar.observer;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -34,11 +31,9 @@ import java.util.List;
  *
  * @author Jeroen Meulemeester
  */
-@RunWith(Parameterized.class)
 public class OrcsTest extends WeatherObserverTest<Orcs> {
 
-  @Parameterized.Parameters
-  public static Collection<Object[]> data() {
+  static Collection<Object[]> dataProvider() {
     final List<Object[]> testData = new ArrayList<>();
     testData.add(new Object[]{WeatherType.SUNNY, "The sun hurts the orcs' eyes."});
     testData.add(new Object[]{WeatherType.RAINY, "The orcs are dripping wet."});
@@ -49,12 +44,9 @@ public class OrcsTest extends WeatherObserverTest<Orcs> {
 
   /**
    * Create a new test with the given weather and expected response
-   *
-   * @param weather  The weather that should be unleashed on the observer
-   * @param response The expected response from the observer
    */
-  public OrcsTest(final WeatherType weather, final String response) {
-    super(weather, response, Orcs::new);
+  public OrcsTest() {
+    super(Orcs::new);
   }
 
 }

--- a/observer/src/test/java/com/iluwatar/observer/WeatherObserverTest.java
+++ b/observer/src/test/java/com/iluwatar/observer/WeatherObserverTest.java
@@ -22,13 +22,16 @@
  */
 package com.iluwatar.observer;
 
-import static org.junit.Assert.assertEquals;
-
 import com.iluwatar.observer.utils.InMemoryAppender;
 import java.util.function.Supplier;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Date: 12/27/15 - 11:44 AM
@@ -40,12 +43,12 @@ public abstract class WeatherObserverTest<O extends WeatherObserver> {
 
   private InMemoryAppender appender;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     appender = new InMemoryAppender();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     appender.stop();
   }
@@ -56,37 +59,24 @@ public abstract class WeatherObserverTest<O extends WeatherObserver> {
   private final Supplier<O> factory;
 
   /**
-   * The weather type currently tested
-   */
-  private final WeatherType weather;
-
-  /**
-   * The expected response from the observer
-   */
-  private final String response;
-
-  /**
    * Create a new test instance using the given parameters
    *
-   * @param weather  The weather currently being tested
-   * @param response The expected response from the observer
    * @param factory  The factory, used to create an instance of the tested observer
    */
-  WeatherObserverTest(final WeatherType weather, final String response, final Supplier<O> factory) {
-    this.weather = weather;
-    this.response = response;
+  WeatherObserverTest(final Supplier<O> factory) {
     this.factory = factory;
   }
 
   /**
    * Verify if the weather has the expected influence on the observer
    */
-  @Test
-  public void testObserver() {
+  @ParameterizedTest
+  @MethodSource("dataProvider")
+  public void testObserver(WeatherType weather, String response) {
     final O observer = this.factory.get();
     assertEquals(0, appender.getLogSize());
 
-    observer.update(this.weather);
+    observer.update(weather);
     assertEquals(response, appender.getLastMessage());
     assertEquals(1, appender.getLogSize());
   }

--- a/observer/src/test/java/com/iluwatar/observer/WeatherTest.java
+++ b/observer/src/test/java/com/iluwatar/observer/WeatherTest.java
@@ -23,12 +23,12 @@
 package com.iluwatar.observer;
 
 import com.iluwatar.observer.utils.InMemoryAppender;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -44,12 +44,12 @@ public class WeatherTest {
 
   private InMemoryAppender appender;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     appender = new InMemoryAppender(Weather.class);
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     appender.stop();
   }

--- a/observer/src/test/java/com/iluwatar/observer/generic/GHobbitsTest.java
+++ b/observer/src/test/java/com/iluwatar/observer/generic/GHobbitsTest.java
@@ -22,12 +22,7 @@
  */
 package com.iluwatar.observer.generic;
 
-import com.iluwatar.observer.Hobbits;
-import com.iluwatar.observer.WeatherObserverTest;
 import com.iluwatar.observer.WeatherType;
-
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -38,11 +33,9 @@ import java.util.List;
  *
  * @author Jeroen Meulemeester
  */
-@RunWith(Parameterized.class)
 public class GHobbitsTest extends ObserverTest<GHobbits> {
 
-  @Parameterized.Parameters
-  public static Collection<Object[]> data() {
+  static Collection<Object[]> dataProvider() {
     final List<Object[]> testData = new ArrayList<>();
     testData.add(new Object[]{WeatherType.SUNNY, "The happy hobbits bade in the warm sun."});
     testData.add(new Object[]{WeatherType.RAINY, "The hobbits look for cover from the rain."});
@@ -53,12 +46,9 @@ public class GHobbitsTest extends ObserverTest<GHobbits> {
 
   /**
    * Create a new test with the given weather and expected response
-   *
-   * @param weather  The weather that should be unleashed on the observer
-   * @param response The expected response from the observer
    */
-  public GHobbitsTest(final WeatherType weather, final String response) {
-    super(weather, response, GHobbits::new);
+  public GHobbitsTest() {
+    super(GHobbits::new);
   }
 
 }

--- a/observer/src/test/java/com/iluwatar/observer/generic/GWeatherTest.java
+++ b/observer/src/test/java/com/iluwatar/observer/generic/GWeatherTest.java
@@ -25,12 +25,12 @@ package com.iluwatar.observer.generic;
 import com.iluwatar.observer.WeatherObserver;
 import com.iluwatar.observer.WeatherType;
 import com.iluwatar.observer.utils.InMemoryAppender;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 
 /**
@@ -42,12 +42,12 @@ public class GWeatherTest {
 
   private InMemoryAppender appender;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     appender = new InMemoryAppender(GWeather.class);
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     appender.stop();
   }

--- a/observer/src/test/java/com/iluwatar/observer/generic/ObserverTest.java
+++ b/observer/src/test/java/com/iluwatar/observer/generic/ObserverTest.java
@@ -22,14 +22,16 @@
  */
 package com.iluwatar.observer.generic;
 
-import static org.junit.Assert.assertEquals;
-
 import com.iluwatar.observer.WeatherType;
 import com.iluwatar.observer.utils.InMemoryAppender;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
 import java.util.function.Supplier;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Date: 12/27/15 - 11:44 AM
@@ -41,12 +43,12 @@ public abstract class ObserverTest<O extends Observer> {
 
   private InMemoryAppender appender;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     appender = new InMemoryAppender();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     appender.stop();
   }
@@ -57,38 +59,25 @@ public abstract class ObserverTest<O extends Observer> {
   private final Supplier<O> factory;
 
   /**
-   * The weather type currently tested
-   */
-  private final WeatherType weather;
-
-  /**
-   * The expected response from the observer
-   */
-  private final String response;
-
-  /**
    * Create a new test instance using the given parameters
    *
-   * @param weather  The weather currently being tested
-   * @param response The expected response from the observer
    * @param factory  The factory, used to create an instance of the tested observer
    */
-  ObserverTest(final WeatherType weather, final String response, final Supplier<O> factory) {
-    this.weather = weather;
-    this.response = response;
+  ObserverTest(final Supplier<O> factory) {
     this.factory = factory;
   }
 
   /**
    * Verify if the weather has the expected influence on the observer
    */
-  @Test
-  public void testObserver() {
+  @ParameterizedTest
+  @MethodSource("dataProvider")
+  public void testObserver(WeatherType weather, String response) {
     final O observer = this.factory.get();
     assertEquals(0, appender.getLogSize());
 
-    observer.update(null, this.weather);
-    assertEquals(this.response, appender.getLastMessage());
+    observer.update(null, weather);
+    assertEquals(response, appender.getLastMessage());
     assertEquals(1, appender.getLogSize());
   }
 

--- a/observer/src/test/java/com/iluwatar/observer/generic/OrcsTest.java
+++ b/observer/src/test/java/com/iluwatar/observer/generic/OrcsTest.java
@@ -24,9 +24,6 @@ package com.iluwatar.observer.generic;
 
 import com.iluwatar.observer.WeatherType;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -36,11 +33,9 @@ import java.util.List;
  *
  * @author Jeroen Meulemeester
  */
-@RunWith(Parameterized.class)
 public class OrcsTest extends ObserverTest<GOrcs> {
 
-  @Parameterized.Parameters
-  public static Collection<Object[]> data() {
+  static Collection<Object[]> dataProvider() {
     final List<Object[]> testData = new ArrayList<>();
     testData.add(new Object[]{WeatherType.SUNNY, "The sun hurts the orcs' eyes."});
     testData.add(new Object[]{WeatherType.RAINY, "The orcs are dripping wet."});
@@ -51,12 +46,9 @@ public class OrcsTest extends ObserverTest<GOrcs> {
 
   /**
    * Create a new test with the given weather and expected response
-   *
-   * @param weather  The weather that should be unleashed on the observer
-   * @param response The expected response from the observer
    */
-  public OrcsTest(final WeatherType weather, final String response) {
-    super(weather, response, GOrcs::new);
+  public OrcsTest() {
+    super(GOrcs::new);
   }
 
 }

--- a/page-object/pom.xml
+++ b/page-object/pom.xml
@@ -34,8 +34,13 @@
     <artifactId>page-object</artifactId>
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/page-object/src/test/java/com/iluwatar/pageobject/AlbumListPageTest.java
+++ b/page-object/src/test/java/com/iluwatar/pageobject/AlbumListPageTest.java
@@ -22,14 +22,13 @@
  */
 package com.iluwatar.pageobject;
 
-
-import static org.junit.Assert.assertTrue;
-
 import com.gargoylesoftware.htmlunit.WebClient;
 import com.iluwatar.pageobject.pages.AlbumListPage;
 import com.iluwatar.pageobject.pages.AlbumPage;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test Album Selection and Album Listing
@@ -38,7 +37,7 @@ public class AlbumListPageTest {
 
   private AlbumListPage albumListPage = new AlbumListPage(new WebClient());
 
-  @Before
+  @BeforeEach
   public void setUp() {
     albumListPage.navigateToPage();
   }

--- a/page-object/src/test/java/com/iluwatar/pageobject/AlbumPageTest.java
+++ b/page-object/src/test/java/com/iluwatar/pageobject/AlbumPageTest.java
@@ -22,13 +22,13 @@
  */
 package com.iluwatar.pageobject;
 
-import static org.junit.Assert.assertTrue;
-
 import com.gargoylesoftware.htmlunit.WebClient;
 import com.iluwatar.pageobject.pages.AlbumListPage;
 import com.iluwatar.pageobject.pages.AlbumPage;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test Album Page Operations
@@ -37,7 +37,7 @@ public class AlbumPageTest {
 
   private AlbumPage albumPage = new AlbumPage(new WebClient());
 
-  @Before
+  @BeforeEach
   public void setUp() {
     albumPage.navigateToPage();
   }

--- a/page-object/src/test/java/com/iluwatar/pageobject/LoginPageTest.java
+++ b/page-object/src/test/java/com/iluwatar/pageobject/LoginPageTest.java
@@ -22,13 +22,13 @@
  */
 package com.iluwatar.pageobject;
 
-import static org.junit.Assert.assertTrue;
-
 import com.gargoylesoftware.htmlunit.WebClient;
 import com.iluwatar.pageobject.pages.AlbumListPage;
 import com.iluwatar.pageobject.pages.LoginPage;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test Login Page Object
@@ -37,7 +37,7 @@ public class LoginPageTest {
 
   private LoginPage loginPage = new LoginPage(new WebClient());
 
-  @Before
+  @BeforeEach
   public void setUp() {
     loginPage.navigateToPage();
   }

--- a/partial-response/pom.xml
+++ b/partial-response/pom.xml
@@ -40,6 +40,11 @@
             <artifactId>junit</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
         </dependency>

--- a/poison-pill/pom.xml
+++ b/poison-pill/pom.xml
@@ -34,8 +34,13 @@
   <artifactId>poison-pill</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/poison-pill/src/test/java/com/iluwatar/poison/pill/AppTest.java
+++ b/poison-pill/src/test/java/com/iluwatar/poison/pill/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.poison.pill;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * 

--- a/poison-pill/src/test/java/com/iluwatar/poison/pill/ConsumerTest.java
+++ b/poison-pill/src/test/java/com/iluwatar/poison/pill/ConsumerTest.java
@@ -25,16 +25,16 @@ package com.iluwatar.poison.pill;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.AppenderBase;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 
 import java.time.LocalDateTime;
 import java.util.LinkedList;
 import java.util.List;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Date: 12/27/15 - 9:45 PM
@@ -45,12 +45,12 @@ public class ConsumerTest {
 
   private InMemoryAppender appender;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     appender = new InMemoryAppender(Consumer.class);
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     appender.stop();
   }

--- a/poison-pill/src/test/java/com/iluwatar/poison/pill/PoisonMessageTest.java
+++ b/poison-pill/src/test/java/com/iluwatar/poison/pill/PoisonMessageTest.java
@@ -22,10 +22,11 @@
  */
 package com.iluwatar.poison.pill;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.iluwatar.poison.pill.Message.Headers;
 import static com.iluwatar.poison.pill.Message.POISON_PILL;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Date: 12/27/15 - 10:30 PM
@@ -34,29 +35,39 @@ import static com.iluwatar.poison.pill.Message.POISON_PILL;
  */
 public class PoisonMessageTest {
 
-  @Test(expected = UnsupportedOperationException.class)
+  @Test
   public void testAddHeader() throws Exception {
-    POISON_PILL.addHeader(Headers.SENDER, "sender");
+    assertThrows(UnsupportedOperationException.class, () -> {
+      POISON_PILL.addHeader(Headers.SENDER, "sender");
+    });
   }
 
-  @Test(expected = UnsupportedOperationException.class)
+  @Test
   public void testGetHeader() throws Exception {
-    POISON_PILL.getHeader(Headers.SENDER);
+    assertThrows(UnsupportedOperationException.class, () -> {
+      POISON_PILL.getHeader(Headers.SENDER);
+    });
   }
 
-  @Test(expected = UnsupportedOperationException.class)
+  @Test
   public void testGetHeaders() throws Exception {
-    POISON_PILL.getHeaders();
+    assertThrows(UnsupportedOperationException.class, () -> {
+      POISON_PILL.getHeaders();
+    });
   }
 
-  @Test(expected = UnsupportedOperationException.class)
+  @Test
   public void testSetBody() throws Exception {
-    POISON_PILL.setBody("Test message.");
+    assertThrows(UnsupportedOperationException.class, () -> {
+      POISON_PILL.setBody("Test message.");
+    });
   }
 
-  @Test(expected = UnsupportedOperationException.class)
+  @Test
   public void testGetBody() throws Exception {
-    POISON_PILL.getBody();
+    assertThrows(UnsupportedOperationException.class, () -> {
+      POISON_PILL.getBody();
+    });
   }
 
 }

--- a/poison-pill/src/test/java/com/iluwatar/poison/pill/ProducerTest.java
+++ b/poison-pill/src/test/java/com/iluwatar/poison/pill/ProducerTest.java
@@ -22,12 +22,12 @@
  */
 package com.iluwatar.poison.pill;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;

--- a/poison-pill/src/test/java/com/iluwatar/poison/pill/SimpleMessageTest.java
+++ b/poison-pill/src/test/java/com/iluwatar/poison/pill/SimpleMessageTest.java
@@ -22,14 +22,15 @@
  */
 package com.iluwatar.poison.pill;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Date: 12/27/15 - 10:25 PM
@@ -51,11 +52,13 @@ public class SimpleMessageTest {
     assertEquals(senderName, message.getHeaders().get(Message.Headers.SENDER));
   }
 
-  @Test(expected = UnsupportedOperationException.class)
+  @Test
   public void testUnModifiableHeaders() {
     final SimpleMessage message = new SimpleMessage();
     final Map<Message.Headers, String> headers = message.getHeaders();
-    headers.put(Message.Headers.SENDER, "test");
+    assertThrows(UnsupportedOperationException.class, () -> {
+      headers.put(Message.Headers.SENDER, "test");
+    });
   }
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,14 +32,16 @@
         <spring-data.version>1.9.2.RELEASE</spring-data.version>
         <h2.version>1.4.190</h2.version>
         <junit.version>4.12</junit.version>
+        <junit-jupiter.version>5.0.2</junit-jupiter.version>
+        <junit-vintage.version>${junit.version}.2</junit-vintage.version>
+        <junit-platform.version>1.0.2</junit-platform.version>
+        <sping-test-junit5.version>1.0.2</sping-test-junit5.version>
         <compiler.version>3.0</compiler.version>
         <jacoco.version>0.7.2.201409121644</jacoco.version>
         <commons-dbcp.version>1.4</commons-dbcp.version>
         <camel.version>2.16.1</camel.version>
         <guava.version>19.0</guava.version>
-        <systemrules.version>1.15.1</systemrules.version>
         <mockito.version>1.10.19</mockito.version>
-        <hierarchical-junit-runner-version>4.12.1</hierarchical-junit-runner-version>
         <apache-httpcomponents.version>4.5.2</apache-httpcomponents.version>
         <htmlunit.version>2.22</htmlunit.version>
         <guice.version>4.0</guice.version>
@@ -154,6 +156,13 @@
         <module>retry</module>
     </modules>
 
+    <repositories>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
+    </repositories>
+
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -165,11 +174,6 @@
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-entitymanager</artifactId>
                 <version>${hibernate.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework</groupId>
-                <artifactId>spring-test</artifactId>
-                <version>${spring.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
@@ -219,9 +223,45 @@
                 <version>${camel.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-api</artifactId>
+                <version>${junit-jupiter.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>${junit.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
+                <version>${junit-jupiter.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-params</artifactId>
+                <version>${junit-jupiter.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-migrationsupport</artifactId>
+                <version>${junit-jupiter.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.vintage</groupId>
+                <artifactId>junit-vintage-engine</artifactId>
+                <version>${junit-vintage.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.github.sbrannen</groupId>
+                <artifactId>spring-test-junit5</artifactId>
+                <version>${sping-test-junit5.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -234,18 +274,6 @@
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>${guava.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.github.stefanbirkner</groupId>
-                <artifactId>system-rules</artifactId>
-                <version>${systemrules.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>de.bechte.junit</groupId>
-                <artifactId>junit-hierarchicalcontextrunner</artifactId>
-                <version>${hierarchical-junit-runner-version}</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>net.sourceforge.htmlunit</groupId>
@@ -374,12 +402,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.18.1</version>
+                <version>2.19.1</version>
                 <dependencies>
                     <dependency>
-                        <groupId>org.apache.maven.surefire</groupId>
-                        <artifactId>surefire-junit47</artifactId>
-                        <version>2.18.1</version>
+                        <groupId>org.junit.platform</groupId>
+                        <artifactId>junit-platform-surefire-provider</artifactId>
+                        <version>${junit-platform.version}</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/private-class-data/pom.xml
+++ b/private-class-data/pom.xml
@@ -34,8 +34,13 @@
   <artifactId>private-class-data</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/private-class-data/src/test/java/com/iluwatar/privateclassdata/AppTest.java
+++ b/private-class-data/src/test/java/com/iluwatar/privateclassdata/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.privateclassdata;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * 

--- a/private-class-data/src/test/java/com/iluwatar/privateclassdata/ImmutableStewTest.java
+++ b/private-class-data/src/test/java/com/iluwatar/privateclassdata/ImmutableStewTest.java
@@ -23,11 +23,11 @@
 package com.iluwatar.privateclassdata;
 
 import com.iluwatar.privateclassdata.utils.InMemoryAppender;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Date: 12/27/15 - 10:46 PM
@@ -38,12 +38,12 @@ public class ImmutableStewTest {
 
   private InMemoryAppender appender;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     appender = new InMemoryAppender();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     appender.stop();
   }

--- a/private-class-data/src/test/java/com/iluwatar/privateclassdata/StewTest.java
+++ b/private-class-data/src/test/java/com/iluwatar/privateclassdata/StewTest.java
@@ -23,11 +23,11 @@
 package com.iluwatar.privateclassdata;
 
 import com.iluwatar.privateclassdata.utils.InMemoryAppender;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Date: 12/27/15 - 10:46 PM
@@ -38,12 +38,12 @@ public class StewTest {
 
   private InMemoryAppender appender;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     appender = new InMemoryAppender();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     appender.stop();
   }

--- a/producer-consumer/pom.xml
+++ b/producer-consumer/pom.xml
@@ -34,8 +34,13 @@
   <artifactId>producer-consumer</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/producer-consumer/src/test/java/com/iluwatar/producer/consumer/AppTest.java
+++ b/producer-consumer/src/test/java/com/iluwatar/producer/consumer/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.producer.consumer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * 

--- a/producer-consumer/src/test/java/com/iluwatar/producer/consumer/ConsumerTest.java
+++ b/producer-consumer/src/test/java/com/iluwatar/producer/consumer/ConsumerTest.java
@@ -22,9 +22,12 @@
  */
 package com.iluwatar.producer.consumer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 /**
  * Date: 12/27/15 - 11:01 PM

--- a/producer-consumer/src/test/java/com/iluwatar/producer/consumer/ProducerTest.java
+++ b/producer-consumer/src/test/java/com/iluwatar/producer/consumer/ProducerTest.java
@@ -22,8 +22,10 @@
  */
 package com.iluwatar.producer.consumer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
+import static java.time.Duration.ofMillis;
+import static org.junit.jupiter.api.Assertions.assertTimeout;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -36,15 +38,17 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
  */
 public class ProducerTest {
 
-  @Test(timeout = 6000)
+  @Test
   public void testProduce() throws Exception {
-    final ItemQueue queue = mock(ItemQueue.class);
-    final Producer producer = new Producer("producer", queue);
+    assertTimeout(ofMillis(6000), () -> {
+      final ItemQueue queue = mock(ItemQueue.class);
+      final Producer producer = new Producer("producer", queue);
 
-    producer.produce();
-    verify(queue).put(any(Item.class));
+      producer.produce();
+      verify(queue).put(any(Item.class));
 
-    verifyNoMoreInteractions(queue);
+      verifyNoMoreInteractions(queue);
+    });
   }
 
 }

--- a/promise/pom.xml
+++ b/promise/pom.xml
@@ -34,8 +34,13 @@
   <artifactId>promise</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/promise/src/test/java/com/iluwatar/promise/AppTest.java
+++ b/promise/src/test/java/com/iluwatar/promise/AppTest.java
@@ -22,9 +22,9 @@
  */
 package com.iluwatar.promise;
 
-import java.util.concurrent.ExecutionException;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Test;
+import java.util.concurrent.ExecutionException;
 
 /**
  * 

--- a/promise/src/test/java/com/iluwatar/promise/PromiseTest.java
+++ b/promise/src/test/java/com/iluwatar/promise/PromiseTest.java
@@ -22,13 +22,8 @@
  */
 package com.iluwatar.promise;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -39,10 +34,14 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
 /**
  * Tests Promise class.
  */
@@ -50,9 +49,8 @@ public class PromiseTest {
 
   private Executor executor;
   private Promise<Integer> promise;
-  @Rule public ExpectedException exception = ExpectedException.none();
 
-  @Before
+  @BeforeEach
   public void setUp() {
     executor = Executors.newSingleThreadExecutor();
     promise = new Promise<>();

--- a/property/pom.xml
+++ b/property/pom.xml
@@ -34,8 +34,13 @@
   <artifactId>property</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/property/src/test/java/com/iluwatar/property/AppTest.java
+++ b/property/src/test/java/com/iluwatar/property/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.property;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * 

--- a/property/src/test/java/com/iluwatar/property/CharacterTest.java
+++ b/property/src/test/java/com/iluwatar/property/CharacterTest.java
@@ -22,13 +22,13 @@
  */
 package com.iluwatar.property;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.iluwatar.property.Character.Type;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Date: 12/28/15 - 7:46 PM

--- a/prototype/pom.xml
+++ b/prototype/pom.xml
@@ -34,8 +34,18 @@
   <artifactId>prototype</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/prototype/src/test/java/com/iluwatar/prototype/AppTest.java
+++ b/prototype/src/test/java/com/iluwatar/prototype/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.prototype;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * 

--- a/prototype/src/test/java/com/iluwatar/prototype/HeroFactoryImplTest.java
+++ b/prototype/src/test/java/com/iluwatar/prototype/HeroFactoryImplTest.java
@@ -22,9 +22,9 @@
  */
 package com.iluwatar.prototype;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;

--- a/prototype/src/test/java/com/iluwatar/prototype/PrototypeTest.java
+++ b/prototype/src/test/java/com/iluwatar/prototype/PrototypeTest.java
@@ -22,27 +22,24 @@
  */
 package com.iluwatar.prototype;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Arrays;
 import java.util.Collection;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * Date: 12/28/15 - 8:45 PM
  * @param <P> Prototype
  * @author Jeroen Meulemeester
  */
-@RunWith(Parameterized.class)
 public class PrototypeTest<P extends Prototype> {
-
-  @Parameterized.Parameters
-  public static Collection<Object[]> data() {
+  static Collection<Object[]> dataProvider() {
     return Arrays.asList(
             new Object[]{new OrcBeast(), "Orcish wolf"},
             new Object[]{new OrcMage(), "Orcish mage"},
@@ -53,35 +50,15 @@ public class PrototypeTest<P extends Prototype> {
     );
   }
 
-  /**
-   * The tested prototype instance
-   */
-  private final P testedPrototype;
+  @ParameterizedTest
+  @MethodSource("dataProvider")
+  public void testPrototype(P testedPrototype, String expectedToString) throws Exception {
+    assertEquals(expectedToString, testedPrototype.toString());
 
-  /**
-   * The expected {@link Prototype#toString()} value
-   */
-  private final String expectedToString;
-
-  /**
-   * Create a new test instance, using the given test object and expected value
-   *
-   * @param testedPrototype  The tested prototype instance
-   * @param expectedToString The expected {@link Prototype#toString()} value
-   */
-  public PrototypeTest(final P testedPrototype, final String expectedToString) {
-    this.expectedToString = expectedToString;
-    this.testedPrototype = testedPrototype;
-  }
-
-  @Test
-  public void testPrototype() throws Exception {
-    assertEquals(this.expectedToString, this.testedPrototype.toString());
-
-    final Object clone = this.testedPrototype.clone();
+    final Object clone = testedPrototype.clone();
     assertNotNull(clone);
-    assertNotSame(clone, this.testedPrototype);
-    assertSame(this.testedPrototype.getClass(), clone.getClass());
+    assertNotSame(clone, testedPrototype);
+    assertSame(testedPrototype.getClass(), clone.getClass());
   }
 
 }

--- a/proxy/pom.xml
+++ b/proxy/pom.xml
@@ -34,8 +34,13 @@
   <artifactId>proxy</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/proxy/src/test/java/com/iluwatar/proxy/AppTest.java
+++ b/proxy/src/test/java/com/iluwatar/proxy/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.proxy;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * 

--- a/proxy/src/test/java/com/iluwatar/proxy/IvoryTowerTest.java
+++ b/proxy/src/test/java/com/iluwatar/proxy/IvoryTowerTest.java
@@ -23,14 +23,12 @@
 package com.iluwatar.proxy;
 
 import com.iluwatar.proxy.utils.InMemoryAppender;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for {@link IvoryTower}
@@ -39,12 +37,12 @@ public class IvoryTowerTest {
 
   private InMemoryAppender appender;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     appender = new InMemoryAppender(IvoryTower.class);
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     appender.stop();
   }

--- a/proxy/src/test/java/com/iluwatar/proxy/WizardTest.java
+++ b/proxy/src/test/java/com/iluwatar/proxy/WizardTest.java
@@ -22,9 +22,9 @@
  */
 package com.iluwatar.proxy;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests for {@link Wizard}

--- a/proxy/src/test/java/com/iluwatar/proxy/WizardTowerProxyTest.java
+++ b/proxy/src/test/java/com/iluwatar/proxy/WizardTowerProxyTest.java
@@ -23,12 +23,12 @@
 package com.iluwatar.proxy;
 
 import com.iluwatar.proxy.utils.InMemoryAppender;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for {@link WizardTowerProxy}
@@ -37,12 +37,12 @@ public class WizardTowerProxyTest {
 
   private InMemoryAppender appender;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     appender = new InMemoryAppender();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     appender.stop();
   }

--- a/publish-subscribe/pom.xml
+++ b/publish-subscribe/pom.xml
@@ -41,8 +41,14 @@
 			<artifactId>camel-stream</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 </project>

--- a/publish-subscribe/src/test/java/com/iluwatar/publish/subscribe/AppTest.java
+++ b/publish-subscribe/src/test/java/com/iluwatar/publish/subscribe/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.publish.subscribe;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * 

--- a/queue-load-leveling/pom.xml
+++ b/queue-load-leveling/pom.xml
@@ -34,8 +34,13 @@
   <artifactId>queue-load-leveling</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/queue-load-leveling/src/test/java/com/iluwatar/queue/load/leveling/AppTest.java
+++ b/queue-load-leveling/src/test/java/com/iluwatar/queue/load/leveling/AppTest.java
@@ -22,9 +22,9 @@
  */
 package com.iluwatar.queue.load.leveling;
 
-import java.io.IOException;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Test;
+import java.io.IOException;
 
 /**
  * Application Test

--- a/queue-load-leveling/src/test/java/com/iluwatar/queue/load/leveling/MessageQueueTest.java
+++ b/queue-load-leveling/src/test/java/com/iluwatar/queue/load/leveling/MessageQueueTest.java
@@ -22,9 +22,9 @@
  */
 package com.iluwatar.queue.load.leveling;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * 

--- a/queue-load-leveling/src/test/java/com/iluwatar/queue/load/leveling/MessageTest.java
+++ b/queue-load-leveling/src/test/java/com/iluwatar/queue/load/leveling/MessageTest.java
@@ -22,8 +22,9 @@
  */
 package com.iluwatar.queue.load.leveling;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * 

--- a/queue-load-leveling/src/test/java/com/iluwatar/queue/load/leveling/TaskGenSrvExeTest.java
+++ b/queue-load-leveling/src/test/java/com/iluwatar/queue/load/leveling/TaskGenSrvExeTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.queue.load.leveling;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * 

--- a/reactor/pom.xml
+++ b/reactor/pom.xml
@@ -34,8 +34,13 @@
   <artifactId>reactor</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/reactor/src/test/java/com/iluwatar/reactor/app/ReactorTest.java
+++ b/reactor/src/test/java/com/iluwatar/reactor/app/ReactorTest.java
@@ -22,15 +22,13 @@
  */
 package com.iluwatar.reactor.app;
 
-import java.io.IOException;
-
-import com.iluwatar.reactor.framework.NioReactor;
-import org.junit.Test;
-
 import com.iluwatar.reactor.framework.SameThreadDispatcher;
 import com.iluwatar.reactor.framework.ThreadPoolDispatcher;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
 
 /**
  * 

--- a/reader-writer-lock/pom.xml
+++ b/reader-writer-lock/pom.xml
@@ -35,8 +35,13 @@
     <artifactId>reader-writer-lock</artifactId>
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/reader-writer-lock/src/test/java/com/iluwatar/reader/writer/lock/AppTest.java
+++ b/reader-writer-lock/src/test/java/com/iluwatar/reader/writer/lock/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.reader.writer.lock;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Application test

--- a/reader-writer-lock/src/test/java/com/iluwatar/reader/writer/lock/ReaderAndWriterTest.java
+++ b/reader-writer-lock/src/test/java/com/iluwatar/reader/writer/lock/ReaderAndWriterTest.java
@@ -24,9 +24,9 @@
 package com.iluwatar.reader.writer.lock;
 
 import com.iluwatar.reader.writer.lock.utils.InMemoryAppender;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,7 +34,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author hongshuwei@gmail.com
@@ -43,12 +43,12 @@ public class ReaderAndWriterTest {
 
   private InMemoryAppender appender;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     appender = new InMemoryAppender();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     appender.stop();
   }

--- a/reader-writer-lock/src/test/java/com/iluwatar/reader/writer/lock/ReaderTest.java
+++ b/reader-writer-lock/src/test/java/com/iluwatar/reader/writer/lock/ReaderTest.java
@@ -23,9 +23,9 @@
 package com.iluwatar.reader.writer.lock;
 
 import com.iluwatar.reader.writer.lock.utils.InMemoryAppender;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,7 +33,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.spy;
 
 /**
@@ -43,12 +43,12 @@ public class ReaderTest {
 
   private InMemoryAppender appender;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     appender = new InMemoryAppender(Reader.class);
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     appender.stop();
   }

--- a/reader-writer-lock/src/test/java/com/iluwatar/reader/writer/lock/WriterTest.java
+++ b/reader-writer-lock/src/test/java/com/iluwatar/reader/writer/lock/WriterTest.java
@@ -23,9 +23,9 @@
 package com.iluwatar.reader.writer.lock;
 
 import com.iluwatar.reader.writer.lock.utils.InMemoryAppender;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,7 +33,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.spy;
 
 /**
@@ -43,12 +43,12 @@ public class WriterTest {
 
   private InMemoryAppender appender;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     appender = new InMemoryAppender(Writer.class);
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     appender.stop();
   }

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -34,8 +34,9 @@
     <artifactId>repository</artifactId>
     <dependencies>
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-test</artifactId>
+            <groupId>com.github.sbrannen</groupId>
+            <artifactId>spring-test-junit5</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.data</groupId>
@@ -54,8 +55,13 @@
             <artifactId>h2</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/repository/src/test/java/com/iluwatar/repository/AnnotationBasedRepositoryTest.java
+++ b/repository/src/test/java/com/iluwatar/repository/AnnotationBasedRepositoryTest.java
@@ -22,21 +22,21 @@
  */
 package com.iluwatar.repository;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.List;
 
 import javax.annotation.Resource;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
 
 import com.google.common.collect.Lists;
@@ -46,7 +46,7 @@ import com.google.common.collect.Lists;
  * by {@link org.springframework.data.jpa.domain.Specification} are also test.
  * 
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = { AppConfig.class }, loader = AnnotationConfigContextLoader.class)
 public class AnnotationBasedRepositoryTest {
 
@@ -63,7 +63,7 @@ public class AnnotationBasedRepositoryTest {
   /**
    * Prepare data for test
    */
-  @Before
+  @BeforeEach
   public void setup() {
 
     repository.save(persons);
@@ -123,7 +123,7 @@ public class AnnotationBasedRepositoryTest {
     assertEquals(terry, actual);
   }
 
-  @After
+  @AfterEach
   public void cleanup() {
 
     repository.deleteAll();

--- a/repository/src/test/java/com/iluwatar/repository/AppConfigTest.java
+++ b/repository/src/test/java/com/iluwatar/repository/AppConfigTest.java
@@ -22,19 +22,19 @@
  */
 package com.iluwatar.repository;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
 import javax.sql.DataSource;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -42,7 +42,7 @@ import org.springframework.transaction.annotation.Transactional;
  * This case is Just for test the Annotation Based configuration
  * 
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = { AppConfig.class }, loader = AnnotationConfigContextLoader.class)
 public class AppConfigTest {
 

--- a/repository/src/test/java/com/iluwatar/repository/AppTest.java
+++ b/repository/src/test/java/com/iluwatar/repository/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.repository;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 

--- a/repository/src/test/java/com/iluwatar/repository/RepositoryTest.java
+++ b/repository/src/test/java/com/iluwatar/repository/RepositoryTest.java
@@ -22,21 +22,21 @@
  */
 package com.iluwatar.repository;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.List;
 
 import javax.annotation.Resource;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import com.google.common.collect.Lists;
 
@@ -44,7 +44,7 @@ import com.google.common.collect.Lists;
  * Test case to test the functions of {@link PersonRepository}, beside the CRUD functions, the query
  * by {@link org.springframework.data.jpa.domain.Specification} are also test.
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(locations = { "classpath:applicationContext.xml" })
 public class RepositoryTest {
 
@@ -61,7 +61,7 @@ public class RepositoryTest {
   /**
    * Prepare data for test
    */
-  @Before
+  @BeforeEach
   public void setup() {
 
     repository.save(persons);
@@ -121,7 +121,7 @@ public class RepositoryTest {
     assertEquals(terry, actual);
   }
 
-  @After
+  @AfterEach
   public void cleanup() {
 
     repository.deleteAll();

--- a/resource-acquisition-is-initialization/pom.xml
+++ b/resource-acquisition-is-initialization/pom.xml
@@ -34,8 +34,13 @@
   <artifactId>resource-acquisition-is-initialization</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/resource-acquisition-is-initialization/src/test/java/com/iluwatar/resource/acquisition/is/initialization/AppTest.java
+++ b/resource-acquisition-is-initialization/src/test/java/com/iluwatar/resource/acquisition/is/initialization/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.resource.acquisition.is.initialization;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * 

--- a/resource-acquisition-is-initialization/src/test/java/com/iluwatar/resource/acquisition/is/initialization/ClosableTest.java
+++ b/resource-acquisition-is-initialization/src/test/java/com/iluwatar/resource/acquisition/is/initialization/ClosableTest.java
@@ -22,17 +22,18 @@
  */
 package com.iluwatar.resource.acquisition.is.initialization;
 
-import static org.junit.Assert.assertTrue;
-
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.AppenderBase;
 import java.util.LinkedList;
 import java.util.List;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Date: 12/28/15 - 9:31 PM
@@ -43,12 +44,12 @@ public class ClosableTest {
 
   private InMemoryAppender appender;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     appender = new InMemoryAppender();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     appender.stop();
   }

--- a/retry/pom.xml
+++ b/retry/pom.xml
@@ -32,8 +32,13 @@
     <packaging>jar</packaging>
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/retry/src/test/java/com/iluwatar/retry/FindCustomerTest.java
+++ b/retry/src/test/java/com/iluwatar/retry/FindCustomerTest.java
@@ -24,9 +24,11 @@
 
 package com.iluwatar.retry;
 
+import org.junit.jupiter.api.Test;
+
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
-import org.junit.Test;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Unit tests for {@link FindCustomer}.
@@ -50,9 +52,11 @@ public class FindCustomerTest {
    * 
    * @throws Exception the expected exception
    */
-  @Test(expected = BusinessException.class)
+  @Test
   public void oneException() throws Exception {
-    new FindCustomer("123", new BusinessException("test")).perform();
+    assertThrows(BusinessException.class, () -> {
+      new FindCustomer("123", new BusinessException("test")).perform();
+    });
   }
 
   /**

--- a/retry/src/test/java/com/iluwatar/retry/RetryTest.java
+++ b/retry/src/test/java/com/iluwatar/retry/RetryTest.java
@@ -24,10 +24,11 @@
 
 package com.iluwatar.retry;
 
+import org.junit.jupiter.api.Test;
+
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Unit tests for {@link Retry}.

--- a/semaphore/pom.xml
+++ b/semaphore/pom.xml
@@ -34,8 +34,13 @@
   <artifactId>semaphore</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/semaphore/src/test/java/com/iluwatar/semaphore/AppTest.java
+++ b/semaphore/src/test/java/com/iluwatar/semaphore/AppTest.java
@@ -22,7 +22,8 @@
  */
 package com.iluwatar.semaphore;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
 import java.io.IOException;
 
 /**

--- a/semaphore/src/test/java/com/iluwatar/semaphore/FruitBowlTest.java
+++ b/semaphore/src/test/java/com/iluwatar/semaphore/FruitBowlTest.java
@@ -22,8 +22,11 @@
  */
 package com.iluwatar.semaphore;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Test taking from and putting Fruit into a FruitBowl

--- a/semaphore/src/test/java/com/iluwatar/semaphore/SemaphoreTest.java
+++ b/semaphore/src/test/java/com/iluwatar/semaphore/SemaphoreTest.java
@@ -22,8 +22,10 @@
  */
 package com.iluwatar.semaphore;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test case for acquiring and releasing a Semaphore

--- a/servant/pom.xml
+++ b/servant/pom.xml
@@ -34,8 +34,13 @@
   <artifactId>servant</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/servant/src/test/java/com/iluwatar/servant/AppTest.java
+++ b/servant/src/test/java/com/iluwatar/servant/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.servant;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * 

--- a/servant/src/test/java/com/iluwatar/servant/KingTest.java
+++ b/servant/src/test/java/com/iluwatar/servant/KingTest.java
@@ -22,9 +22,10 @@
  */
 package com.iluwatar.servant;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Date: 12/28/15 - 9:40 PM

--- a/servant/src/test/java/com/iluwatar/servant/QueenTest.java
+++ b/servant/src/test/java/com/iluwatar/servant/QueenTest.java
@@ -22,9 +22,11 @@
  */
 package com.iluwatar.servant;
 
-import org.junit.Test;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Date: 12/28/15 - 9:52 PM

--- a/servant/src/test/java/com/iluwatar/servant/ServantTest.java
+++ b/servant/src/test/java/com/iluwatar/servant/ServantTest.java
@@ -22,12 +22,12 @@
  */
 package com.iluwatar.servant;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;

--- a/service-layer/pom.xml
+++ b/service-layer/pom.xml
@@ -40,11 +40,16 @@
 	<dependency>
 		<groupId>com.h2database</groupId>
 		<artifactId>h2</artifactId>
-	</dependency>  
+	</dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-api</artifactId>
+        <scope>test</scope>
+    </dependency>
+    <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-engine</artifactId>
+        <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/service-layer/src/test/java/com/iluwatar/servicelayer/app/AppTest.java
+++ b/service-layer/src/test/java/com/iluwatar/servicelayer/app/AppTest.java
@@ -23,9 +23,8 @@
 package com.iluwatar.servicelayer.app;
 
 import com.iluwatar.servicelayer.hibernate.HibernateUtil;
-
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * 
@@ -40,7 +39,7 @@ public class AppTest {
     App.main(args);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     HibernateUtil.dropSession();
   }

--- a/service-layer/src/test/java/com/iluwatar/servicelayer/common/BaseDaoTest.java
+++ b/service-layer/src/test/java/com/iluwatar/servicelayer/common/BaseDaoTest.java
@@ -22,17 +22,18 @@
  */
 package com.iluwatar.servicelayer.common;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-
 import com.iluwatar.servicelayer.hibernate.HibernateUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Date: 12/28/15 - 10:53 PM
@@ -74,7 +75,7 @@ public abstract class BaseDaoTest<E extends BaseEntity, D extends DaoBaseImpl<E>
     this.dao = dao;
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     for (int i = 0; i < INITIAL_COUNT; i++) {
       final String className = dao.persistentClass.getSimpleName();
@@ -83,7 +84,7 @@ public abstract class BaseDaoTest<E extends BaseEntity, D extends DaoBaseImpl<E>
     }
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     HibernateUtil.dropSession();
   }

--- a/service-layer/src/test/java/com/iluwatar/servicelayer/magic/MagicServiceImplTest.java
+++ b/service-layer/src/test/java/com/iluwatar/servicelayer/magic/MagicServiceImplTest.java
@@ -28,15 +28,14 @@ import com.iluwatar.servicelayer.spellbook.Spellbook;
 import com.iluwatar.servicelayer.spellbook.SpellbookDao;
 import com.iluwatar.servicelayer.wizard.Wizard;
 import com.iluwatar.servicelayer.wizard.WizardDao;
-
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;

--- a/service-layer/src/test/java/com/iluwatar/servicelayer/spell/SpellDaoImplTest.java
+++ b/service-layer/src/test/java/com/iluwatar/servicelayer/spell/SpellDaoImplTest.java
@@ -23,13 +23,12 @@
 package com.iluwatar.servicelayer.spell;
 
 import com.iluwatar.servicelayer.common.BaseDaoTest;
-
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Date: 12/28/15 - 11:02 PM

--- a/service-layer/src/test/java/com/iluwatar/servicelayer/spellbook/SpellbookDaoImplTest.java
+++ b/service-layer/src/test/java/com/iluwatar/servicelayer/spellbook/SpellbookDaoImplTest.java
@@ -23,13 +23,12 @@
 package com.iluwatar.servicelayer.spellbook;
 
 import com.iluwatar.servicelayer.common.BaseDaoTest;
-
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Date: 12/28/15 - 11:44 PM

--- a/service-layer/src/test/java/com/iluwatar/servicelayer/wizard/WizardDaoImplTest.java
+++ b/service-layer/src/test/java/com/iluwatar/servicelayer/wizard/WizardDaoImplTest.java
@@ -23,13 +23,12 @@
 package com.iluwatar.servicelayer.wizard;
 
 import com.iluwatar.servicelayer.common.BaseDaoTest;
-
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Date: 12/28/15 - 11:46 PM

--- a/service-locator/pom.xml
+++ b/service-locator/pom.xml
@@ -34,8 +34,13 @@
   <artifactId>service-locator</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/service-locator/src/test/java/com/iluwatar/servicelocator/AppTest.java
+++ b/service-locator/src/test/java/com/iluwatar/servicelocator/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.servicelocator;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * 

--- a/service-locator/src/test/java/com/iluwatar/servicelocator/ServiceLocatorTest.java
+++ b/service-locator/src/test/java/com/iluwatar/servicelocator/ServiceLocatorTest.java
@@ -22,13 +22,13 @@
  */
 package com.iluwatar.servicelocator;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Date: 12/29/15 - 19:07 PM

--- a/singleton/pom.xml
+++ b/singleton/pom.xml
@@ -34,8 +34,13 @@
   <artifactId>singleton</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/singleton/src/test/java/com/iluwatar/singleton/AppTest.java
+++ b/singleton/src/test/java/com/iluwatar/singleton/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.singleton;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * 

--- a/singleton/src/test/java/com/iluwatar/singleton/SingletonTest.java
+++ b/singleton/src/test/java/com/iluwatar/singleton/SingletonTest.java
@@ -22,8 +22,8 @@
  */
 package com.iluwatar.singleton;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,7 +32,11 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.function.Supplier;
-import org.junit.Test;
+
+import static java.time.Duration.ofMillis;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTimeout;
 
 /**
  * This class provides several test case that test singleton construction.
@@ -80,29 +84,30 @@ public abstract class SingletonTest<S> {
   /**
    * Test singleton instance in a concurrent setting
    */
-  @Test(timeout = 10000)
+  @Test
   public void testMultipleCallsReturnTheSameObjectInDifferentThreads() throws Exception {
+    assertTimeout(ofMillis(10000), () -> {
+      // Create 10000 tasks and inside each callable instantiate the singleton class
+      final List<Callable<S>> tasks = new ArrayList<>();
+      for (int i = 0; i < 10000; i++) {
+        tasks.add(this.singletonInstanceMethod::get);
+      }
 
-    // Create 10000 tasks and inside each callable instantiate the singleton class
-    final List<Callable<S>> tasks = new ArrayList<>();
-    for (int i = 0; i < 10000; i++) {
-      tasks.add(this.singletonInstanceMethod::get);
-    }
+      // Use up to 8 concurrent threads to handle the tasks
+      final ExecutorService executorService = Executors.newFixedThreadPool(8);
+      final List<Future<S>> results = executorService.invokeAll(tasks);
 
-    // Use up to 8 concurrent threads to handle the tasks
-    final ExecutorService executorService = Executors.newFixedThreadPool(8);
-    final List<Future<S>> results = executorService.invokeAll(tasks);
+      // wait for all of the threads to complete
+      final S expectedInstance = this.singletonInstanceMethod.get();
+      for (Future<S> res : results) {
+        final S instance = res.get();
+        assertNotNull(instance);
+        assertSame(expectedInstance, instance);
+      }
 
-    // wait for all of the threads to complete
-    final S expectedInstance = this.singletonInstanceMethod.get();
-    for (Future<S> res : results) {
-      final S instance = res.get();
-      assertNotNull(instance);
-      assertSame(expectedInstance, instance);
-    }
-
-    // tidy up the executor
-    executorService.shutdown();
+      // tidy up the executor
+      executorService.shutdown();
+    });
 
   }
 

--- a/specification/pom.xml
+++ b/specification/pom.xml
@@ -34,8 +34,18 @@
   <artifactId>specification</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/specification/src/test/java/com/iluwatar/specification/app/AppTest.java
+++ b/specification/src/test/java/com/iluwatar/specification/app/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.specification.app;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * 

--- a/specification/src/test/java/com/iluwatar/specification/creature/CreatureTest.java
+++ b/specification/src/test/java/com/iluwatar/specification/creature/CreatureTest.java
@@ -25,30 +25,26 @@ package com.iluwatar.specification.creature;
 import com.iluwatar.specification.property.Color;
 import com.iluwatar.specification.property.Movement;
 import com.iluwatar.specification.property.Size;
-
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Arrays;
 import java.util.Collection;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Date: 12/29/15 - 7:47 PM
  *
  * @author Jeroen Meulemeester
  */
-@RunWith(Parameterized.class)
 public class CreatureTest {
 
   /**
    * @return The tested {@link Creature} instance and its expected specs
    */
-  @Parameterized.Parameters
-  public static Collection<Object[]> data() {
+  public static Collection<Object[]> dataProvider() {
     return Arrays.asList(
             new Object[]{new Dragon(), "Dragon", Size.LARGE, Movement.FLYING, Color.RED},
             new Object[]{new Goblin(), "Goblin", Size.SMALL, Movement.WALKING, Color.GREEN},
@@ -59,71 +55,36 @@ public class CreatureTest {
     );
   }
 
-  /**
-   * The tested creature
-   */
-  private final Creature testedCreature;
-
-  /**
-   * The expected name of the tested creature
-   */
-  private final String name;
-
-  /**
-   * The expected size of the tested creature
-   */
-  private final Size size;
-
-  /**
-   * The expected movement type of the tested creature
-   */
-  private final Movement movement;
-
-  /**
-   * The expected color of the tested creature
-   */
-  private final Color color;
-
-  /**
-   * @param testedCreature The tested creature
-   * @param name           The expected name of the creature
-   * @param size           The expected size of the creature
-   * @param movement       The expected movement type of the creature
-   * @param color          The expected color of the creature
-   */
-  public CreatureTest(final Creature testedCreature, final String name, final Size size,
-                      final Movement movement, final Color color) {
-    this.testedCreature = testedCreature;
-    this.name = name;
-    this.size = size;
-    this.movement = movement;
-    this.color = color;
+  @ParameterizedTest
+  @MethodSource("dataProvider")
+  public void testGetName(Creature testedCreature, String name) throws Exception {
+    assertEquals(name, testedCreature.getName());
   }
 
-
-  @Test
-  public void testGetName() throws Exception {
-    assertEquals(this.name, this.testedCreature.getName());
+  @ParameterizedTest
+  @MethodSource("dataProvider")
+  public void testGetSize(Creature testedCreature, String name, Size size) throws Exception {
+    assertEquals(size, testedCreature.getSize());
   }
 
-  @Test
-  public void testGetSize() throws Exception {
-    assertEquals(this.size, this.testedCreature.getSize());
+  @ParameterizedTest
+  @MethodSource("dataProvider")
+  public void testGetMovement(Creature testedCreature, String name, Size size, Movement movement) throws Exception {
+    assertEquals(movement, testedCreature.getMovement());
   }
 
-  @Test
-  public void testGetMovement() throws Exception {
-    assertEquals(this.movement, this.testedCreature.getMovement());
+  @ParameterizedTest
+  @MethodSource("dataProvider")
+  public void testGetColor(Creature testedCreature, String name, Size size, Movement movement,
+                           Color color) throws Exception {
+    assertEquals(color, testedCreature.getColor());
   }
 
-  @Test
-  public void testGetColor() throws Exception {
-    assertEquals(this.color, this.testedCreature.getColor());
-  }
-
-  @Test
-  public void testToString() throws Exception {
-    final String toString = this.testedCreature.toString();
+  @ParameterizedTest
+  @MethodSource("dataProvider")
+  public void testToString(Creature testedCreature, String name, Size size, Movement movement,
+                           Color color) throws Exception {
+    final String toString = testedCreature.toString();
     assertNotNull(toString);
     assertEquals(
             String.format("%s [size=%s, movement=%s, color=%s]", name, size, movement, color),

--- a/specification/src/test/java/com/iluwatar/specification/selector/ColorSelectorTest.java
+++ b/specification/src/test/java/com/iluwatar/specification/selector/ColorSelectorTest.java
@@ -24,11 +24,10 @@ package com.iluwatar.specification.selector;
 
 import com.iluwatar.specification.creature.Creature;
 import com.iluwatar.specification.property.Color;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Test;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/specification/src/test/java/com/iluwatar/specification/selector/MovementSelectorTest.java
+++ b/specification/src/test/java/com/iluwatar/specification/selector/MovementSelectorTest.java
@@ -23,13 +23,11 @@
 package com.iluwatar.specification.selector;
 
 import com.iluwatar.specification.creature.Creature;
-import com.iluwatar.specification.property.Color;
 import com.iluwatar.specification.property.Movement;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Test;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/specification/src/test/java/com/iluwatar/specification/selector/SizeSelectorTest.java
+++ b/specification/src/test/java/com/iluwatar/specification/selector/SizeSelectorTest.java
@@ -24,11 +24,10 @@ package com.iluwatar.specification.selector;
 
 import com.iluwatar.specification.creature.Creature;
 import com.iluwatar.specification.property.Size;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Test;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/state/pom.xml
+++ b/state/pom.xml
@@ -34,13 +34,13 @@
   <artifactId>state</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/state/src/test/java/com/iluwatar/state/AppTest.java
+++ b/state/src/test/java/com/iluwatar/state/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.state;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  *

--- a/state/src/test/java/com/iluwatar/state/MammothTest.java
+++ b/state/src/test/java/com/iluwatar/state/MammothTest.java
@@ -25,16 +25,16 @@ package com.iluwatar.state;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.AppenderBase;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 
 import java.util.LinkedList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Date: 12/29/15 - 8:27 PM
@@ -45,12 +45,12 @@ public class MammothTest {
 
   private InMemoryAppender appender;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     appender = new InMemoryAppender();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     appender.stop();
   }

--- a/step-builder/pom.xml
+++ b/step-builder/pom.xml
@@ -35,8 +35,13 @@
   <artifactId>step-builder</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/step-builder/src/test/java/com/iluwatar/stepbuilder/AppTest.java
+++ b/step-builder/src/test/java/com/iluwatar/stepbuilder/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.stepbuilder;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * 

--- a/step-builder/src/test/java/com/iluwatar/stepbuilder/CharacterStepBuilderTest.java
+++ b/step-builder/src/test/java/com/iluwatar/stepbuilder/CharacterStepBuilderTest.java
@@ -22,14 +22,14 @@
  */
 package com.iluwatar.stepbuilder;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Date: 12/29/15 - 9:21 PM

--- a/strategy/pom.xml
+++ b/strategy/pom.xml
@@ -34,8 +34,18 @@
   <artifactId>strategy</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/strategy/src/test/java/com/iluwatar/strategy/AppTest.java
+++ b/strategy/src/test/java/com/iluwatar/strategy/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.strategy;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * 

--- a/strategy/src/test/java/com/iluwatar/strategy/DragonSlayerTest.java
+++ b/strategy/src/test/java/com/iluwatar/strategy/DragonSlayerTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.strategy;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;

--- a/strategy/src/test/java/com/iluwatar/strategy/DragonSlayingStrategyTest.java
+++ b/strategy/src/test/java/com/iluwatar/strategy/DragonSlayingStrategyTest.java
@@ -25,11 +25,10 @@ package com.iluwatar.strategy;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.AppenderBase;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
@@ -37,21 +36,19 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Date: 12/29/15 - 10:58 PM
  *
  * @author Jeroen Meulemeester
  */
-@RunWith(Parameterized.class)
 public class DragonSlayingStrategyTest {
 
   /**
    * @return The test parameters for each cycle
    */
-  @Parameterized.Parameters
-  public static Collection<Object[]> data() {
+  static Collection<Object[]> dataProvider() {
     return Arrays.asList(
         new Object[]{
             new MeleeStrategy(),
@@ -68,47 +65,27 @@ public class DragonSlayingStrategyTest {
     );
   }
 
-  /**
-   * The tested strategy
-   */
-  private final DragonSlayingStrategy strategy;
-
-  /**
-   * The expected action in the log
-   */
-  private final String expectedResult;
-
   private InMemoryAppender appender;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     appender = new InMemoryAppender();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     appender.stop();
   }
 
 
   /**
-   * Create a new test instance for the given strategy
-   *
-   * @param strategy       The tested strategy
-   * @param expectedResult The expected result
-   */
-  public DragonSlayingStrategyTest(final DragonSlayingStrategy strategy, final String expectedResult) {
-    this.strategy = strategy;
-    this.expectedResult = expectedResult;
-  }
-
-  /**
    * Test if executing the strategy gives the correct response
    */
-  @Test
-  public void testExecute() {
-    this.strategy.execute();
-    assertEquals(this.expectedResult, appender.getLastMessage());
+  @ParameterizedTest
+  @MethodSource("dataProvider")
+  public void testExecute(DragonSlayingStrategy strategy, String expectedResult) {
+    strategy.execute();
+    assertEquals(expectedResult, appender.getLastMessage());
     assertEquals(1, appender.getLogSize());
   }
 

--- a/template-method/pom.xml
+++ b/template-method/pom.xml
@@ -34,8 +34,13 @@
   <artifactId>template-method</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/template-method/src/test/java/com/iluwatar/templatemethod/AppTest.java
+++ b/template-method/src/test/java/com/iluwatar/templatemethod/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.templatemethod;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * 

--- a/template-method/src/test/java/com/iluwatar/templatemethod/HalflingThiefTest.java
+++ b/template-method/src/test/java/com/iluwatar/templatemethod/HalflingThiefTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.templatemethod;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;

--- a/template-method/src/test/java/com/iluwatar/templatemethod/StealingMethodTest.java
+++ b/template-method/src/test/java/com/iluwatar/templatemethod/StealingMethodTest.java
@@ -22,18 +22,18 @@
  */
 package com.iluwatar.templatemethod;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.AppenderBase;
 import java.util.LinkedList;
 import java.util.List;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Date: 12/30/15 - 18:12 PM
@@ -44,12 +44,12 @@ public abstract class StealingMethodTest<M extends StealingMethod> {
 
   private InMemoryAppender appender;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     appender = new InMemoryAppender();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     appender.stop();
   }

--- a/thread-pool/pom.xml
+++ b/thread-pool/pom.xml
@@ -34,8 +34,13 @@
   <artifactId>thread-pool</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/thread-pool/src/test/java/com/iluwatar/threadpool/AppTest.java
+++ b/thread-pool/src/test/java/com/iluwatar/threadpool/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.threadpool;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Application test

--- a/thread-pool/src/test/java/com/iluwatar/threadpool/TaskTest.java
+++ b/thread-pool/src/test/java/com/iluwatar/threadpool/TaskTest.java
@@ -22,8 +22,7 @@
  */
 package com.iluwatar.threadpool;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -33,11 +32,13 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.function.Function;
 import java.util.function.IntFunction;
-import java.util.function.ToIntFunction;
 import java.util.stream.Collectors;
-import org.junit.Test;
+
+import static java.time.Duration.ofMillis;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTimeout;
 
 /**
  * Date: 12/30/15 - 18:22 PM
@@ -82,30 +83,31 @@ public abstract class TaskTest<T extends Task> {
    * Verify if the generated id is unique for each task, even if the tasks are created in separate
    * threads
    */
-  @Test(timeout = 10000)
+  @Test
   public void testIdGeneration() throws Exception {
-    final ExecutorService service = Executors.newFixedThreadPool(THREAD_COUNT);
+    assertTimeout(ofMillis(10000), () -> {
+      final ExecutorService service = Executors.newFixedThreadPool(THREAD_COUNT);
 
-    final List<Callable<Integer>> tasks = new ArrayList<>();
-    for (int i = 0; i < TASK_COUNT; i++) {
-      tasks.add(() -> factory.apply(1).getId());
-    }
+      final List<Callable<Integer>> tasks = new ArrayList<>();
+      for (int i = 0; i < TASK_COUNT; i++) {
+        tasks.add(() -> factory.apply(1).getId());
+      }
 
-    final List<Integer> ids = service.invokeAll(tasks)
-        .stream()
-        .map(TaskTest::get)
-        .filter(Objects::nonNull)
-        .collect(Collectors.toList());
+      final List<Integer> ids = service.invokeAll(tasks)
+          .stream()
+          .map(TaskTest::get)
+          .filter(Objects::nonNull)
+          .collect(Collectors.toList());
 
-    service.shutdownNow();
+      service.shutdownNow();
 
-    final long uniqueIdCount = ids.stream()
-        .distinct()
-        .count();
+      final long uniqueIdCount = ids.stream()
+          .distinct()
+          .count();
 
-    assertEquals(TASK_COUNT, ids.size());
-    assertEquals(TASK_COUNT, uniqueIdCount);
-
+      assertEquals(TASK_COUNT, ids.size());
+      assertEquals(TASK_COUNT, uniqueIdCount);
+    });
   }
 
   /**

--- a/thread-pool/src/test/java/com/iluwatar/threadpool/WorkerTest.java
+++ b/thread-pool/src/test/java/com/iluwatar/threadpool/WorkerTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.threadpool;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;

--- a/throttling/pom.xml
+++ b/throttling/pom.xml
@@ -35,10 +35,16 @@
 
     <artifactId>throttling</artifactId>
 	<dependencies>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-		</dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
 	</dependencies>
 
 </project>

--- a/throttling/src/test/java/com/iluwatar/throttling/AppTest.java
+++ b/throttling/src/test/java/com/iluwatar/throttling/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.throttling;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Application test

--- a/throttling/src/test/java/com/iluwatar/throttling/B2BServiceTest.java
+++ b/throttling/src/test/java/com/iluwatar/throttling/B2BServiceTest.java
@@ -22,11 +22,11 @@
  */
 package com.iluwatar.throttling;
 
-import org.junit.Assert;
-import org.junit.Test;
-
 import com.iluwatar.throttling.timer.ThrottleTimerImpl;
 import com.iluwatar.throttling.timer.Throttler;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * B2BServiceTest class to test the B2BService
@@ -43,6 +43,6 @@ public class B2BServiceTest {
       service.dummyCustomerApi(tenant);
     }
     long counter = CallsCount.getCount(tenant.getName());
-    Assert.assertTrue("Counter limit must be reached", counter == 2);
+    assertTrue(counter == 2, "Counter limit must be reached");
   }
 }

--- a/throttling/src/test/java/com/iluwatar/throttling/TenantTest.java
+++ b/throttling/src/test/java/com/iluwatar/throttling/TenantTest.java
@@ -22,19 +22,21 @@
  */
 package com.iluwatar.throttling;
 
-import org.junit.Test;
-
-import com.iluwatar.throttling.Tenant;
+import org.junit.jupiter.api.Test;
 
 import java.security.InvalidParameterException;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * TenantTest to test the creation of Tenant with valid parameters.
  */
 public class TenantTest {
 
-  @Test(expected = InvalidParameterException.class)
+  @Test
   public void constructorTest() {
-    Tenant tenant = new Tenant("FailTenant", -1);
+    assertThrows(InvalidParameterException.class, () -> {
+      Tenant tenant = new Tenant("FailTenant", -1);
+    });
   }
 }

--- a/tls/pom.xml
+++ b/tls/pom.xml
@@ -35,8 +35,13 @@
   <artifactId>tls</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/tls/src/test/java/com/iluwatar/tls/AppTest.java
+++ b/tls/src/test/java/com/iluwatar/tls/AppTest.java
@@ -23,7 +23,7 @@
 
 package com.iluwatar.tls;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests that thread local storage example runs without errors.

--- a/tls/src/test/java/com/iluwatar/tls/DateFormatCallableTest.java
+++ b/tls/src/test/java/com/iluwatar/tls/DateFormatCallableTest.java
@@ -32,10 +32,11 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * 
@@ -86,7 +87,7 @@ public class DateFormatCallableTest {
   /**
    * Run Callable and prepare results for usage in the test methods
    */
-  @BeforeClass
+  @BeforeAll
   public static void setup() {
     // Create a callable
     DateFormatCallable callableDf = new DateFormatCallable("dd/MM/yyyy", "15/12/2015");

--- a/tls/src/test/java/com/iluwatar/tls/DateFormatCallableTestIncorrectDateFormat.java
+++ b/tls/src/test/java/com/iluwatar/tls/DateFormatCallableTestIncorrectDateFormat.java
@@ -30,10 +30,11 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * 
@@ -84,7 +85,7 @@ public class DateFormatCallableTestIncorrectDateFormat {
   /**
    * Run Callable and prepare results for usage in the test methods
    */
-  @BeforeClass
+  @BeforeAll
   public static void setup() {
     // Create a callable. Pass a string date value not matching the format string
     DateFormatCallable callableDf = new DateFormatCallable("dd/MM/yyyy", "15.12.2015");

--- a/tls/src/test/java/com/iluwatar/tls/DateFormatCallableTestMultiThread.java
+++ b/tls/src/test/java/com/iluwatar/tls/DateFormatCallableTestMultiThread.java
@@ -32,10 +32,11 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * 
@@ -90,7 +91,7 @@ public class DateFormatCallableTestMultiThread {
   /**
    * Run Callable and prepare results for usage in the test methods
    */
-  @BeforeClass
+  @BeforeAll
   public static void setup() {
     // Create a callable
     DateFormatCallable callableDf = new DateFormatCallable("dd/MM/yyyy", "15/12/2015");

--- a/tolerant-reader/pom.xml
+++ b/tolerant-reader/pom.xml
@@ -34,8 +34,18 @@
   <artifactId>tolerant-reader</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-migrationsupport</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/tolerant-reader/src/test/java/com/iluwatar/tolerantreader/AppTest.java
+++ b/tolerant-reader/src/test/java/com/iluwatar/tolerantreader/AppTest.java
@@ -22,9 +22,9 @@
  */
 package com.iluwatar.tolerantreader;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -42,8 +42,8 @@ public class AppTest {
     App.main(args);
   }
 
-  @Before
-  @After
+  @BeforeEach
+  @AfterEach
   public void cleanup() {
     File file1 = new File("fish1.out");
     file1.delete();

--- a/tolerant-reader/src/test/java/com/iluwatar/tolerantreader/RainbowFishSerializerTest.java
+++ b/tolerant-reader/src/test/java/com/iluwatar/tolerantreader/RainbowFishSerializerTest.java
@@ -23,19 +23,21 @@
 package com.iluwatar.tolerantreader;
 
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 /**
  * Date: 12/30/15 - 18:39 PM
  *
  * @author Jeroen Meulemeester
  */
+@EnableRuleMigrationSupport
 public class RainbowFishSerializerTest {
 
   /**

--- a/twin/pom.xml
+++ b/twin/pom.xml
@@ -34,8 +34,13 @@
   <artifactId>twin</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/twin/src/test/java/com/iluwatar/twin/AppTest.java
+++ b/twin/src/test/java/com/iluwatar/twin/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.twin;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * 

--- a/twin/src/test/java/com/iluwatar/twin/BallItemTest.java
+++ b/twin/src/test/java/com/iluwatar/twin/BallItemTest.java
@@ -22,8 +22,8 @@
  */
 package com.iluwatar.twin;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -33,9 +33,10 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.AppenderBase;
 import java.util.LinkedList;
 import java.util.List;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 import org.slf4j.LoggerFactory;
 
@@ -48,12 +49,12 @@ public class BallItemTest {
 
   private InMemoryAppender appender;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     appender = new InMemoryAppender();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     appender.stop();
   }

--- a/twin/src/test/java/com/iluwatar/twin/BallThreadTest.java
+++ b/twin/src/test/java/com/iluwatar/twin/BallThreadTest.java
@@ -22,10 +22,12 @@
  */
 package com.iluwatar.twin;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static java.lang.Thread.UncaughtExceptionHandler;
 import static java.lang.Thread.sleep;
+import static java.time.Duration.ofMillis;
+import static org.junit.jupiter.api.Assertions.assertTimeout;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -44,68 +46,74 @@ public class BallThreadTest {
   /**
    * Verify if the {@link BallThread} can be resumed
    */
-  @Test(timeout = 5000)
+  @Test
   public void testSuspend() throws Exception {
-    final BallThread ballThread = new BallThread();
+    assertTimeout(ofMillis(5000), () -> {
+      final BallThread ballThread = new BallThread();
 
-    final BallItem ballItem = mock(BallItem.class);
-    ballThread.setTwin(ballItem);
+      final BallItem ballItem = mock(BallItem.class);
+      ballThread.setTwin(ballItem);
 
-    ballThread.start();
+      ballThread.start();
 
-    verify(ballItem, timeout(2000).atLeastOnce()).draw();
-    verify(ballItem, timeout(2000).atLeastOnce()).move();
-    ballThread.suspendMe();
+      verify(ballItem, timeout(2000).atLeastOnce()).draw();
+      verify(ballItem, timeout(2000).atLeastOnce()).move();
+      ballThread.suspendMe();
 
-    sleep(1000);
+      sleep(1000);
 
-    ballThread.stopMe();
-    ballThread.join();
+      ballThread.stopMe();
+      ballThread.join();
 
-    verifyNoMoreInteractions(ballItem);
+      verifyNoMoreInteractions(ballItem);
+    });
   }
 
   /**
    * Verify if the {@link BallThread} can be resumed
    */
-  @Test(timeout = 5000)
+  @Test
   public void testResume() throws Exception {
-    final BallThread ballThread = new BallThread();
+    assertTimeout(ofMillis(5000), () -> {
+      final BallThread ballThread = new BallThread();
 
-    final BallItem ballItem = mock(BallItem.class);
-    ballThread.setTwin(ballItem);
+      final BallItem ballItem = mock(BallItem.class);
+      ballThread.setTwin(ballItem);
 
-    ballThread.suspendMe();
-    ballThread.start();
+      ballThread.suspendMe();
+      ballThread.start();
 
-    sleep(1000);
+      sleep(1000);
 
-    verifyZeroInteractions(ballItem);
+      verifyZeroInteractions(ballItem);
 
-    ballThread.resumeMe();
-    verify(ballItem, timeout(2000).atLeastOnce()).draw();
-    verify(ballItem, timeout(2000).atLeastOnce()).move();
+      ballThread.resumeMe();
+      verify(ballItem, timeout(2000).atLeastOnce()).draw();
+      verify(ballItem, timeout(2000).atLeastOnce()).move();
 
-    ballThread.stopMe();
-    ballThread.join();
+      ballThread.stopMe();
+      ballThread.join();
 
-    verifyNoMoreInteractions(ballItem);
+      verifyNoMoreInteractions(ballItem);
+    });
   }
 
   /**
    * Verify if the {@link BallThread} is interruptible
    */
-  @Test(timeout = 5000)
+  @Test
   public void testInterrupt() throws Exception {
-    final BallThread ballThread = new BallThread();
-    final UncaughtExceptionHandler exceptionHandler = mock(UncaughtExceptionHandler.class);
-    ballThread.setUncaughtExceptionHandler(exceptionHandler);
-    ballThread.setTwin(mock(BallItem.class));
-    ballThread.start();
-    ballThread.interrupt();
-    ballThread.join();
+    assertTimeout(ofMillis(5000), () -> {
+      final BallThread ballThread = new BallThread();
+      final UncaughtExceptionHandler exceptionHandler = mock(UncaughtExceptionHandler.class);
+      ballThread.setUncaughtExceptionHandler(exceptionHandler);
+      ballThread.setTwin(mock(BallItem.class));
+      ballThread.start();
+      ballThread.interrupt();
+      ballThread.join();
 
-    verify(exceptionHandler).uncaughtException(eq(ballThread), any(RuntimeException.class));
-    verifyNoMoreInteractions(exceptionHandler);
+      verify(exceptionHandler).uncaughtException(eq(ballThread), any(RuntimeException.class));
+      verifyNoMoreInteractions(exceptionHandler);
+    });
   }
 }

--- a/unit-of-work/pom.xml
+++ b/unit-of-work/pom.xml
@@ -16,6 +16,11 @@
             <artifactId>junit</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
         </dependency>

--- a/value-object/pom.xml
+++ b/value-object/pom.xml
@@ -41,8 +41,13 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/value-object/src/test/java/com/iluwatar/value/object/AppTest.java
+++ b/value-object/src/test/java/com/iluwatar/value/object/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.value.object;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Application test

--- a/value-object/src/test/java/com/iluwatar/value/object/HeroStatTest.java
+++ b/value-object/src/test/java/com/iluwatar/value/object/HeroStatTest.java
@@ -22,14 +22,12 @@
  */
 package com.iluwatar.value.object;
 
+import com.google.common.testing.EqualsTester;
+import org.junit.jupiter.api.Test;
+
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
-
 import static org.junit.Assert.assertThat;
-
-import com.google.common.testing.EqualsTester;
-
-import org.junit.Test;
 
 /**
  * Unit test for HeroStat.

--- a/visitor/pom.xml
+++ b/visitor/pom.xml
@@ -34,8 +34,13 @@
   <artifactId>visitor</artifactId>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/visitor/src/test/java/com/iluwatar/visitor/AppTest.java
+++ b/visitor/src/test/java/com/iluwatar/visitor/AppTest.java
@@ -22,7 +22,7 @@
  */
 package com.iluwatar.visitor;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * 

--- a/visitor/src/test/java/com/iluwatar/visitor/UnitTest.java
+++ b/visitor/src/test/java/com/iluwatar/visitor/UnitTest.java
@@ -22,14 +22,15 @@
  */
 package com.iluwatar.visitor;
 
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.function.Function;
+
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-
-import java.util.Arrays;
-import java.util.function.Function;
-import org.junit.Test;
 
 /**
  * Date: 12/30/15 - 18:59 PM

--- a/visitor/src/test/java/com/iluwatar/visitor/VisitorTest.java
+++ b/visitor/src/test/java/com/iluwatar/visitor/VisitorTest.java
@@ -22,18 +22,19 @@
  */
 package com.iluwatar.visitor;
 
-import static org.junit.Assert.assertEquals;
-
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.AppenderBase;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Date: 12/30/15 - 18:59 PM
@@ -45,12 +46,12 @@ public abstract class VisitorTest<V extends UnitVisitor> {
 
   private InMemoryAppender appender;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     appender = new InMemoryAppender();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     appender.stop();
   }


### PR DESCRIPTION
Migrate project to JUnit5 
- Switched all modules to use junit platform
- If it is impossible to convert module to junit 5 engine, use vintage engine instead (run tests as junit4)
- Should potentially resolve #408 

