### PR TITLE
#781: Resolve ClassCastException in App.java 

### DIFF
--- a/acyclic-visitor/src/main/java/com/iluwatar/acyclicvisitor/ConfigureForUnixVisitor.java
+++ b/acyclic-visitor/src/main/java/com/iluwatar/acyclicvisitor/ConfigureForUnixVisitor.java
@@ -26,13 +26,17 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * ConfigureForUnixVisitor class implements zoom's visit method for Unix 
+ * ConfigureForUnixVisitor class implements zoom's and hayes' visit method for Unix 
  * manufacturer
  */
-public class ConfigureForUnixVisitor implements ModemVisitor, ZoomVisitor {
+public class ConfigureForUnixVisitor implements AllModemVisitor {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ConfigureForUnixVisitor.class);
-
+   
+  public void visit(Hayes hayes) {
+    LOGGER.info(hayes + " used with Dos configurator.");
+  }
+  
   public void visit(Zoom zoom) {
     LOGGER.info(zoom + " used with Unix configurator.");
   }


### PR DESCRIPTION
#781 Resolve ClassCastException in App.java 
      Resolved ClassCastException thrown because ConfigureForUnixVisitor didn't implements HayesVisitor. 
Implemented AllModemVisitor in ConfigureForUnixVisitor class and added visit(Hayes hayes) method.