### PR TITLE
Fix for issue #954 : Add external Dependencies to run with Java11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,8 @@
         <aws-lambda-java-events.version>2.0.1</aws-lambda-java-events.version>
         <jackson.version>2.8.5</jackson.version>
         <pmd.version>3.12.0</pmd.version>
+        <jaxb-api.version>2.3.0</jaxb-api.version>
+        <annotation-api.version>1.3.1</annotation-api.version>
     </properties>
     <modules>
         <module>abstract-factory</module>
@@ -297,6 +299,16 @@
                 <groupId>org.mongodb</groupId>
                 <artifactId>mongo-java-driver</artifactId>
                 <version>${mongo-java-driver.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+                <version>${jaxb-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.annotation</groupId>
+                <artifactId>javax.annotation-api</artifactId>
+                <version>${annotation-api.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -63,5 +63,15 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>1.3.1</version>
+        </dependency>
     </dependencies>
 </project>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -66,12 +66,10 @@
         <dependency>
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
-            <version>2.3.0</version>
         </dependency>
         <dependency>
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
-            <version>1.3.1</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Issue:
JAXB API and javax.Annotations were removed from jdk11, so some tests were failing. 

Changes:
Add javax.annotation and java.xml.bind as external maven dependencies

Verification:
Verified tests with jdk-11