### PR TITLE
Dependency 'junit-platform-launcher' is added

### DIFF
--- a/factory-method/pom.xml
+++ b/factory-method/pom.xml
@@ -23,25 +23,32 @@
     THE SOFTWARE.
 
 -->
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
-  <parent>
-    <groupId>com.iluwatar</groupId>
-    <artifactId>java-design-patterns</artifactId>
-    <version>1.20.0-SNAPSHOT</version>
-  </parent>
-  <artifactId>factory-method</artifactId>
-  <dependencies>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-  </dependencies>
+<project
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+	xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>com.iluwatar</groupId>
+		<artifactId>java-design-patterns</artifactId>
+		<version>1.20.0-SNAPSHOT</version>
+	</parent>
+	<artifactId>factory-method</artifactId>
+	<dependencies>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.platform</groupId>
+			<artifactId>junit-platform-launcher</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
         <mongo-java-driver.version>3.3.0</mongo-java-driver.version>
         <slf4j.version>1.7.21</slf4j.version>
         <logback.version>1.1.7</logback.version>
+        <junit-platform.launcher.version>1.0.2</junit-platform.launcher.version>
     </properties>
     <modules>
         <module>abstract-factory</module>
@@ -256,6 +257,12 @@
                 <groupId>org.junit.vintage</groupId>
                 <artifactId>junit-vintage-engine</artifactId>
                 <version>${junit-vintage.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+              <groupId>org.junit.platform</groupId>
+			<artifactId>junit-platform-launcher</artifactId>
+                <version>${junit-platform.launcher.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/trampoline/src/main/java/com/iluwatar/trampoline/TrampolineApp.java
+++ b/trampoline/src/main/java/com/iluwatar/trampoline/TrampolineApp.java
@@ -23,36 +23,41 @@
 
 package com.iluwatar.trampoline;
 
-
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
- * <p>Trampoline pattern allows to define recursive algorithms by iterative loop </p>
- * <p>it is possible to implement algorithms recursively in Java without blowing the stack
- * and to interleave the execution of functions without hard coding them together or even using threads.</p>
+ * <p>
+ * Trampoline pattern allows to define recursive algorithms by iterative loop
+ * </p>
+ * <p>
+ * it is possible to implement algorithms recursively in Java without blowing
+ * the stack and to interleave the execution of functions without hard coding
+ * them together or even using threads.
+ * </p>
  */
-@Slf4j
 public class TrampolineApp {
+	private static final Logger LOGGER = LoggerFactory.getLogger(TrampolineApp.class);
 
-  /**
-   * Main program for showing pattern. It does loop with factorial function.
-   * */
-  public static void main(String[] args) {
-    log.info("start pattern");
-    Integer result = loop(10, 1).result();
-    log.info("result {}", result);
+	/**
+	 * Main program for showing pattern. It does loop with factorial function.
+	 */
+	public static void main(String[] args) {
+		LOGGER.info("start pattern");
+		Integer result = loop(10, 1).result();
+		LOGGER.info("result {}", result);
 
-  }
+	}
 
-  /**
-   * Manager for pattern. Define it with a factorial function.
-   */
-  public static Trampoline<Integer> loop(int times, int prod) {
-    if (times == 0) {
-      return Trampoline.done(prod);
-    } else {
-      return Trampoline.more(() -> loop(times - 1, prod * times));
-    }
-  }
+	/**
+	 * Manager for pattern. Define it with a factorial function.
+	 */
+	public static Trampoline<Integer> loop(int times, int prod) {
+		if (times == 0) {
+			return Trampoline.done(prod);
+		} else {
+			return Trampoline.more(() -> loop(times - 1, prod * times));
+		}
+	}
 
 }

--- a/trampoline/src/main/java/com/iluwatar/trampoline/TrampolineApp.java
+++ b/trampoline/src/main/java/com/iluwatar/trampoline/TrampolineApp.java
@@ -23,41 +23,36 @@
 
 package com.iluwatar.trampoline;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import lombok.extern.slf4j.Slf4j;
 
 /**
- * <p>
- * Trampoline pattern allows to define recursive algorithms by iterative loop
- * </p>
- * <p>
- * it is possible to implement algorithms recursively in Java without blowing
- * the stack and to interleave the execution of functions without hard coding
- * them together or even using threads.
- * </p>
+ * <p>Trampoline pattern allows to define recursive algorithms by iterative loop </p>
+ * <p>it is possible to implement algorithms recursively in Java without blowing the stack
+ * and to interleave the execution of functions without hard coding them together or even using threads.</p>
  */
+@Slf4j
 public class TrampolineApp {
-	private static final Logger LOGGER = LoggerFactory.getLogger(TrampolineApp.class);
 
-	/**
-	 * Main program for showing pattern. It does loop with factorial function.
-	 */
-	public static void main(String[] args) {
-		LOGGER.info("start pattern");
-		Integer result = loop(10, 1).result();
-		LOGGER.info("result {}", result);
+  /**
+   * Main program for showing pattern. It does loop with factorial function.
+   * */
+  public static void main(String[] args) {
+    log.info("start pattern");
+    Integer result = loop(10, 1).result();
+    log.info("result {}", result);
 
-	}
+  }
 
-	/**
-	 * Manager for pattern. Define it with a factorial function.
-	 */
-	public static Trampoline<Integer> loop(int times, int prod) {
-		if (times == 0) {
-			return Trampoline.done(prod);
-		} else {
-			return Trampoline.more(() -> loop(times - 1, prod * times));
-		}
-	}
+  /**
+   * Manager for pattern. Define it with a factorial function.
+   */
+  public static Trampoline<Integer> loop(int times, int prod) {
+    if (times == 0) {
+      return Trampoline.done(prod);
+    } else {
+      return Trampoline.more(() -> loop(times - 1, prod * times));
+    }
+  }
 
 }


### PR DESCRIPTION
The AppTest class in factory pattern has an error because of junit-platform-launcher' eclipse bug on version **Oxygen.3 Release (4.7.3)**. 

Dependency '**junit-platform-launcher**' is added to pom.xml for running test classes.

For detail info about Eclipse bug, please [click here.](https://stackoverflow.com/questions/46717693/eclipse-no-tests-found-using-junit-5-caused-by-noclassdeffounderror)
