### PR TITLE
Rejuvenate log levels

### DIFF
--- a/data-bus/src/main/java/com/iluwatar/databus/members/MessageCollectorMember.java
+++ b/data-bus/src/main/java/com/iluwatar/databus/members/MessageCollectorMember.java
@@ -57,7 +57,7 @@ public class MessageCollectorMember implements Member {
   }
 
   private void handleEvent(MessageData data) {
-    LOGGER.info(String.format("%s sees message %s", name, data.getMessage()));
+    LOGGER.finest(String.format("%s sees message %s", name, data.getMessage()));
     messages.add(data.getMessage());
   }
 


### PR DESCRIPTION
## Introduction

We are in the process of evaluating our [research prototype Eclipse plug-in](https://github.com/ponder-lab/Logging-Level-Evolution-Plugin) that "rejuvenates" log statement levels based on how "interesting" the enclosing methods are to the developers. The assumption is that methods that are worked on more and more recently by developers should have higher log levels (e.g., INFO as compared to FINEST). Our end goal is to reduce information overload, as well as alleviate developers from manually making log level changes.

The transformation decision is made by analyzing the "degree of interest" (DOI) values of enclosing methods for logging invocations. DOI value is a kind of real number for a program element which shows how developers are interested in it. It is computed from the interaction events between developer and element, such as developer edits the element. In this project, we compute the DOI using the project's git history.

We are looking for feedback on our tool from developers. If you can, we would appreciate if you can **comment on each of the transformations** in the case that this PR is not accepted. Of course, we would also love to contribute to your project.

## Transformed Logging Statements

Here is a list of DOI values for enclosing methods of transformed log invocations in your projects:

log expression | original log level | transformed log level | type FQN | enclosing method | DOI value
-- | -- | -- | -- | -- | --
LOGGER.info(String.format("%s   sees message %s",name,data.getMessage())) | INFO | FINEST | com.iluwatar.databus.members.MessageCollectorMember | handleEvent(com.iluwatar.databus.data.MessageData) | 0.394


## Settings

We have several settings to analyze these DOI values. The settings we are using in this pull request are:
- Treat CONFIG/WARNING/SEVERE level as a category and not a traditional level, i.e., our tool ignores CONFIG/WARNING/SEVERE log level (setting 1).
- Never lower the logging level of logging statements within catch blocks (setting 2).
- The number of commits evaluated: 1000 (setting 3).

Head: b6b4602baf5a12d8b76b3f8dd0284bae44230aa9

We can vary these settings and rerun our if you desire.

## DOI Intervals

For your information, we also generate a list of DOI value intervals. Given this list, our tool could rejuvenate log levels by knowing which intervals the DOI values of enclosing methods for log invocations are in:

subject | DOI boundary | log level
-- | -- | --
abstract-document | [0.0, 0.654) | FINEST
abstract-document | [0.654, 1.308) | FINER
abstract-document | [1.308, 1.9619999) | FINE
abstract-document | [1.9619999, 2.616) | INFO
abstract-factory | [0.0, 1.3447499) | FINEST
abstract-factory | [1.3447499, 2.6894999) | FINER
abstract-factory | [2.6894999, 4.03425) | FINE
abstract-factory | [4.03425, 5.3789997) | INFO
acyclic-visitor | [0.0, 0.90549994) | FINEST
acyclic-visitor | [0.90549994, 1.8109999) | FINER
acyclic-visitor | [1.8109999, 2.7164998) | FINE
acyclic-visitor | [2.7164998, 3.6219997) | INFO
adapter | [0.0, 0.8495) | FINEST
adapter | [0.8495, 1.699) | FINER
adapter | [1.699, 2.5485) | FINE
adapter | [2.5485, 3.398) | INFO
aggregator-service | [0.0, 0.49525) | FINEST
aggregator-service | [0.49525, 0.9905) | FINER
aggregator-service | [0.9905, 1.48575) | FINE
aggregator-service | [1.48575, 1.981) | INFO
ambassador | [0.0, 1.6615) | FINEST
ambassador | [1.6615, 3.323) | FINER
ambassador | [3.323, 4.9845) | FINE
ambassador | [4.9845, 6.646) | INFO
api-gateway-service | [0.0, 0.175) | FINEST
api-gateway-service | [0.175, 0.35) | FINER
api-gateway-service | [0.35, 0.525) | FINE
api-gateway-service | [0.525, 0.7) | INFO
async-method-invocation | [0.0, 1.2937499) | FINEST
async-method-invocation | [1.2937499, 2.5874999) | FINER
async-method-invocation | [2.5874999, 3.88125) | FINE
async-method-invocation | [3.88125, 5.1749997) | INFO
balking | [0.0, 0.824) | FINEST
balking | [0.824, 1.648) | FINER
balking | [1.648, 2.4720001) | FINE
balking | [2.4720001, 3.296) | INFO
bridge | [0.0, 1.1782501) | FINEST
bridge | [1.1782501, 2.3565001) | FINER
bridge | [2.3565001, 3.5347502) | FINE
bridge | [3.5347502, 4.7130003) | INFO
builder | [0.0, 1.14425) | FINEST
builder | [1.14425, 2.2885) | FINER
builder | [2.2885, 3.4327502) | FINE
builder | [3.4327502, 4.577) | INFO
business-delegate | [0.0, 0.34149998) | FINEST
business-delegate | [0.34149998, 0.68299997) | FINER
business-delegate | [0.68299997, 1.0244999) | FINE
business-delegate | [1.0244999, 1.3659999) | INFO
caching | [0.0, 0.87999994) | FINEST
caching | [0.87999994, 1.7599999) | FINER
caching | [1.7599999, 2.6399999) | FINE
caching | [2.6399999, 3.5199997) | INFO
callback | [0.0, 0.68299997) | FINEST
callback | [0.68299997, 1.3659999) | FINER
callback | [1.3659999, 2.0489998) | FINE
callback | [2.0489998, 2.7319999) | INFO
chain | [0.0, 0.34575) | FINEST
chain | [0.34575, 0.6915) | FINER
chain | [0.6915, 1.03725) | FINE
chain | [1.03725, 1.383) | INFO
collection-pipeline | [0.0, 1.1535) | FINEST
collection-pipeline | [1.1535, 2.307) | FINER
collection-pipeline | [2.307, 3.4604998) | FINE
collection-pipeline | [3.4604998, 4.614) | INFO
command | [0.0, 0.68724996) | FINEST
command | [0.68724996, 1.3744999) | FINER
command | [1.3744999, 2.06175) | FINE
command | [2.06175, 2.7489998) | INFO
composite | [0.0, 0.80275) | FINEST
composite | [0.80275, 1.6055) | FINER
composite | [1.6055, 2.4082499) | FINE
composite | [2.4082499, 3.211) | INFO
converter | [0.0, 0.96575) | FINEST
converter | [0.96575, 1.9315) | FINER
converter | [1.9315, 2.89725) | FINE
converter | [2.89725, 3.863) | INFO
cqrs | [0.0, 0.62424994) | FINEST
cqrs | [0.62424994, 1.2484999) | FINER
cqrs | [1.2484999, 1.8727498) | FINE
cqrs | [1.8727498, 2.4969997) | INFO
dao | [0.0, 1.6750001) | FINEST
dao | [1.6750001, 3.3500001) | FINER
dao | [3.3500001, 5.025) | FINE
dao | [5.025, 6.7000003) | INFO
data-bus | [0.0, 0.40174997) | FINEST
data-bus | [0.40174997, 0.80349994) | FINER
data-bus | [0.80349994, 1.2052499) | FINE
data-bus | [1.2052499, 1.6069999) | INFO
data-mapper | [0.0, 2.5797498) | FINEST
data-mapper | [2.5797498, 5.1594996) | FINER
data-mapper | [5.1594996, 7.739249) | FINE
data-mapper | [7.739249, 10.318999) | INFO
data-transfer-object | [0.0, 1.16125) | FINEST
data-transfer-object | [1.16125, 2.3225) | FINER
data-transfer-object | [2.3225, 3.4837499) | FINE
data-transfer-object | [3.4837499, 4.645) | INFO
decorator | [0.0, 1.43475) | FINEST
decorator | [1.43475, 2.8695) | FINER
decorator | [2.8695, 4.30425) | FINE
decorator | [4.30425, 5.739) | INFO
delegation | [0.0, 0.34149998) | FINEST
delegation | [0.34149998, 0.68299997) | FINER
delegation | [0.68299997, 1.0244999) | FINE
delegation | [1.0244999, 1.3659999) | INFO
dependency-injection | [0.0, 1.123) | FINEST
dependency-injection | [1.123, 2.246) | FINER
dependency-injection | [2.246, 3.369) | FINE
dependency-injection | [3.369, 4.492) | INFO
dirty-flag | [0.0, 0.7815) | FINEST
dirty-flag | [0.7815, 1.563) | FINER
dirty-flag | [1.563, 2.3445) | FINE
dirty-flag | [2.3445, 3.126) | INFO
double-checked-locking | [0.0, 1.5027499) | FINEST
double-checked-locking | [1.5027499, 3.0054998) | FINER
double-checked-locking | [3.0054998, 4.5082498) | FINE
double-checked-locking | [4.5082498, 6.0109997) | INFO
double-dispatch | [0.0, 0.62775) | FINEST
double-dispatch | [0.62775, 1.2555) | FINER
double-dispatch | [1.2555, 1.88325) | FINE
double-dispatch | [1.88325, 2.511) | INFO
eip-aggregator | [0.0, 0.49525) | FINEST
eip-aggregator | [0.49525, 0.9905) | FINER
eip-aggregator | [0.9905, 1.48575) | FINE
eip-aggregator | [1.48575, 1.981) | INFO
eip-message-channel | [0.0, 0.175) | FINEST
eip-message-channel | [0.175, 0.35) | FINER
eip-message-channel | [0.35, 0.525) | FINE
eip-message-channel | [0.525, 0.7) | INFO
eip-publish-subscribe | [0.0, 0.175) | FINEST
eip-publish-subscribe | [0.175, 0.35) | FINER
eip-publish-subscribe | [0.35, 0.525) | FINE
eip-publish-subscribe | [0.525, 0.7) | INFO
eip-splitter | [0.0, 0.333) | FINEST
eip-splitter | [0.333, 0.666) | FINER
eip-splitter | [0.666, 0.999) | FINE
eip-splitter | [0.999, 1.332) | INFO
eip-wire-tap | [0.0, 0.508) | FINEST
eip-wire-tap | [0.508, 1.016) | FINER
eip-wire-tap | [1.016, 1.524) | FINE
eip-wire-tap | [1.524, 2.032) | INFO
event-aggregator | [0.0, 0.48674998) | FINEST
event-aggregator | [0.48674998, 0.97349995) | FINER
event-aggregator | [0.97349995, 1.4602499) | FINE
event-aggregator | [1.4602499, 1.9469999) | INFO
event-asynchronous | [0.0, 5.7609997) | FINEST
event-asynchronous | [5.7609997, 11.521999) | FINER
event-asynchronous | [11.521999, 17.282999) | FINE
event-asynchronous | [17.282999, 23.043999) | INFO
event-driven-architecture | [0.0, 0.841) | FINEST
event-driven-architecture | [0.841, 1.682) | FINER
event-driven-architecture | [1.682, 2.523) | FINE
event-driven-architecture | [2.523, 3.364) | INFO
event-queue | [0.0, 2.1865) | FINEST
event-queue | [2.1865, 4.373) | FINER
event-queue | [4.373, 6.5595) | FINE
event-queue | [6.5595, 8.746) | INFO
event-sourcing | [0.0, 5.50875) | FINEST
event-sourcing | [5.50875, 11.0175) | FINER
event-sourcing | [11.0175, 16.526249) | FINE
event-sourcing | [16.526249, 22.035) | INFO
execute-around | [0.0, 0.67875) | FINEST
execute-around | [0.67875, 1.3575) | FINER
execute-around | [1.3575, 2.0362499) | FINE
execute-around | [2.0362499, 2.715) | INFO
extension-objects | [0.0, 0.93175) | FINEST
extension-objects | [0.93175, 1.8635) | FINER
extension-objects | [1.8635, 2.79525) | FINE
extension-objects | [2.79525, 3.727) | INFO
facade | [0.0, 1.5239999) | FINEST
facade | [1.5239999, 3.0479999) | FINER
facade | [3.0479999, 4.5719995) | FINE
facade | [4.5719995, 6.0959997) | INFO
factory-kit | [0.0, 0.50374997) | FINEST
factory-kit | [0.50374997, 1.0074999) | FINER
factory-kit | [1.0074999, 1.5112499) | FINE
factory-kit | [1.5112499, 2.0149999) | INFO
factory-method | [0.0, 0.50374997) | FINEST
factory-method | [0.50374997, 1.0074999) | FINER
factory-method | [1.0074999, 1.5112499) | FINE
factory-method | [1.5112499, 2.0149999) | INFO
feature-toggle | [0.0, 1.1145) | FINEST
feature-toggle | [1.1145, 2.229) | FINER
feature-toggle | [2.229, 3.3435001) | FINE
feature-toggle | [3.3435001, 4.458) | INFO
fluentinterface | [0.0, 4.7264996) | FINEST
fluentinterface | [4.7264996, 9.452999) | FINER
fluentinterface | [9.452999, 14.179499) | FINE
fluentinterface | [14.179499, 18.905998) | INFO
flux | [0.0, 0.34149998) | FINEST
flux | [0.34149998, 0.68299997) | FINER
flux | [0.68299997, 1.0244999) | FINE
flux | [1.0244999, 1.3659999) | INFO
flyweight | [0.0, 0.34575) | FINEST
flyweight | [0.34575, 0.6915) | FINER
flyweight | [0.6915, 1.03725) | FINE
flyweight | [1.03725, 1.383) | INFO
front-controller | [0.0, 0.49099997) | FINEST
front-controller | [0.49099997, 0.98199993) | FINER
front-controller | [0.98199993, 1.4729999) | FINE
front-controller | [1.4729999, 1.9639999) | INFO
guarded-suspension | [0.0, 0.65325) | FINEST
guarded-suspension | [0.65325, 1.3065) | FINER
guarded-suspension | [1.3065, 1.9597499) | FINE
guarded-suspension | [1.9597499, 2.613) | INFO
half-sync-half-async | [0.0, 0.32025) | FINEST
half-sync-half-async | [0.32025, 0.6405) | FINER
half-sync-half-async | [0.6405, 0.96075) | FINE
half-sync-half-async | [0.96075, 1.281) | INFO
hexagonal | [0.0, 6.27975) | FINEST
hexagonal | [6.27975, 12.5595) | FINER
hexagonal | [12.5595, 18.839249) | FINE
hexagonal | [18.839249, 25.119) | INFO
image-microservice | [0.0, 0.34575) | FINEST
image-microservice | [0.34575, 0.6915) | FINER
image-microservice | [0.6915, 1.03725) | FINE
image-microservice | [1.03725, 1.383) | INFO
information-microservice | [0.0, 0.34575) | FINEST
information-microservice | [0.34575, 0.6915) | FINER
information-microservice | [0.6915, 1.03725) | FINE
information-microservice | [1.03725, 1.383) | INFO
intercepting-filter | [0.0, 0.46975) | FINEST
intercepting-filter | [0.46975, 0.9395) | FINER
intercepting-filter | [0.9395, 1.40925) | FINE
intercepting-filter | [1.40925, 1.879) | INFO
interpreter | [0.0, 0.92249995) | FINEST
interpreter | [0.92249995, 1.8449999) | FINER
interpreter | [1.8449999, 2.7675) | FINE
interpreter | [2.7675, 3.6899998) | INFO
inventory-microservice | [0.0, 0.68724996) | FINEST
inventory-microservice | [0.68724996, 1.3744999) | FINER
inventory-microservice | [1.3744999, 2.06175) | FINE
inventory-microservice | [2.06175, 2.7489998) | INFO
iterator | [0.0, 1.3284999) | FINEST
iterator | [1.3284999, 2.6569998) | FINER
iterator | [2.6569998, 3.9854999) | FINE
iterator | [3.9854999, 5.3139997) | INFO
layers | [0.0, 0.46975) | FINEST
layers | [0.46975, 0.9395) | FINER
layers | [0.9395, 1.40925) | FINE
layers | [1.40925, 1.879) | INFO
lazy-loading | [0.0, 0.666) | FINEST
lazy-loading | [0.666, 1.332) | FINER
lazy-loading | [1.332, 1.998) | FINE
lazy-loading | [1.998, 2.664) | INFO
marker | [0.0, 1.32775) | FINEST
marker | [1.32775, 2.6555) | FINER
marker | [2.6555, 3.98325) | FINE
marker | [3.98325, 5.311) | INFO
master-worker-pattern | [0.0, 0.175) | FINEST
master-worker-pattern | [0.175, 0.35) | FINER
master-worker-pattern | [0.35, 0.525) | FINE
master-worker-pattern | [0.525, 0.7) | INFO
mediator | [0.0, 0.34149998) | FINEST
mediator | [0.34149998, 0.68299997) | FINER
mediator | [0.68299997, 1.0244999) | FINE
mediator | [1.0244999, 1.3659999) | INFO
memento | [0.0, 1.1995) | FINEST
memento | [1.1995, 2.399) | FINER
memento | [2.399, 3.5984998) | FINE
memento | [3.5984998, 4.798) | INFO
model-view-controller | [0.0, 0.51224995) | FINEST
model-view-controller | [0.51224995, 1.0244999) | FINER
model-view-controller | [1.0244999, 1.5367498) | FINE
model-view-controller | [1.5367498, 2.0489998) | INFO
model-view-presenter | [0.0, 0.68299997) | FINEST
model-view-presenter | [0.68299997, 1.3659999) | FINER
model-view-presenter | [1.3659999, 2.0489998) | FINE
model-view-presenter | [2.0489998, 2.7319999) | INFO
module | [0.0, 1.1924999) | FINEST
module | [1.1924999, 2.3849998) | FINER
module | [2.3849998, 3.5774996) | FINE
module | [3.5774996, 4.7699995) | INFO
monad | [0.0, 0.49525) | FINEST
monad | [0.49525, 0.9905) | FINER
monad | [0.9905, 1.48575) | FINE
monad | [1.48575, 1.981) | INFO
monostate | [0.0, 0.666) | FINEST
monostate | [0.666, 1.332) | FINER
monostate | [1.332, 1.998) | FINE
monostate | [1.998, 2.664) | INFO
multiton | [0.0, 0.68299997) | FINEST
multiton | [0.68299997, 1.3659999) | FINER
multiton | [1.3659999, 2.0489998) | FINE
multiton | [2.0489998, 2.7319999) | INFO
mute-idiom | [0.0, 1.2129999) | FINEST
mute-idiom | [1.2129999, 2.4259999) | FINER
mute-idiom | [2.4259999, 3.639) | FINE
mute-idiom | [3.639, 4.8519998) | INFO
mutex | [0.0, 0.807) | FINEST
mutex | [0.807, 1.614) | FINER
mutex | [1.614, 2.421) | FINE
mutex | [2.421, 3.228) | INFO
naked-objects-dom | [0.0, 1.02875) | FINEST
naked-objects-dom | [1.02875, 2.0575) | FINER
naked-objects-dom | [2.0575, 3.0862498) | FINE
naked-objects-dom | [3.0862498, 4.115) | INFO
naked-objects-integtests | [0.0, 0.96925) | FINEST
naked-objects-integtests | [0.96925, 1.9385) | FINER
naked-objects-integtests | [1.9385, 2.9077501) | FINE
naked-objects-integtests | [2.9077501, 3.877) | INFO
null-object | [0.0, 0.3245) | FINEST
null-object | [0.3245, 0.649) | FINER
null-object | [0.649, 0.9735) | FINE
null-object | [0.9735, 1.298) | INFO
object-mother | [0.0, 0.48249996) | FINEST
object-mother | [0.48249996, 0.9649999) | FINER
object-mother | [0.9649999, 1.4474999) | FINE
object-mother | [1.4474999, 1.9299998) | INFO
object-pool | [0.0, 2.02775) | FINEST
object-pool | [2.02775, 4.0555) | FINER
object-pool | [4.0555, 6.08325) | FINE
object-pool | [6.08325, 8.111) | INFO
observer | [0.0, 0.6115) | FINEST
observer | [0.6115, 1.223) | FINER
observer | [1.223, 1.8345001) | FINE
observer | [1.8345001, 2.446) | INFO
partial-response | [0.0, 1.4177499) | FINEST
partial-response | [1.4177499, 2.8354998) | FINER
partial-response | [2.8354998, 4.2532496) | FINE
partial-response | [4.2532496, 5.6709995) | INFO
poison-pill | [0.0, 0.49099997) | FINEST
poison-pill | [0.49099997, 0.98199993) | FINER
poison-pill | [0.98199993, 1.4729999) | FINE
poison-pill | [1.4729999, 1.9639999) | INFO
price-microservice | [0.0, 0.34575) | FINEST
price-microservice | [0.34575, 0.6915) | FINER
price-microservice | [0.6915, 1.03725) | FINE
price-microservice | [1.03725, 1.383) | INFO
private-class-data | [0.0, 0.6235) | FINEST
private-class-data | [0.6235, 1.247) | FINER
private-class-data | [1.247, 1.8705) | FINE
private-class-data | [1.8705, 2.494) | INFO
producer-consumer | [0.0, 0.858) | FINEST
producer-consumer | [0.858, 1.716) | FINER
producer-consumer | [1.716, 2.574) | FINE
producer-consumer | [2.574, 3.432) | INFO
promise | [0.0, 2.5124998) | FINEST
promise | [2.5124998, 5.0249996) | FINER
promise | [5.0249996, 7.5374994) | FINE
promise | [7.5374994, 10.049999) | INFO
property | [0.0, 0.84525) | FINEST
property | [0.84525, 1.6905) | FINER
property | [1.6905, 2.53575) | FINE
property | [2.53575, 3.381) | INFO
prototype | [0.0, 0.66674995) | FINEST
prototype | [0.66674995, 1.3334999) | FINER
prototype | [1.3334999, 2.0002499) | FINE
prototype | [2.0002499, 2.6669998) | INFO
proxy | [0.0, 0.43149996) | FINEST
proxy | [0.43149996, 0.8629999) | FINER
proxy | [0.8629999, 1.2944999) | FINE
proxy | [1.2944999, 1.7259998) | INFO
queue-load-leveling | [0.0, 0.666) | FINEST
queue-load-leveling | [0.666, 1.332) | FINER
queue-load-leveling | [1.332, 1.998) | FINE
queue-load-leveling | [1.998, 2.664) | INFO
reactor | [0.0, 0.722) | FINEST
reactor | [0.722, 1.444) | FINER
reactor | [1.444, 2.166) | FINE
reactor | [2.166, 2.888) | INFO
reader-writer-lock | [0.0, 0.98275) | FINEST
reader-writer-lock | [0.98275, 1.9655) | FINER
reader-writer-lock | [1.9655, 2.94825) | FINE
reader-writer-lock | [2.94825, 3.931) | INFO
repository | [0.0, 1.4814999) | FINEST
repository | [1.4814999, 2.9629998) | FINER
repository | [2.9629998, 4.4445) | FINE
repository | [4.4445, 5.9259996) | INFO
resource-acquisition-is-initialization | [0.0, 0.48674998) | FINEST
resource-acquisition-is-initialization | [0.48674998, 0.97349995) | FINER
resource-acquisition-is-initialization | [0.97349995, 1.4602499) | FINE
resource-acquisition-is-initialization | [1.4602499, 1.9469999) | INFO
retry | [0.0, 0.85024995) | FINEST
retry | [0.85024995, 1.7004999) | FINER
retry | [1.7004999, 2.5507498) | FINE
retry | [2.5507498, 3.4009998) | INFO
sample-application | [0.0, 0.34149998) | FINEST
sample-application | [0.34149998, 0.68299997) | FINER
sample-application | [0.68299997, 1.0244999) | FINE
sample-application | [1.0244999, 1.3659999) | INFO
semaphore | [0.0, 0.8155) | FINEST
semaphore | [0.8155, 1.631) | FINER
semaphore | [1.631, 2.4465) | FINE
semaphore | [2.4465, 3.262) | INFO
servant | [0.0, 0.48674998) | FINEST
servant | [0.48674998, 0.97349995) | FINER
servant | [0.97349995, 1.4602499) | FINE
servant | [1.4602499, 1.9469999) | INFO
serverless | [0.0, 0.175) | FINEST
serverless | [0.175, 0.35) | FINER
serverless | [0.35, 0.525) | FINE
serverless | [0.525, 0.7) | INFO
service-layer | [0.0, 1.58425) | FINEST
service-layer | [1.58425, 3.1685) | FINER
service-layer | [3.1685, 4.75275) | FINE
service-layer | [4.75275, 6.337) | INFO
service-locator | [0.0, 0.50799996) | FINEST
service-locator | [0.50799996, 1.0159999) | FINER
service-locator | [1.0159999, 1.5239999) | FINE
service-locator | [1.5239999, 2.0319998) | INFO
singleton | [0.0, 1.31925) | FINEST
singleton | [1.31925, 2.6385) | FINER
singleton | [2.6385, 3.9577498) | FINE
singleton | [3.9577498, 5.277) | INFO
spatial-partition | [0.0, 0.44425) | FINEST
spatial-partition | [0.44425, 0.8885) | FINER
spatial-partition | [0.8885, 1.33275) | FINE
spatial-partition | [1.33275, 1.777) | INFO
specification | [0.0, 1.4942499) | FINEST
specification | [1.4942499, 2.9884999) | FINER
specification | [2.9884999, 4.48275) | FINE
specification | [4.48275, 5.9769998) | INFO
state | [0.0, 1.02025) | FINEST
state | [1.02025, 2.0405) | FINER
state | [2.0405, 3.06075) | FINE
state | [3.06075, 4.081) | INFO
step-builder | [0.0, 0.68724996) | FINEST
step-builder | [0.68724996, 1.3744999) | FINER
step-builder | [1.3744999, 2.06175) | FINE
step-builder | [2.06175, 2.7489998) | INFO
strategy | [0.0, 1.2937499) | FINEST
strategy | [1.2937499, 2.5874999) | FINER
strategy | [2.5874999, 3.88125) | FINE
strategy | [3.88125, 5.1749997) | INFO
template-method | [0.0, 0.33725) | FINEST
template-method | [0.33725, 0.6745) | FINER
template-method | [0.6745, 1.01175) | FINE
template-method | [1.01175, 1.349) | INFO
test-automation | [0.0, 0.22674999) | FINEST
test-automation | [0.22674999, 0.45349997) | FINER
test-automation | [0.45349997, 0.6802499) | FINE
test-automation | [0.6802499, 0.90699995) | INFO
thread-pool | [0.0, 1.1995) | FINEST
thread-pool | [1.1995, 2.399) | FINER
thread-pool | [2.399, 3.5984998) | FINE
thread-pool | [3.5984998, 4.798) | INFO
throttling | [0.0, 3.296) | FINEST
throttling | [3.296, 6.592) | FINER
throttling | [6.592, 9.8880005) | FINE
throttling | [9.8880005, 13.184) | INFO
tls | [0.0, 0.41449994) | FINEST
tls | [0.41449994, 0.8289999) | FINER
tls | [0.8289999, 1.2434998) | FINE
tls | [1.2434998, 1.6579998) | INFO
tolerant-reader | [0.0, 1.349) | FINEST
tolerant-reader | [1.349, 2.698) | FINER
tolerant-reader | [2.698, 4.047) | FINE
tolerant-reader | [4.047, 5.396) | INFO
trampoline | [0.0, 1.5885) | FINEST
trampoline | [1.5885, 3.177) | FINER
trampoline | [3.177, 4.7655) | FINE
trampoline | [4.7655, 6.354) | INFO
twin | [0.0, 1.7075) | FINEST
twin | [1.7075, 3.415) | FINER
twin | [3.415, 5.1225) | FINE
twin | [5.1225, 6.83) | INFO
unit-of-work | [0.0, 0.42724997) | FINEST
unit-of-work | [0.42724997, 0.85449994) | FINER
unit-of-work | [0.85449994, 1.28175) | FINE
unit-of-work | [1.28175, 1.7089999) | INFO
value-object | [0.0, 0.50799996) | FINEST
value-object | [0.50799996, 1.0159999) | FINER
value-object | [1.0159999, 1.5239999) | FINE
value-object | [1.5239999, 2.0319998) | INFO
visitor | [0.0, 0.33725) | FINEST
visitor | [0.33725, 0.6745) | FINER
visitor | [0.6745, 1.01175) | FINE
visitor | [1.01175, 1.349) | INFO



