### PR TITLE
Change Travis CI to use Java 8 for S3_website 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty   # Xenial build environment won't allow installation of Java 8
 env:
   global:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer
@@ -7,8 +8,16 @@ env:
 language: ruby
 rvm:
   - 2.2.0
+jdk:
+- oraclejdk8
 
 install: bundle install --jobs=3 --retry=3
+
+addons:
+  apt:
+    packages:
+      - oracle-java8-installer
+      
 script: bash cibuild.sh
 after_script: if [ "$TRAVIS_BRANCH" == "gh-pages" ]; then travis_retry bundle exec s3_website push; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ rvm:
 jdk:
 - oraclejdk8
 
+before_install:
+    - sudo apt-get update
+    - sudo apt-get install -y curl
+    
 install: bundle install --jobs=3 --retry=3
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: bionic   # Xenial build environment won't allow installation of Java 8
+dist: trusty   # Xenial build environment won't allow installation of Java 8
 env:
   global:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer
@@ -13,7 +13,7 @@ jdk:
 
 before_install:
     - sudo apt-get update
-    - sudo apt-get install -y curl
+    - sudo apt-get install -y curl libcurl4-openssl-dev
     
 install: bundle install --jobs=3 --retry=3
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty   # Xenial build environment won't allow installation of Java 8
+dist: bionic   # Xenial build environment won't allow installation of Java 8
 env:
   global:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer


### PR DESCRIPTION
- This PR makes Travis CI use Java 8, which requires the Trusty build environment. 
- Refer to the issue #912 

This comes from a known issue with the S3_website repo, which is not actively maintained. It seems to not support anything higher than Java 8, which makes the gh-pages build fail when Travis CI tries to use Java 11.  

