### PR TITLE
fix dirty-flag implementation

### DIFF
--- a/dirty-flag/src/main/java/com/iluwatar/dirtyflag/App.java
+++ b/dirty-flag/src/main/java/com/iluwatar/dirtyflag/App.java
@@ -48,6 +48,13 @@ import java.util.concurrent.TimeUnit;
  * when needed. {@link World} mainly serves the data to the front-end.
  */
 public class App {
+
+  private final World world;
+
+  public App(World world) {
+    this.world = world;
+  }
+
   /**
    * Program execution point
    */
@@ -57,7 +64,6 @@ public class App {
     executorService.scheduleAtFixedRate(new Runnable() {
       @Override
       public void run() {
-        World world = new World();
         List<String> countries = world.fetch();
         System.out.println("Our world currently has the following countries:-");
         for (String country : countries) {
@@ -74,7 +80,7 @@ public class App {
    *          command line args
    */
   public static void main(String[] args) {
-    App app = new App();
+    App app = new App(new World());
 
     app.run();
   }

--- a/dirty-flag/src/main/java/com/iluwatar/dirtyflag/DataFetcher.java
+++ b/dirty-flag/src/main/java/com/iluwatar/dirtyflag/DataFetcher.java
@@ -37,7 +37,7 @@ import java.util.List;
  */
 public class DataFetcher {
 
-  private final String filename = "world.txt";
+  private final String filename = "./dirty-flag/src/main/resources/world.txt";
   private long lastFetched;
 
   public DataFetcher() {
@@ -58,8 +58,7 @@ public class DataFetcher {
    * @return List of strings
    */
   public List<String> fetch() {
-    ClassLoader classLoader = getClass().getClassLoader();
-    File file = new File(classLoader.getResource(filename).getFile());
+    File file = new File(filename);
 
     if (isDirty(file.lastModified())) {
       System.out.println(filename + " is dirty! Re-fetching file content...");

--- a/dirty-flag/src/main/java/com/iluwatar/dirtyflag/DataFetcher.java
+++ b/dirty-flag/src/main/java/com/iluwatar/dirtyflag/DataFetcher.java
@@ -37,7 +37,7 @@ import java.util.List;
  */
 public class DataFetcher {
 
-  private final String filename = "./dirty-flag/src/main/resources/world.txt";
+  private final String filename = "./src/main/resources/world.txt";
   private long lastFetched;
 
   public DataFetcher() {


### PR DESCRIPTION
fix two dirty-flag's issues:
 - every time new World is created. It leads that wolds.txt is always dirty. 
-  seems "File file = new File(classLoader.getResource(filename).getFile());" doesn't take into account any updates in the check file during runtime.

Pull request description

- instantiate World only once. it fix the issue with the state;
- replace new File(classLoader.getResource(filename).getFile()); to new File(path) to take into account any changes in world.txt file in runtime;

> For detailed contributing instructions see https://github.com/iluwatar/java-design-patterns/wiki/01.-How-to-contribute
