### PR TITLE
Change Travis CI build env. to Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+dist: trusty   # Xenial build environment won't allow installation of Java 8
 jdk:
 - oraclejdk8
 


### PR DESCRIPTION
Change Travis CI Build Environment to Trusty

- This PR is to fix an issue causing the Travis CI build to fail.  The problem seems to have stemmed from the build using Travis CI's Xenial build environment, which would not allow you to install anything less than java 9.

- This is in reference to Issue #903. 


Pull request description

- The only change made here is one line of code telling Travis CI to use the Trusty build environment instead of the Xenial one.
