### PR TITLE
Fix script blocking of presentations due to address used to download remark.js

### DIFF
--- a/abstract-factory/etc/presentation.html
+++ b/abstract-factory/etc/presentation.html
@@ -181,7 +181,7 @@ Use the Abstract Factory pattern when:
 * Source code http://java-design-patterns.com/patterns/abstract-factory/
 
     </textarea>
-    <script src="https://gnab.github.io/remark/downloads/remark-latest.min.js">
+    <script src="https://remarkjs.com/downloads/remark-latest.min.js">
     </script>
     <script>
       var slideshow = remark.create();

--- a/command/etc/presentation.html
+++ b/command/etc/presentation.html
@@ -234,7 +234,7 @@ Use the Command pattern when you want to:
 * Source code http://java-design-patterns.com/patterns/command/
 
     </textarea>
-    <script src="https://gnab.github.io/remark/downloads/remark-latest.min.js">
+    <script src="https://remarkjs.com/downloads/remark-latest.min.js">
     </script>
     <script>
       var slideshow = remark.create();

--- a/factory-method/etc/presentation.html
+++ b/factory-method/etc/presentation.html
@@ -176,7 +176,7 @@ Use the Factory Method pattern when:
 * Source code http://java-design-patterns.com/patterns/factory-method/
 
     </textarea>
-    <script src="https://gnab.github.io/remark/downloads/remark-latest.min.js">
+    <script src="https://remarkjs.com/downloads/remark-latest.min.js">
     </script>
     <script>
       var slideshow = remark.create();


### PR DESCRIPTION
Sometimes the presentations would fail due to the content of remark.js being delivered through unauthenticated source.

The new source seems to work successfully.