### PR TITLE
Use the @TestInstance annotation

### DIFF
--- a/interpreter/src/test/java/com/iluwatar/interpreter/ExpressionTest.java
+++ b/interpreter/src/test/java/com/iluwatar/interpreter/ExpressionTest.java
@@ -23,6 +23,7 @@
 package com.iluwatar.interpreter;
 
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -43,6 +44,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  * @param <E> Type of Expression
  * @author Jeroen Meulemeester
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class ExpressionTest<E extends Expression> {
 
   /**
@@ -87,6 +89,13 @@ public abstract class ExpressionTest<E extends Expression> {
     this.expectedToString = expectedToString;
     this.factory = factory;
   }
+
+  /**
+   * Create a new set of test entries with the expected result
+   *
+   * @return The list of parameters used during this test
+   */
+  public abstract Stream<Arguments> expressionProvider();
 
   /**
    * Verify if the expression calculates the correct result when calling {@link E#interpret()}

--- a/interpreter/src/test/java/com/iluwatar/interpreter/MinusExpressionTest.java
+++ b/interpreter/src/test/java/com/iluwatar/interpreter/MinusExpressionTest.java
@@ -38,7 +38,8 @@ public class MinusExpressionTest extends ExpressionTest<MinusExpression> {
    *
    * @return The list of parameters used during this test
    */
-  public static Stream<Arguments> expressionProvider() {
+  @Override
+  public Stream<Arguments> expressionProvider() {
     return prepareParameters((f, s) -> f - s);
   }
 

--- a/interpreter/src/test/java/com/iluwatar/interpreter/MultiplyExpressionTest.java
+++ b/interpreter/src/test/java/com/iluwatar/interpreter/MultiplyExpressionTest.java
@@ -38,7 +38,8 @@ public class MultiplyExpressionTest extends ExpressionTest<MultiplyExpression> {
    *
    * @return The list of parameters used during this test
    */
-  public static Stream<Arguments> expressionProvider() {
+  @Override
+  public Stream<Arguments> expressionProvider() {
     return prepareParameters((f, s) -> f * s);
   }
 

--- a/interpreter/src/test/java/com/iluwatar/interpreter/NumberExpressionTest.java
+++ b/interpreter/src/test/java/com/iluwatar/interpreter/NumberExpressionTest.java
@@ -42,7 +42,8 @@ public class NumberExpressionTest extends ExpressionTest<NumberExpression> {
    *
    * @return The list of parameters used during this test
    */
-  public static Stream<Arguments> expressionProvider() {
+  @Override
+  public Stream<Arguments> expressionProvider() {
     return prepareParameters((f, s) -> f);
   }
 

--- a/interpreter/src/test/java/com/iluwatar/interpreter/PlusExpressionTest.java
+++ b/interpreter/src/test/java/com/iluwatar/interpreter/PlusExpressionTest.java
@@ -38,7 +38,8 @@ public class PlusExpressionTest extends ExpressionTest<PlusExpression> {
    *
    * @return The list of parameters used during this test
    */
-  public static Stream<Arguments> expressionProvider() {
+  @Override
+  public Stream<Arguments> expressionProvider() {
     return prepareParameters((f, s) -> f + s);
   }
 

--- a/observer/src/test/java/com/iluwatar/observer/HobbitsTest.java
+++ b/observer/src/test/java/com/iluwatar/observer/HobbitsTest.java
@@ -33,7 +33,8 @@ import java.util.List;
  */
 public class HobbitsTest extends WeatherObserverTest<Hobbits> {
 
-  static Collection<Object[]> dataProvider() {
+  @Override
+  public Collection<Object[]> dataProvider() {
     final List<Object[]> testData = new ArrayList<>();
     testData.add(new Object[]{WeatherType.SUNNY, "The happy hobbits bade in the warm sun."});
     testData.add(new Object[]{WeatherType.RAINY, "The hobbits look for cover from the rain."});

--- a/observer/src/test/java/com/iluwatar/observer/OrcsTest.java
+++ b/observer/src/test/java/com/iluwatar/observer/OrcsTest.java
@@ -33,7 +33,8 @@ import java.util.List;
  */
 public class OrcsTest extends WeatherObserverTest<Orcs> {
 
-  static Collection<Object[]> dataProvider() {
+  @Override
+  public Collection<Object[]> dataProvider() {
     final List<Object[]> testData = new ArrayList<>();
     testData.add(new Object[]{WeatherType.SUNNY, "The sun hurts the orcs' eyes."});
     testData.add(new Object[]{WeatherType.RAINY, "The orcs are dripping wet."});

--- a/observer/src/test/java/com/iluwatar/observer/WeatherObserverTest.java
+++ b/observer/src/test/java/com/iluwatar/observer/WeatherObserverTest.java
@@ -23,11 +23,14 @@
 package com.iluwatar.observer;
 
 import com.iluwatar.observer.utils.InMemoryAppender;
+
+import java.util.Collection;
 import java.util.function.Supplier;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -39,6 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * @param <O> Type of WeatherObserver
  * @author Jeroen Meulemeester
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class WeatherObserverTest<O extends WeatherObserver> {
 
   private InMemoryAppender appender;
@@ -66,6 +70,8 @@ public abstract class WeatherObserverTest<O extends WeatherObserver> {
   WeatherObserverTest(final Supplier<O> factory) {
     this.factory = factory;
   }
+
+  public abstract Collection<Object[]> dataProvider();
 
   /**
    * Verify if the weather has the expected influence on the observer

--- a/observer/src/test/java/com/iluwatar/observer/generic/GHobbitsTest.java
+++ b/observer/src/test/java/com/iluwatar/observer/generic/GHobbitsTest.java
@@ -35,7 +35,8 @@ import java.util.List;
  */
 public class GHobbitsTest extends ObserverTest<GHobbits> {
 
-  static Collection<Object[]> dataProvider() {
+  @Override
+  public Collection<Object[]> dataProvider() {
     final List<Object[]> testData = new ArrayList<>();
     testData.add(new Object[]{WeatherType.SUNNY, "The happy hobbits bade in the warm sun."});
     testData.add(new Object[]{WeatherType.RAINY, "The hobbits look for cover from the rain."});

--- a/observer/src/test/java/com/iluwatar/observer/generic/ObserverTest.java
+++ b/observer/src/test/java/com/iluwatar/observer/generic/ObserverTest.java
@@ -26,9 +26,11 @@ import com.iluwatar.observer.WeatherType;
 import com.iluwatar.observer.utils.InMemoryAppender;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.Collection;
 import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -39,6 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * @param <O> Type of Observer
  * @author Jeroen Meulemeester
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class ObserverTest<O extends Observer> {
 
   private InMemoryAppender appender;
@@ -66,6 +69,8 @@ public abstract class ObserverTest<O extends Observer> {
   ObserverTest(final Supplier<O> factory) {
     this.factory = factory;
   }
+
+  public abstract Collection<Object[]> dataProvider();
 
   /**
    * Verify if the weather has the expected influence on the observer

--- a/observer/src/test/java/com/iluwatar/observer/generic/OrcsTest.java
+++ b/observer/src/test/java/com/iluwatar/observer/generic/OrcsTest.java
@@ -35,7 +35,8 @@ import java.util.List;
  */
 public class OrcsTest extends ObserverTest<GOrcs> {
 
-  static Collection<Object[]> dataProvider() {
+  @Override
+  public Collection<Object[]> dataProvider() {
     final List<Object[]> testData = new ArrayList<>();
     testData.add(new Object[]{WeatherType.SUNNY, "The sun hurts the orcs' eyes."});
     testData.add(new Object[]{WeatherType.RAINY, "The orcs are dripping wet."});


### PR DESCRIPTION
Use the TestInstance annotation in class to avoid ```static``` and  enable inhertied of methods refered by MethodSource.

> For detailed contributing instructions see https://github.com/iluwatar/java-design-patterns/wiki/01.-How-to-contribute
