### PR TITLE
Add JXR plugin to get rid of WARNING Unable to locate Source XRef to …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -465,6 +465,11 @@
                 <artifactId>maven-pmd-plugin</artifactId>
                 <version>${pmd.version}</version>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jxr-plugin</artifactId>
+                <version>3.0.0</version>
+            </plugin>
         </plugins>
     </reporting>
 


### PR DESCRIPTION
This fixes build warnings in #939 

- By adding the JXR plugin the PMD report can pickup links in site and warning disappears.
 
No more "[WARNING] Unable to locate Source XRef to link to - DISABLED" in output when building project.