### PR TITLE
fixed failing tests (#860)

### DIFF
--- a/twin/src/test/java/com/iluwatar/twin/BallThreadTest.java
+++ b/twin/src/test/java/com/iluwatar/twin/BallThreadTest.java
@@ -30,11 +30,7 @@ import static java.time.Duration.ofMillis;
 import static org.junit.jupiter.api.Assertions.assertTimeout;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.timeout;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.*;
 
 /**
  * Date: 12/30/15 - 18:55 PM
@@ -55,9 +51,9 @@ public class BallThreadTest {
       ballThread.setTwin(ballItem);
 
       ballThread.start();
-
-      verify(ballItem, timeout(2000).atLeastOnce()).draw();
-      verify(ballItem, timeout(2000).atLeastOnce()).move();
+      sleep(200);
+      verify(ballItem, atLeastOnce()).draw();
+      verify(ballItem, atLeastOnce()).move();
       ballThread.suspendMe();
 
       sleep(1000);
@@ -88,8 +84,9 @@ public class BallThreadTest {
       verifyZeroInteractions(ballItem);
 
       ballThread.resumeMe();
-      verify(ballItem, timeout(2000).atLeastOnce()).draw();
-      verify(ballItem, timeout(2000).atLeastOnce()).move();
+      sleep(200);
+      verify(ballItem, atLeastOnce()).draw();
+      verify(ballItem, atLeastOnce()).move();
 
       ballThread.stopMe();
       ballThread.join();


### PR DESCRIPTION
Bug fix for (#860  )

- fixed the failing tests for twin pattern

Pull request description

- removed the timeout from VerificationMode passed to mockito verify method. This timeout was cause for failure. It seemed redundant as well, as there is a timeout on the test itself. 
- Also, the tests were failing because the ballThread.start wasn't getting started fast enough and the Mockito verify gets called before the thread initialization. 
