### PR TITLE
Fix compiler/build warning

### DIFF
--- a/naked-objects/pom.xml
+++ b/naked-objects/pom.xml
@@ -17,23 +17,14 @@
 		<groupId>com.iluwatar</groupId>
 		<version>1.22.0-SNAPSHOT</version>
 	</parent>
-
 	<artifactId>naked-objects</artifactId>
-
 	<packaging>pom</packaging>
-
-	<prerequisites>
-		<maven>3.0.4</maven>
-	</prerequisites>
-
 	<properties>
 		<isis.version>1.9.0</isis.version>
-
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<assertj-core.version>2.0.0</assertj-core.version>
 	</properties>
-
 	<repositories>
 		<repository>
 			<id>apache.snapshots</id>

--- a/pom.xml
+++ b/pom.xml
@@ -370,6 +370,11 @@
                         <argLine>-Xmx1024M ${argLine}</argLine>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-maven-plugin</artifactId>
+                    <version>${spring-boot.version}</version>
+                </plugin>
             </plugins>
         </pluginManagement>
 


### PR DESCRIPTION
This fixes following issues during build process, #944.

[WARNING] 
[WARNING] Some problems were encountered while building the effective model for com.iluwatar:image-microservice:jar:1.22.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.springframework.boot:spring-boot-maven-plugin is missing. @ com.iluwatar:image-microservice:[unknown-version], /home/travis/build/iluwatar/java-design-patterns/api-gateway/image-microservice/pom.xml, line 55, column 15
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for com.iluwatar:price-microservice:jar:1.22.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.springframework.boot:spring-boot-maven-plugin is missing. @ com.iluwatar:price-microservice:[unknown-version], /home/travis/build/iluwatar/java-design-patterns/api-gateway/price-microservice/pom.xml, line 57, column 15
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for com.iluwatar:api-gateway-service:jar:1.22.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.springframework.boot:spring-boot-maven-plugin is missing. @ com.iluwatar:api-gateway-service:[unknown-version], /home/travis/build/iluwatar/java-design-patterns/api-gateway/api-gateway-service/pom.xml, line 64, column 15
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for com.iluwatar:information-microservice:jar:1.22.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.springframework.boot:spring-boot-maven-plugin is missing. @ com.iluwatar:information-microservice:[unknown-version], /home/travis/build/iluwatar/java-design-patterns/aggregator-microservices/information-microservice/pom.xml, line 57, column 21
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for com.iluwatar:aggregator-service:jar:1.22.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.springframework.boot:spring-boot-maven-plugin is missing. @ com.iluwatar:aggregator-service:[unknown-version], /home/travis/build/iluwatar/java-design-patterns/aggregator-microservices/aggregator-service/pom.xml, line 64, column 21
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for com.iluwatar:inventory-microservice:jar:1.22.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.springframework.boot:spring-boot-maven-plugin is missing. @ com.iluwatar:inventory-microservice:[unknown-version], /home/travis/build/iluwatar/java-design-patterns/aggregator-microservices/inventory-microservice/pom.xml, line 56, column 21
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
[WARNING] The project com.iluwatar:naked-objects:pom:1.22.0-SNAPSHOT uses prerequisites which is only intended for maven-plugin projects but not for non maven-plugin projects. For such purposes you should use the maven-enforcer-plugin. See https://maven.apache.org/enforcer/enforcer-rules/requireMavenVersion.html