### PR TITLE
#643 Fix flaky tests for throttling pattern

### DIFF
--- a/throttling/src/test/java/com/iluwatar/throttling/B2BServiceTest.java
+++ b/throttling/src/test/java/com/iluwatar/throttling/B2BServiceTest.java
@@ -22,29 +22,27 @@
  */
 package com.iluwatar.throttling;
 
-import com.iluwatar.throttling.timer.ThrottleTimerImpl;
 import com.iluwatar.throttling.timer.Throttler;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * B2BServiceTest class to test the B2BService
  */
 public class B2BServiceTest {
 
-  @Disabled
   @Test
   public void dummyCustomerApiTest() {
     Tenant tenant = new Tenant("testTenant", 2);
-    Throttler timer = new ThrottleTimerImpl(100);
+    // In order to assure that throttling limits will not be reset, we use an empty throttling implementation
+    Throttler timer = () -> {};
     B2BService service = new B2BService(timer);
 
     for (int i = 0; i < 5; i++) {
       service.dummyCustomerApi(tenant);
     }
     long counter = CallsCount.getCount(tenant.getName());
-    assertTrue(counter == 2, "Counter limit must be reached");
+    assertEquals(2, counter, "Counter limit must be reached");
   }
 }

--- a/throttling/src/test/java/com/iluwatar/throttling/B2BServiceTest.java
+++ b/throttling/src/test/java/com/iluwatar/throttling/B2BServiceTest.java
@@ -36,7 +36,7 @@ public class B2BServiceTest {
   public void dummyCustomerApiTest() {
     Tenant tenant = new Tenant("testTenant", 2);
     // In order to assure that throttling limits will not be reset, we use an empty throttling implementation
-    Throttler timer = () -> {};
+    Throttler timer = () -> { };
     B2BService service = new B2BService(timer);
 
     for (int i = 0; i < 5; i++) {


### PR DESCRIPTION
I took a look at the Travis logs and the troublesome test. From examining the code and tinkering around, my best guess is that in the Travis environment, the threat that resets the API access limit may prematurely reset the count, making the assertion fail.

I have instead changed the throttler to be an empty implementation (to avoid any unintended resets, which is not the point of the test). Additionally, I changed it to an assertEquals so that in the event of another failure, we can see exactly what the counter ended up being, which will help with debugging.
