### PR TITLE
Fix intermittent failure in Balking pattern describe in #699

### DIFF
--- a/balking/src/test/java/com/iluwatar/balking/WashingMachineTest.java
+++ b/balking/src/test/java/com/iluwatar/balking/WashingMachineTest.java
@@ -22,14 +22,13 @@
  */
 package com.iluwatar.balking;
 
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link WashingMachine}
@@ -38,12 +37,14 @@ public class WashingMachineTest {
 
   private volatile WashingMachineState machineStateGlobal;
 
-  @Disabled
   @Test
   public void wash() throws Exception {
     WashingMachine washingMachine = new WashingMachine();
     ExecutorService executorService = Executors.newFixedThreadPool(2);
-    executorService.execute(washingMachine::wash);
+    executorService.execute(() -> {
+        washingMachine.wash();
+        machineStateGlobal = washingMachine.getWashingMachineState();
+      });
     executorService.execute(() -> {
       washingMachine.wash();
       machineStateGlobal = washingMachine.getWashingMachineState();

--- a/balking/src/test/java/com/iluwatar/balking/WashingMachineTest.java
+++ b/balking/src/test/java/com/iluwatar/balking/WashingMachineTest.java
@@ -42,9 +42,9 @@ public class WashingMachineTest {
     WashingMachine washingMachine = new WashingMachine();
     ExecutorService executorService = Executors.newFixedThreadPool(2);
     executorService.execute(() -> {
-        washingMachine.wash();
-        machineStateGlobal = washingMachine.getWashingMachineState();
-      });
+      washingMachine.wash();
+      machineStateGlobal = washingMachine.getWashingMachineState();
+    });
     executorService.execute(() -> {
       washingMachine.wash();
       machineStateGlobal = washingMachine.getWashingMachineState();


### PR DESCRIPTION
Fix intermittent failure

- Enable the "wash" test for the Balking pattern

Solves #699 

- The problem here was that sometimes, the ExecutorService execute the second instruction instead of the first one.
We can see it in the log file : https://api.travis-ci.org/v3/job/329176022/log.txt
(the pool-1-thread-2 was launch before).
So the machineStateGlobal variable was set to ENABLED.

- The fix proposed here is to set the machineStateGlobal variable for each execution. It will not depend anymore on the order.
