### PR TITLE
Execute Around - use lambda

### DIFF
--- a/execute-around/src/main/java/com/iluwatar/execute/around/App.java
+++ b/execute-around/src/main/java/com/iluwatar/execute/around/App.java
@@ -22,7 +22,6 @@
  */
 package com.iluwatar.execute.around;
 
-import java.io.FileWriter;
 import java.io.IOException;
 
 /**
@@ -42,14 +41,11 @@ public class App {
    */
   public static void main(String[] args) throws IOException {
 
-    new SimpleFileWriter("testfile.txt", new FileWriterAction() {
-
-      @Override
-      public void writeFile(FileWriter writer) throws IOException {
-        writer.write("Hello");
-        writer.append(" ");
-        writer.append("there!");
-      }
-    });
+    FileWriterAction writeHello = writer -> {
+      writer.write("Hello");
+      writer.append(" ");
+      writer.append("there!");
+    };
+    new SimpleFileWriter("testfile.txt", writeHello);
   }
 }

--- a/execute-around/src/main/java/com/iluwatar/execute/around/FileWriterAction.java
+++ b/execute-around/src/main/java/com/iluwatar/execute/around/FileWriterAction.java
@@ -30,6 +30,7 @@ import java.io.IOException;
  * Interface for specifying what to do with the file resource.
  *
  */
+@FunctionalInterface
 public interface FileWriterAction {
 
   void writeFile(FileWriter writer) throws IOException;


### PR DESCRIPTION
Refactor the Execute Around pattern to use a lambda. Lambdas make such patterns feel lighter weight.

I first heard about this pattern in a talk by Venkat Subramanian. The thrust of the talk was that lambdas made such patterns nicer.

I extracted the lambda to its own variable to make clearer the type it's implementing.