### PR TITLE
Trampoline pattern logger fix

### DIFF
--- a/trampoline/src/main/java/com/iluwatar/trampoline/TrampolineApp.java
+++ b/trampoline/src/main/java/com/iluwatar/trampoline/TrampolineApp.java
@@ -23,36 +23,41 @@
 
 package com.iluwatar.trampoline;
 
-
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
- * <p>Trampoline pattern allows to define recursive algorithms by iterative loop </p>
- * <p>it is possible to implement algorithms recursively in Java without blowing the stack
- * and to interleave the execution of functions without hard coding them together or even using threads.</p>
+ * <p>
+ * Trampoline pattern allows to define recursive algorithms by iterative loop
+ * </p>
+ * <p>
+ * it is possible to implement algorithms recursively in Java without blowing
+ * the stack and to interleave the execution of functions without hard coding
+ * them together or even using threads.
+ * </p>
  */
-@Slf4j
 public class TrampolineApp {
+	private static final Logger LOGGER = LoggerFactory.getLogger(TrampolineApp.class);
 
-  /**
-   * Main program for showing pattern. It does loop with factorial function.
-   * */
-  public static void main(String[] args) {
-    log.info("start pattern");
-    Integer result = loop(10, 1).result();
-    log.info("result {}", result);
+	/**
+	 * Main program for showing pattern. It does loop with factorial function.
+	 */
+	public static void main(String[] args) {
+		LOGGER.info("start pattern");
+		Integer result = loop(10, 1).result();
+		LOGGER.info("result {}", result);
 
-  }
+	}
 
-  /**
-   * Manager for pattern. Define it with a factorial function.
-   */
-  public static Trampoline<Integer> loop(int times, int prod) {
-    if (times == 0) {
-      return Trampoline.done(prod);
-    } else {
-      return Trampoline.more(() -> loop(times - 1, prod * times));
-    }
-  }
+	/**
+	 * Manager for pattern. Define it with a factorial function.
+	 */
+	public static Trampoline<Integer> loop(int times, int prod) {
+		if (times == 0) {
+			return Trampoline.done(prod);
+		} else {
+			return Trampoline.more(() -> loop(times - 1, prod * times));
+		}
+	}
 
 }


### PR DESCRIPTION
Trampoline pattern has logger object build error.
The error fixed with using **org.slf4j.Logger**.

Instead of using anatation, Logger object is created for logging.