### PR TITLE
Remove redundant explicit super() constructor calls #694

### DIFF
--- a/cqrs/src/main/java/com/iluwatar/cqrs/domain/model/Author.java
+++ b/cqrs/src/main/java/com/iluwatar/cqrs/domain/model/Author.java
@@ -56,7 +56,6 @@ public class Author {
   }
 
   protected Author() {
-    super();
   }
 
   public long getId() {

--- a/cqrs/src/main/java/com/iluwatar/cqrs/domain/model/Book.java
+++ b/cqrs/src/main/java/com/iluwatar/cqrs/domain/model/Book.java
@@ -58,7 +58,6 @@ public class Book {
   }
 
   protected Book() {
-    super();
   }
 
   public long getId() {

--- a/cqrs/src/main/java/com/iluwatar/cqrs/dto/Author.java
+++ b/cqrs/src/main/java/com/iluwatar/cqrs/dto/Author.java
@@ -51,7 +51,6 @@ public class Author {
   }
 
   public Author() {
-    super();
   }
 
   public String getName() {

--- a/cqrs/src/main/java/com/iluwatar/cqrs/dto/Book.java
+++ b/cqrs/src/main/java/com/iluwatar/cqrs/dto/Book.java
@@ -47,7 +47,6 @@ public class Book {
   }
 
   public Book() {
-    super();
   }
 
   public String getTitle() {

--- a/event-aggregator/src/main/java/com/iluwatar/event/aggregator/KingsHand.java
+++ b/event-aggregator/src/main/java/com/iluwatar/event/aggregator/KingsHand.java
@@ -30,7 +30,6 @@ package com.iluwatar.event.aggregator;
 public class KingsHand extends EventEmitter implements EventObserver {
 
   public KingsHand() {
-    super();
   }
 
   public KingsHand(EventObserver obs) {

--- a/event-aggregator/src/main/java/com/iluwatar/event/aggregator/LordBaelish.java
+++ b/event-aggregator/src/main/java/com/iluwatar/event/aggregator/LordBaelish.java
@@ -30,7 +30,6 @@ package com.iluwatar.event.aggregator;
 public class LordBaelish extends EventEmitter {
 
   public LordBaelish() {
-    super();
   }
 
   public LordBaelish(EventObserver obs) {

--- a/event-aggregator/src/main/java/com/iluwatar/event/aggregator/LordVarys.java
+++ b/event-aggregator/src/main/java/com/iluwatar/event/aggregator/LordVarys.java
@@ -30,7 +30,6 @@ package com.iluwatar.event.aggregator;
 public class LordVarys extends EventEmitter {
 
   public LordVarys() {
-    super();
   }
 
   public LordVarys(EventObserver obs) {

--- a/event-aggregator/src/main/java/com/iluwatar/event/aggregator/Scout.java
+++ b/event-aggregator/src/main/java/com/iluwatar/event/aggregator/Scout.java
@@ -30,7 +30,6 @@ package com.iluwatar.event.aggregator;
 public class Scout extends EventEmitter {
 
   public Scout() {
-    super();
   }
 
   public Scout(EventObserver obs) {


### PR DESCRIPTION
This PR removes few more explicit calls to `super()`.

Relates to #694