### PR TITLE
Minor refactorings in Hexagonal architecture

### DIFF
--- a/hexagonal/src/main/java/com/iluwatar/hexagonal/database/MongoTicketRepository.java
+++ b/hexagonal/src/main/java/com/iluwatar/hexagonal/database/MongoTicketRepository.java
@@ -111,21 +111,6 @@ public class MongoTicketRepository implements LotteryTicketRepository {
   }
 
   /**
-   * @return mongo client
-   */
-  public MongoClient getMongoClient() {
-    return mongoClient;
-  }
-
-  /**
-   *
-   * @return mongo database
-   */
-  public MongoDatabase getMongoDatabase() {
-    return database;
-  }
-
-  /**
    *
    * @return tickets collection
    */

--- a/hexagonal/src/main/java/com/iluwatar/hexagonal/domain/LotteryNumbers.java
+++ b/hexagonal/src/main/java/com/iluwatar/hexagonal/domain/LotteryNumbers.java
@@ -22,6 +22,8 @@
  */
 package com.iluwatar.hexagonal.domain;
 
+import com.google.common.base.Joiner;
+
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.PrimitiveIterator;
@@ -84,15 +86,7 @@ public class LotteryNumbers {
    * @return numbers as comma separated string
    */
   public String getNumbersAsString() {
-    StringBuilder builder = new StringBuilder();
-    Iterator<Integer> iterator = numbers.iterator();
-    for (int i = 0; i < NUM_NUMBERS; i++) {
-      builder.append(iterator.next());
-      if (i < NUM_NUMBERS - 1) {
-        builder.append(",");
-      }
-    }
-    return builder.toString();
+    return Joiner.on(',').join(numbers);
   }
   
   /**

--- a/hexagonal/src/main/java/com/iluwatar/hexagonal/domain/LotteryNumbers.java
+++ b/hexagonal/src/main/java/com/iluwatar/hexagonal/domain/LotteryNumbers.java
@@ -29,7 +29,6 @@ import java.util.HashSet;
 import java.util.PrimitiveIterator;
 import java.util.Random;
 import java.util.Set;
-import java.util.Iterator;
 
 /**
  *

--- a/hexagonal/src/main/java/com/iluwatar/hexagonal/domain/LotteryTicketId.java
+++ b/hexagonal/src/main/java/com/iluwatar/hexagonal/domain/LotteryTicketId.java
@@ -23,7 +23,6 @@
 package com.iluwatar.hexagonal.domain;
 
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.LongAdder;
 
 /**
  * Lottery ticked id

--- a/hexagonal/src/main/java/com/iluwatar/hexagonal/domain/LotteryTicketId.java
+++ b/hexagonal/src/main/java/com/iluwatar/hexagonal/domain/LotteryTicketId.java
@@ -22,17 +22,19 @@
  */
 package com.iluwatar.hexagonal.domain;
 
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.LongAdder;
+
 /**
  * Lottery ticked id
  */
 public class LotteryTicketId {
 
-  private static volatile int numAllocated;
+  private static AtomicInteger numAllocated = new AtomicInteger(0);
   private final int id;
   
   public LotteryTicketId() {
-    this.id = numAllocated + 1;
-    numAllocated++;
+    this.id = numAllocated.incrementAndGet();
   }
 
   public LotteryTicketId(int id) {

--- a/hexagonal/src/test/java/com/iluwatar/hexagonal/AppTest.java
+++ b/hexagonal/src/test/java/com/iluwatar/hexagonal/AppTest.java
@@ -27,10 +27,10 @@ import org.junit.jupiter.api.Test;
 /**
  * Unit test for simple App.
  */
-public class AppTest {
+class AppTest {
 
   @Test
-  public void testApp() {
+  void testApp() {
     String[] args = {};
     App.main(args);
   }

--- a/hexagonal/src/test/java/com/iluwatar/hexagonal/banking/InMemoryBankTest.java
+++ b/hexagonal/src/test/java/com/iluwatar/hexagonal/banking/InMemoryBankTest.java
@@ -32,19 +32,19 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Tests for banking
  *
  */
-public class InMemoryBankTest {
+class InMemoryBankTest {
 
   private final WireTransfers bank = new InMemoryBank();
   
   @Test
-  public void testInit() {
-    assertEquals(bank.getFunds("foo"), 0);
+  void testInit() {
+    assertEquals(0, bank.getFunds("foo"));
     bank.setFunds("foo", 100);
-    assertEquals(bank.getFunds("foo"), 100);
+    assertEquals(100, bank.getFunds("foo"));
     bank.setFunds("bar", 150);
-    assertEquals(bank.getFunds("bar"), 150);
+    assertEquals(150, bank.getFunds("bar"));
     assertTrue(bank.transferFunds(50, "bar", "foo"));
-    assertEquals(bank.getFunds("foo"), 150);
-    assertEquals(bank.getFunds("bar"), 100);
+    assertEquals(150, bank.getFunds("foo"));
+    assertEquals(100, bank.getFunds("bar"));
   }
 }

--- a/hexagonal/src/test/java/com/iluwatar/hexagonal/banking/MongoBankTest.java
+++ b/hexagonal/src/test/java/com/iluwatar/hexagonal/banking/MongoBankTest.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * Tests for Mongo banking adapter
  */
 @Disabled
-public class MongoBankTest {
+class MongoBankTest {
 
   private static final String TEST_DB = "lotteryDBTest";
   private static final String TEST_ACCOUNTS_COLLECTION = "testAccounts";
@@ -42,7 +42,7 @@ public class MongoBankTest {
   private MongoBank mongoBank;
 
   @BeforeEach
-  public void init() {
+  void init() {
     MongoConnectionPropertiesLoader.load();
     MongoClient mongoClient = new MongoClient(System.getProperty("mongo-host"),
         Integer.parseInt(System.getProperty("mongo-port")));
@@ -52,12 +52,12 @@ public class MongoBankTest {
   }
 
   @Test
-  public void testSetup() {
+  void testSetup() {
     assertEquals(0, mongoBank.getAccountsCollection().count());
   }
 
   @Test
-  public void testFundTransfers() {
+  void testFundTransfers() {
     assertEquals(0, mongoBank.getFunds("000-000"));
     mongoBank.setFunds("000-000", 10);
     assertEquals(10, mongoBank.getFunds("000-000"));

--- a/hexagonal/src/test/java/com/iluwatar/hexagonal/database/InMemoryTicketRepositoryTest.java
+++ b/hexagonal/src/test/java/com/iluwatar/hexagonal/database/InMemoryTicketRepositoryTest.java
@@ -38,23 +38,23 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Tests for {@link LotteryTicketRepository}
  *
  */
-public class InMemoryTicketRepositoryTest {
+class InMemoryTicketRepositoryTest {
 
   private final LotteryTicketRepository repository = new InMemoryTicketRepository();
   
   @BeforeEach
-  public void clear() {
+  void clear() {
     repository.deleteAll();
   }
   
   @Test
-  public void testCrudOperations() {
+  void testCrudOperations() {
     LotteryTicketRepository repository = new InMemoryTicketRepository();
-    assertEquals(repository.findAll().size(), 0);
+    assertTrue(repository.findAll().isEmpty());
     LotteryTicket ticket = LotteryTestUtils.createLotteryTicket();
     Optional<LotteryTicketId> id = repository.save(ticket);
     assertTrue(id.isPresent());
-    assertEquals(repository.findAll().size(), 1);
+    assertEquals(1, repository.findAll().size());
     Optional<LotteryTicket> optionalTicket = repository.findById(id.get());
     assertTrue(optionalTicket.isPresent());
   }

--- a/hexagonal/src/test/java/com/iluwatar/hexagonal/database/MongoTicketRepositoryTest.java
+++ b/hexagonal/src/test/java/com/iluwatar/hexagonal/database/MongoTicketRepositoryTest.java
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Tests for Mongo based ticket repository
  */
 @Disabled
-public class MongoTicketRepositoryTest {
+class MongoTicketRepositoryTest {
 
   private static final String TEST_DB = "lotteryTestDB";
   private static final String TEST_TICKETS_COLLECTION = "lotteryTestTickets";
@@ -50,7 +50,7 @@ public class MongoTicketRepositoryTest {
   private MongoTicketRepository repository;
 
   @BeforeEach
-  public void init() {
+  void init() {
     MongoConnectionPropertiesLoader.load();
     MongoClient mongoClient = new MongoClient(System.getProperty("mongo-host"),
         Integer.parseInt(System.getProperty("mongo-port")));
@@ -61,20 +61,20 @@ public class MongoTicketRepositoryTest {
   }
 
   @Test
-  public void testSetup() {
-    assertTrue(repository.getCountersCollection().count() == 1);
-    assertTrue(repository.getTicketsCollection().count() == 0);
+  void testSetup() {
+    assertEquals(1, repository.getCountersCollection().count());
+    assertEquals(0, repository.getTicketsCollection().count());
   }
 
   @Test
-  public void testNextId() {
+  void testNextId() {
     assertEquals(1, repository.getNextId());
     assertEquals(2, repository.getNextId());
     assertEquals(3, repository.getNextId());
   }
 
   @Test
-  public void testCrudOperations() {
+  void testCrudOperations() {
     // create new lottery ticket and save it
     PlayerDetails details = new PlayerDetails("foo@bar.com", "123-123", "07001234");
     LotteryNumbers random = LotteryNumbers.createRandom();

--- a/hexagonal/src/test/java/com/iluwatar/hexagonal/domain/LotteryNumbersTest.java
+++ b/hexagonal/src/test/java/com/iluwatar/hexagonal/domain/LotteryNumbersTest.java
@@ -28,7 +28,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -37,10 +37,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Unit tests for {@link LotteryNumbers}
  *
  */
-public class LotteryNumbersTest {
+class LotteryNumbersTest {
   
   @Test
-  public void testGivenNumbers() {
+  void testGivenNumbers() {
     LotteryNumbers numbers = LotteryNumbers.create(
             new HashSet<>(Arrays.asList(1, 2, 3, 4)));
     assertEquals(numbers.getNumbers().size(), 4);
@@ -51,7 +51,7 @@ public class LotteryNumbersTest {
   }
   
   @Test
-  public void testNumbersCantBeModified() {
+  void testNumbersCantBeModified() {
     LotteryNumbers numbers = LotteryNumbers.create(
             new HashSet<>(Arrays.asList(1, 2, 3, 4)));
     assertThrows(UnsupportedOperationException.class, () -> {
@@ -60,20 +60,20 @@ public class LotteryNumbersTest {
   }
   
   @Test
-  public void testRandomNumbers() {
+  void testRandomNumbers() {
     LotteryNumbers numbers = LotteryNumbers.createRandom();
     assertEquals(numbers.getNumbers().size(), LotteryNumbers.NUM_NUMBERS);
   }
   
   @Test
-  public void testEquals() {
+  void testEquals() {
     LotteryNumbers numbers1 = LotteryNumbers.create(
             new HashSet<>(Arrays.asList(1, 2, 3, 4)));
     LotteryNumbers numbers2 = LotteryNumbers.create(
             new HashSet<>(Arrays.asList(1, 2, 3, 4)));
-    assertTrue(numbers1.equals(numbers2));
+    assertEquals(numbers1, numbers2);
     LotteryNumbers numbers3 = LotteryNumbers.create(
             new HashSet<>(Arrays.asList(11, 12, 13, 14)));
-    assertFalse(numbers1.equals(numbers3));
+    assertNotEquals(numbers1, numbers3);
   }
 }

--- a/hexagonal/src/test/java/com/iluwatar/hexagonal/domain/LotteryTest.java
+++ b/hexagonal/src/test/java/com/iluwatar/hexagonal/domain/LotteryTest.java
@@ -38,6 +38,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -45,7 +46,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Test the lottery system
  *
  */
-public class LotteryTest {
+class LotteryTest {
 
   private Injector injector;
   @Inject
@@ -55,22 +56,22 @@ public class LotteryTest {
   @Inject
   private WireTransfers wireTransfers;
 
-  public LotteryTest() {
+  LotteryTest() {
     this.injector = Guice.createInjector(new LotteryTestingModule());
   }
 
   @BeforeEach
-  public void setup() {
+  void setup() {
     injector.injectMembers(this);
     // add funds to the test player's bank account
     wireTransfers.setFunds("123-12312", 100);
   }
   
   @Test
-  public void testLottery() {
+  void testLottery() {
     // admin resets the lottery
     administration.resetLottery();
-    assertEquals(administration.getAllSubmittedTickets().size(), 0);
+    assertEquals(0, administration.getAllSubmittedTickets().size());
     
     // players submit the lottery tickets
     Optional<LotteryTicketId> ticket1 = service.submitTicket(LotteryTestUtils.createLotteryTicket("cvt@bbb.com",
@@ -82,7 +83,7 @@ public class LotteryTest {
     Optional<LotteryTicketId> ticket3 = service.submitTicket(LotteryTestUtils.createLotteryTicket("arg@boo.com",
         "123-12312", "+32421255", new HashSet<>(Arrays.asList(6, 8, 13, 19))));
     assertTrue(ticket3.isPresent());
-    assertEquals(administration.getAllSubmittedTickets().size(), 3);
+    assertEquals(3, administration.getAllSubmittedTickets().size());
     
     // perform lottery
     LotteryNumbers winningNumbers = administration.performLottery();
@@ -91,23 +92,23 @@ public class LotteryTest {
     Optional<LotteryTicketId> ticket4 = service.submitTicket(LotteryTestUtils.createLotteryTicket("lucky@orb.com",
         "123-12312", "+12421255", winningNumbers.getNumbers()));
     assertTrue(ticket4.isPresent());
-    assertEquals(administration.getAllSubmittedTickets().size(), 4);
+    assertEquals(4, administration.getAllSubmittedTickets().size());
     
     // check winners
     Map<LotteryTicketId, LotteryTicket> tickets = administration.getAllSubmittedTickets();
     for (LotteryTicketId id: tickets.keySet()) {
       LotteryTicketCheckResult checkResult = service.checkTicketForPrize(id, winningNumbers);
-      assertTrue(checkResult.getResult() != CheckResult.TICKET_NOT_SUBMITTED);
+      assertNotEquals(CheckResult.TICKET_NOT_SUBMITTED, checkResult.getResult());
       if (checkResult.getResult().equals(CheckResult.WIN_PRIZE)) {
         assertTrue(checkResult.getPrizeAmount() > 0);
       } else if (checkResult.getResult().equals(CheckResult.WIN_PRIZE)) {
-        assertEquals(checkResult.getPrizeAmount(), 0);
+        assertEquals(0, checkResult.getPrizeAmount());
       }
     }
     
     // check another ticket that has not been submitted
     LotteryTicketCheckResult checkResult = service.checkTicketForPrize(new LotteryTicketId(), winningNumbers);
-    assertTrue(checkResult.getResult() == CheckResult.TICKET_NOT_SUBMITTED);
-    assertEquals(checkResult.getPrizeAmount(), 0);
+    assertEquals(CheckResult.TICKET_NOT_SUBMITTED, checkResult.getResult());
+    assertEquals(0, checkResult.getPrizeAmount());
   }
 }

--- a/hexagonal/src/test/java/com/iluwatar/hexagonal/domain/LotteryTicketCheckResultTest.java
+++ b/hexagonal/src/test/java/com/iluwatar/hexagonal/domain/LotteryTicketCheckResultTest.java
@@ -26,21 +26,21 @@ import com.iluwatar.hexagonal.domain.LotteryTicketCheckResult.CheckResult;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 /**
  * 
  * Unit tests for {@link LotteryTicketCheckResult}
  *
  */
-public class LotteryTicketCheckResultTest {
+class LotteryTicketCheckResultTest {
 
   @Test
-  public void testEquals() {
+  void testEquals() {
     LotteryTicketCheckResult result1 = new LotteryTicketCheckResult(CheckResult.NO_PRIZE);
     LotteryTicketCheckResult result2 = new LotteryTicketCheckResult(CheckResult.NO_PRIZE);
     assertEquals(result1, result2);
     LotteryTicketCheckResult result3 = new LotteryTicketCheckResult(CheckResult.WIN_PRIZE, 300000);
-    assertFalse(result1.equals(result3));
+    assertNotEquals(result1, result3);
   } 
 }

--- a/hexagonal/src/test/java/com/iluwatar/hexagonal/domain/LotteryTicketIdTest.java
+++ b/hexagonal/src/test/java/com/iluwatar/hexagonal/domain/LotteryTicketIdTest.java
@@ -24,22 +24,22 @@ package com.iluwatar.hexagonal.domain;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 /**
  * Tests for lottery ticket id
  */
-public class LotteryTicketIdTest {
+class LotteryTicketIdTest {
 
   @Test
-  public void testEquals() {
+  void testEquals() {
     LotteryTicketId ticketId1 = new LotteryTicketId();
     LotteryTicketId ticketId2 = new LotteryTicketId();
     LotteryTicketId ticketId3 = new LotteryTicketId();
-    assertFalse(ticketId1.equals(ticketId2));
-    assertFalse(ticketId2.equals(ticketId3));
+    assertNotEquals(ticketId1, ticketId2);
+    assertNotEquals(ticketId2, ticketId3);
     LotteryTicketId ticketId4 = new LotteryTicketId(ticketId1.getId());
-    assertTrue(ticketId1.equals(ticketId4));
+    assertEquals(ticketId1, ticketId4);
   }
 }

--- a/hexagonal/src/test/java/com/iluwatar/hexagonal/domain/LotteryTicketTest.java
+++ b/hexagonal/src/test/java/com/iluwatar/hexagonal/domain/LotteryTicketTest.java
@@ -29,14 +29,15 @@ import java.util.HashSet;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 /**
  * Test Lottery Tickets for equality
  */
-public class LotteryTicketTest {
+class LotteryTicketTest {
 
   @Test
-  public void testEquals() {
+  void testEquals() {
     PlayerDetails details1 = new PlayerDetails("bob@foo.bar", "1212-121212", "+34332322");
     LotteryNumbers numbers1 = LotteryNumbers.create(new HashSet<Integer>(Arrays.asList(1, 2, 3, 4)));
     LotteryTicket ticket1 = new LotteryTicket(new LotteryTicketId(), details1, numbers1);
@@ -47,6 +48,6 @@ public class LotteryTicketTest {
     PlayerDetails details3 = new PlayerDetails("elsa@foo.bar", "1223-121212", "+49332322");
     LotteryNumbers numbers3 = LotteryNumbers.create(new HashSet<Integer>(Arrays.asList(1, 2, 3, 8)));
     LotteryTicket ticket3 = new LotteryTicket(new LotteryTicketId(), details3, numbers3);
-    assertFalse(ticket1.equals(ticket3));
+    assertNotEquals(ticket1, ticket3);
   }
 }

--- a/hexagonal/src/test/java/com/iluwatar/hexagonal/domain/PlayerDetailsTest.java
+++ b/hexagonal/src/test/java/com/iluwatar/hexagonal/domain/PlayerDetailsTest.java
@@ -25,21 +25,21 @@ package com.iluwatar.hexagonal.domain;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 /**
  * 
  * Unit tests for {@link PlayerDetails}
  *
  */
-public class PlayerDetailsTest {
+class PlayerDetailsTest {
 
   @Test
-  public void testEquals() {
+  void testEquals() {
     PlayerDetails details1 = new PlayerDetails("tom@foo.bar", "11212-123434", "+12323425");
     PlayerDetails details2 = new PlayerDetails("tom@foo.bar", "11212-123434", "+12323425");
     assertEquals(details1, details2);
     PlayerDetails details3 = new PlayerDetails("john@foo.bar", "16412-123439", "+34323432");
-    assertFalse(details1.equals(details3));
+    assertNotEquals(details1, details3);
   }  
 }

--- a/hexagonal/src/test/java/com/iluwatar/hexagonal/eventlog/MongoEventLogTest.java
+++ b/hexagonal/src/test/java/com/iluwatar/hexagonal/eventlog/MongoEventLogTest.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * Tests for Mongo event log
  */
 @Disabled
-public class MongoEventLogTest {
+class MongoEventLogTest {
 
   private static final String TEST_DB = "lotteryDBTest";
   private static final String TEST_EVENTS_COLLECTION = "testEvents";
@@ -43,7 +43,7 @@ public class MongoEventLogTest {
   private MongoEventLog mongoEventLog;
 
   @BeforeEach
-  public void init() {
+  void init() {
     MongoConnectionPropertiesLoader.load();
     MongoClient mongoClient = new MongoClient(System.getProperty("mongo-host"),
         Integer.parseInt(System.getProperty("mongo-port")));
@@ -53,12 +53,12 @@ public class MongoEventLogTest {
   }
 
   @Test
-  public void testSetup() {
+  void testSetup() {
     assertEquals(0, mongoEventLog.getEventsCollection().count());
   }
 
   @Test
-  public void testFundTransfers() {
+  void testFundTransfers() {
     PlayerDetails playerDetails = new PlayerDetails("john@wayne.com", "000-000", "03432534543");
     mongoEventLog.prizeError(playerDetails, 1000);
     assertEquals(1, mongoEventLog.getEventsCollection().count());


### PR DESCRIPTION
- Refactored LotteryNumbers to use Joiner from guava library to join lottery numbers. 
- Solved potential thread safety issue in LotteryTicketId class, where it was using raw primitive value and incrementing it which is not thread-safe. So used AtomicInteger for brevity 
- assertEquals arguments were in incorrect order at many places, so changed order of those
- Replaced assertFalse and assertTrue at some places with assertEquals and assertNotEquals for reducing complexity of code
-  Removed public modifiers from test cases, as they are no more needed by JUnit 5
