### PR TITLE
[#449] Added priority queue design pattern

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,9 @@
     LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
     THE SOFTWARE.
---><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.iluwatar</groupId>
     <artifactId>java-design-patterns</artifactId>
@@ -162,10 +164,11 @@
         <module>trampoline</module>
         <module>serverless</module>
         <module>ambassador</module>
-	<module>acyclic-visitor</module>
-	<module>collection-pipeline</module>
-	<module>master-worker-pattern</module>
-	<module>spatial-partition</module>
+        <module>acyclic-visitor</module>
+        <module>collection-pipeline</module>
+        <module>master-worker-pattern</module>
+        <module>spatial-partition</module>
+        <module>priority-queue</module>
     </modules>
 
     <repositories>

--- a/priority-queue/README.md
+++ b/priority-queue/README.md
@@ -1,0 +1,27 @@
+---
+layout: pattern
+title: Priority Queue Pattern
+folder: priority-queue
+permalink: /patterns/priority-queue/
+categories: Behavioral
+tags:
+ - Java
+ - Difficulty-Beginner
+---
+
+## Intent
+Prioritize requests sent to services so that requests with a higher priority are received and processed more quickly than those of a lower priority. This pattern is useful in applications that offer different service level guarantees to individual clients.
+
+## Explanation
+Applications may delegate specific tasks to other services; for example, to perform background processing or to integrate with other applications or services. In the cloud, a message queue is typically used to delegate tasks to background processing. In many cases the order in which requests are received by a service is not important. However, in some cases it may be necessary to prioritize specific requests. These requests should be processed earlier than others of a lower priority that may have been sent previously by the application.
+
+## Applicability
+Use the Property pattern when
+
+* The system must handle multiple tasks that might have different priorities.
+* Different users or tenants should be served with different priority..
+
+## Real world examples
+
+* [ Priority Queue Pattern](https://docs.microsoft.com/en-us/previous-versions/msp-n-p/dn589794(v=pandp.10))
+Microsoft Azure does not provide a queuing mechanism that natively support automatic prioritization of messages through sorting. However, it does provide Azure Service Bus topics and subscriptions, which support a queuing mechanism that provides message filtering, together with a wide range of flexible capabilities that make it ideal for use in almost all priority queue implementations.

--- a/priority-queue/pom.xml
+++ b/priority-queue/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    The MIT License
+    Copyright (c) 2014 Ilkka Seppälä
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>priority-queue</artifactId>
+    <parent>
+        <groupId>com.iluwatar</groupId>
+        <artifactId>java-design-patterns</artifactId>
+        <version>1.21.0-SNAPSHOT</version>
+    </parent>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+
+</project>

--- a/priority-queue/src/main/java/com/iluwatar/priority/queue/Application.java
+++ b/priority-queue/src/main/java/com/iluwatar/priority/queue/Application.java
@@ -1,0 +1,52 @@
+/**
+ * The MIT License
+ * Copyright (c) 2014 Ilkka Seppälä
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * <p>
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * <p>
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.iluwatar.priority.queue;
+
+/**
+ * Example
+ */
+public class Application {
+  /**
+   * main entry
+   */
+  public static void main(String[] args) throws Exception {
+
+    QueueManager queueManager = new QueueManager(100);
+
+    // push some message to queue
+    for (int i = 0; i < 100; i++) {
+      queueManager.publishMessage(new Message("Low Message Priority", 0));
+    }
+
+    for (int i = 0; i < 100; i++) {
+      queueManager.publishMessage(new Message("High Message Priority", 1));
+    }
+
+
+    // run worker
+    Worker worker = new Worker(queueManager);
+    worker.run();
+
+
+  }
+}

--- a/priority-queue/src/main/java/com/iluwatar/priority/queue/Message.java
+++ b/priority-queue/src/main/java/com/iluwatar/priority/queue/Message.java
@@ -1,0 +1,50 @@
+/**
+ * The MIT License
+ * Copyright (c) 2014 Ilkka Seppälä
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.iluwatar.priority.queue;
+
+/**
+ * Simple Bean
+ */
+public class Message implements Comparable<Message> {
+  private String message;
+  private int priority; // define message priority in queue
+
+
+  public Message(String message, int priority) {
+    this.message = message;
+    this.priority = priority;
+  }
+
+  @Override
+  public int compareTo(Message o) {
+    return priority - o.priority;
+  }
+
+  @Override
+  public String toString() {
+    return "Message{"
+        + "message='" + message + '\''
+        + ", priority=" + priority
+        + '}';
+  }
+}

--- a/priority-queue/src/main/java/com/iluwatar/priority/queue/PriorityMessageQueue.java
+++ b/priority-queue/src/main/java/com/iluwatar/priority/queue/PriorityMessageQueue.java
@@ -1,0 +1,174 @@
+/**
+ * The MIT License
+ * Copyright (c) 2014 Ilkka Seppälä
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * <p>
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * <p>
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.iluwatar.priority.queue;
+
+import static java.util.Arrays.copyOf;
+
+/**
+ * Keep high Priority message on top using maxHeap.
+ *
+ * @param <T> :  DataType to push in Queue
+ */
+public class PriorityMessageQueue<T extends Comparable> {
+
+  private int size = 0;
+
+  private int capacity;
+
+
+  private T[] queue;
+
+  public PriorityMessageQueue(T[] queue) {
+    this.queue = queue;
+    this.capacity = queue.length;
+  }
+
+  /**
+   * Remove top message from queue
+   */
+  public T remove() {
+    if (isEmpty()) {
+      return null;
+    }
+
+    T root = queue[0];
+    queue[0] = queue[size - 1];
+    size--;
+    maxHeapifyDown();
+    return root;
+  }
+
+  /**
+   * Add message to queue
+   */
+  public void add(T t) {
+    ensureCapacity();
+    queue[size] = t;
+    size++;
+    maxHeapifyUp();
+  }
+
+  /**
+   * Check queue size
+   */
+  public boolean isEmpty() {
+    return size == 0;
+  }
+
+
+  private void maxHeapifyDown() {
+    int index = 0;
+    while (hasLeftChild(index)) {
+
+      int smallerIndex = leftChildIndex(index);
+
+      if (hasRightChild(index) && right(index).compareTo(left(index)) > 0) {
+        smallerIndex = rightChildIndex(index);
+      }
+
+      if (queue[index].compareTo(queue[smallerIndex]) > 0) {
+        break;
+      } else {
+        swap(index, smallerIndex);
+      }
+
+      index = smallerIndex;
+
+
+    }
+
+  }
+
+  private void maxHeapifyUp() {
+    int index = size - 1;
+    while (hasParent(index) && parent(index).compareTo(queue[index]) < 0) {
+      swap(parentIndex(index), index);
+      index = parentIndex(index);
+    }
+  }
+
+
+  // index
+  private int parentIndex(int pos) {
+    return (pos - 1) / 2;
+  }
+
+  private int leftChildIndex(int parentPos) {
+    return 2 * parentPos + 1;
+  }
+
+  private int rightChildIndex(int parentPos) {
+    return 2 * parentPos + 2;
+  }
+
+  // value
+  private T parent(int childIndex) {
+    return queue[parentIndex(childIndex)];
+  }
+
+  private T left(int parentIndex) {
+    return queue[leftChildIndex(parentIndex)];
+  }
+
+  private T right(int parentIndex) {
+    return queue[rightChildIndex(parentIndex)];
+  }
+
+  // check
+  private boolean hasLeftChild(int index) {
+    return leftChildIndex(index) < size;
+  }
+
+  private boolean hasRightChild(int index) {
+    return rightChildIndex(index) < size;
+  }
+
+  private boolean hasParent(int index) {
+    return parentIndex(index) >= 0;
+  }
+
+  private void swap(int fpos, int tpos) {
+    T tmp = queue[fpos];
+    queue[fpos] = queue[tpos];
+    queue[tpos] = tmp;
+  }
+
+  private void ensureCapacity() {
+    if (size == capacity) {
+      capacity = capacity * 2;
+      queue = copyOf(queue, capacity);
+    }
+  }
+
+  /**
+   * For debug .. print current state of queue
+   */
+  public void print() {
+    for (int i = 0; i <= size / 2; i++) {
+      System.out.print(" PARENT : " + queue[i] + " LEFT CHILD : "
+          + left(i) + " RIGHT CHILD :" + right(i));
+      System.out.println();
+    }
+  }
+
+}

--- a/priority-queue/src/main/java/com/iluwatar/priority/queue/QueueManager.java
+++ b/priority-queue/src/main/java/com/iluwatar/priority/queue/QueueManager.java
@@ -1,0 +1,57 @@
+/**
+ * The MIT License
+ * Copyright (c) 2014 Ilkka Seppälä
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * <p>
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * <p>
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.iluwatar.priority.queue;
+
+/**
+ * Manage priority queue
+ */
+public class QueueManager {
+  /*
+     Priority message
+   */
+  private final PriorityMessageQueue<Message> messagePriorityMessageQueue;
+
+  public QueueManager(int initialCapacity) {
+    messagePriorityMessageQueue = new PriorityMessageQueue<Message>(new Message[initialCapacity]);
+  }
+
+  /**
+   * Publish message to queue
+   */
+  public void publishMessage(Message message) {
+    messagePriorityMessageQueue.add(message);
+  }
+
+
+  /**
+   * recive message from queue
+   */
+  public Message receiveMessage() {
+    if (messagePriorityMessageQueue.isEmpty()) {
+      return null;
+    }
+    return messagePriorityMessageQueue.remove();
+  }
+
+
+}

--- a/priority-queue/src/main/java/com/iluwatar/priority/queue/Worker.java
+++ b/priority-queue/src/main/java/com/iluwatar/priority/queue/Worker.java
@@ -1,0 +1,58 @@
+/**
+ * The MIT License
+ * Copyright (c) 2014 Ilkka Seppälä
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * <p>
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * <p>
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.iluwatar.priority.queue;
+
+/**
+ * Message Worker
+ */
+public class Worker {
+
+  private final QueueManager queueManager;
+
+  public Worker(QueueManager queueManager) {
+    this.queueManager = queueManager;
+  }
+
+  /**
+   * Keep checking queue for message
+   */
+  public void run() throws Exception {
+    while (true) {
+      Message message = queueManager.receiveMessage();
+      if (message == null) {
+        System.out.println("No Message ... waiting");
+        Thread.sleep(200);
+      } else {
+        processMessage(message);
+      }
+    }
+  }
+
+  /**
+   * Process message
+   */
+  private void processMessage(Message message) {
+    System.out.println(message);
+  }
+
+}

--- a/priority-queue/src/test/java/com/iluwatar/priority/queue/PriorityMessageQueueTest.java
+++ b/priority-queue/src/test/java/com/iluwatar/priority/queue/PriorityMessageQueueTest.java
@@ -1,0 +1,51 @@
+package com.iluwatar.priority.queue;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class PriorityMessageQueueTest {
+
+  @Before
+  public void setUp() throws Exception {
+
+  }
+
+  @Test
+  public void remove() {
+    PriorityMessageQueue<String> stringPriorityMessageQueue = new PriorityMessageQueue<>(new String[2]);
+    String pushMessage = "test";
+    stringPriorityMessageQueue.add(pushMessage);
+    Assert.assertEquals(stringPriorityMessageQueue.remove(), pushMessage);
+  }
+
+  @Test
+  public void add() {
+    PriorityMessageQueue<Integer> stringPriorityMessageQueue = new PriorityMessageQueue<>(new Integer[2]);
+    stringPriorityMessageQueue.add(1);
+    stringPriorityMessageQueue.add(5);
+    stringPriorityMessageQueue.add(10);
+    stringPriorityMessageQueue.add(3);
+    Assert.assertTrue(stringPriorityMessageQueue.remove() == 10);
+  }
+
+  @Test
+  public void isEmpty() {
+    PriorityMessageQueue<Integer> stringPriorityMessageQueue = new PriorityMessageQueue<>(new Integer[2]);
+    Assert.assertTrue(stringPriorityMessageQueue.isEmpty());
+    stringPriorityMessageQueue.add(1);
+    stringPriorityMessageQueue.remove();
+    Assert.assertTrue(stringPriorityMessageQueue.isEmpty());
+  }
+
+  @Test
+  public void testEnsureSize() {
+    PriorityMessageQueue<Integer> stringPriorityMessageQueue = new PriorityMessageQueue<>(new Integer[2]);
+    Assert.assertTrue(stringPriorityMessageQueue.isEmpty());
+    stringPriorityMessageQueue.add(1);
+    stringPriorityMessageQueue.add(2);
+    stringPriorityMessageQueue.add(2);
+    stringPriorityMessageQueue.add(3);
+    Assert.assertTrue(stringPriorityMessageQueue.remove() == 3);
+  }
+}

--- a/priority-queue/src/test/java/com/iluwatar/priority/queue/QueueManagerTest.java
+++ b/priority-queue/src/test/java/com/iluwatar/priority/queue/QueueManagerTest.java
@@ -1,0 +1,28 @@
+package com.iluwatar.priority.queue;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+
+public class QueueManagerTest {
+
+  @Test
+  public void publishMessage() {
+    QueueManager queueManager = new QueueManager(2);
+    Message testMessage = new Message("Test Message", 1);
+    queueManager.publishMessage(testMessage);
+    Message recivedMessage = queueManager.receiveMessage();
+    Assert.assertEquals(testMessage, recivedMessage);
+  }
+
+  @Test
+  public void receiveMessage() {
+    QueueManager queueManager = new QueueManager(2);
+    Message testMessage1 = new Message("Test Message 1", 1);
+    queueManager.publishMessage(testMessage1);
+    Message testMessage2 = new Message("Test Message 2", 2);
+    queueManager.publishMessage(testMessage2);
+    Message recivedMessage = queueManager.receiveMessage();
+    Assert.assertEquals(testMessage2, recivedMessage);
+  }
+}


### PR DESCRIPTION

Added priority queue design pattern

- Application posting a message can assign a priority to a message and the messages in the queue are automatically reordered so that messages with a higher priority will be received before those of a lower priority.
- Issue - #449


Pull request description

- Implemented https://docs.microsoft.com/en-us/previous-versions/msp-n-p/dn589794(v=pandp.10) 




> For detailed contributing instructions see https://github.com/iluwatar/java-design-patterns/wiki/01.-How-to-contribute
