### PR TITLE
Correct the command for computing code coverage

### DIFF
--- a/CODE_COVERAGE.md
+++ b/CODE_COVERAGE.md
@@ -1,7 +1,7 @@
 # Code Coverage Report generation
 
 To generate the code coverage report, execute the following command:
-> mvn clean verify
+> mvn clean verify jacoco:report
 
 This will generate code coverage report in each of the modules. In order to view the same, open the following file in your browser.
 > target/site/jacoco/index.html 


### PR DESCRIPTION
The command in file `CODE_COVERAGE.md` creates `jacoco.exec` files but not the reports.
This pull request changes the command to generate the reports, making the rest of the file correct.