### PR TITLE
#941 Java 11 support: Maven version 3.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <junit-vintage.version>${junit.version}.2</junit-vintage.version>
         <junit-platform.version>1.0.2</junit-platform.version>
         <sping-test-junit5.version>1.0.2</sping-test-junit5.version>
-        <compiler.version>3.0</compiler.version>
+        <compiler.version>3.8.0</compiler.version>
         <jacoco.version>0.7.2.201409121644</jacoco.version>
         <commons-dbcp.version>1.4</commons-dbcp.version>
         <camel.version>2.16.1</camel.version>
@@ -357,15 +357,14 @@
         </pluginManagement>
 
         <plugins>
-            <!-- Tell maven to compile using Java 8 -->
+            <!-- Tell maven to compile using Java 11 -->
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
+			    <groupId>org.apache.maven.plugins</groupId>
+			    <artifactId>maven-compiler-plugin</artifactId>
                 <version>${compiler.version}</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
+			    <configuration>
+			        <release>11</release>
+			    </configuration>            
             </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>

--- a/trampoline/pom.xml
+++ b/trampoline/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.16.18</version>
+            <version>1.18.2</version>
         </dependency>
 
 


### PR DESCRIPTION
_Java 11 support: Maven version 3.5.0_

There is no official note for Java 11 support, however I am positive that 3.5.0 it is the minimum version because:

- Since version 3.3 Maven requires version JDK 1.7+ ;

- Maven 3.5.0 was released in 2017, one year _before_ Java 11;

- I've tested and it works! 

_Pull request description_

- In order to test on Java 11 I needed to upgrade:
 
1.  maven-compiler-plugin up to 3.8.0 
2.  lombok up to 1.18.2 only at trampoline project due to a issue with Java 11 (got log not found with old lib)


