### PR TITLE
 Remove redundant explicit super()

### DIFF
--- a/value-object/src/main/java/com/iluwatar/value/object/HeroStat.java
+++ b/value-object/src/main/java/com/iluwatar/value/object/HeroStat.java
@@ -37,7 +37,6 @@ public class HeroStat {
 
   // All constructors must be private.
   private HeroStat(int strength, int intelligence, int luck) {
-    super();
     this.strength = strength;
     this.intelligence = intelligence;
     this.luck = luck;


### PR DESCRIPTION
Remove redundant explicit super() constructor calls #694

Remove redundant explicit super() constructor

The super() calls (taking no arguments) are inserted during compile time, so just make the code more verbose than required.
