### PR TITLE
Maven profiles to support jdk 11 builds. #948

### DIFF
--- a/cqrs/pom.xml
+++ b/cqrs/pom.xml
@@ -39,4 +39,25 @@
 			<artifactId>hibernate-core</artifactId>
 		</dependency>
 	</dependencies>
+	<profiles>
+		<profile>
+			<id>jdk11-deps</id>
+			<activation>
+				<jdk>[11,)</jdk>
+			</activation>
+			<dependencies>
+				<dependency>
+					<groupId>com.sun.xml.bind</groupId>
+					<artifactId>jaxb-impl</artifactId>
+					<scope>test</scope>
+					<version>2.1.17</version>
+				</dependency>
+				<dependency>
+					<groupId>javax.xml.bind</groupId>
+					<artifactId>jaxb-api</artifactId>
+					<scope>test</scope>
+				</dependency>
+			</dependencies>
+		</profile>
+	</profiles>
 </project>

--- a/eip-aggregator/pom.xml
+++ b/eip-aggregator/pom.xml
@@ -70,4 +70,24 @@
         </dependency>
 
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>jdk11-deps</id>
+            <activation>
+                <jdk>[11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.sun.xml.bind</groupId>
+                    <artifactId>jaxb-impl</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
 </project>

--- a/eip-splitter/pom.xml
+++ b/eip-splitter/pom.xml
@@ -70,4 +70,25 @@
         </dependency>
 
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>jdk11-deps</id>
+            <activation>
+                <jdk>[11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.sun.xml.bind</groupId>
+                    <artifactId>jaxb-impl</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
+
 </project>

--- a/eip-wire-tap/pom.xml
+++ b/eip-wire-tap/pom.xml
@@ -70,4 +70,23 @@
         </dependency>
 
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>jdk11-deps</id>
+            <activation>
+                <jdk>[11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.sun.xml.bind</groupId>
+                    <artifactId>jaxb-impl</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/naked-objects/dom/exclude-pmd.properties
+++ b/naked-objects/dom/exclude-pmd.properties
@@ -1,0 +1,24 @@
+#
+# The MIT License
+# Copyright (c) 2014-2016 Ilkka Seppälä
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+domainapp.dom.modules.simple.QSimpleObject=UnusedFormalParameter

--- a/naked-objects/dom/pom.xml
+++ b/naked-objects/dom/pom.xml
@@ -78,7 +78,7 @@
 				<activeByDefault>true</activeByDefault>
 			</activation>
 			<properties>
-                <datanucleus-maven-plugin.version>4.0.1</datanucleus-maven-plugin.version>
+                <datanucleus-maven-plugin.version>5.2.1</datanucleus-maven-plugin.version>
 			</properties>
 			<build>
 				<pluginManagement>

--- a/naked-objects/integtests/pom.xml
+++ b/naked-objects/integtests/pom.xml
@@ -122,6 +122,20 @@
         </repository>  
     </repositories>  
      -->
+	<profiles>
+		<profile>
+			<id>jdk11-deps</id>
+			<activation>
+				<jdk>[11,)</jdk>
+			</activation>
+			<dependencies>
+				<dependency>
+					<groupId>javax.annotation</groupId>
+					<artifactId>javax.annotation-api</artifactId>
+				</dependency>
+			</dependencies>
+		</profile>
+	</profiles>
 
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <jackson.version>2.8.5</jackson.version>
         <pmd.version>3.12.0</pmd.version>
         <log4j.version>1.2.17</log4j.version>
-        <jaxb-api.version>2.3.0</jaxb-api.version>
+        <jaxb-api.version>2.3.1</jaxb-api.version>
         <annotation-api.version>1.3.1</annotation-api.version>
     </properties>
     <modules>
@@ -314,6 +314,11 @@
                 <artifactId>javax.annotation-api</artifactId>
                 <version>${annotation-api.version}</version>
             </dependency>
+            <dependency>
+                <groupId>com.sun.xml.bind</groupId>
+                <artifactId>jaxb-impl</artifactId>
+                <version>2.3.2</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -493,5 +498,34 @@
             </plugin>
         </plugins>
     </reporting>
+
+    <profiles>
+        <profile>
+            <id>jdk11-dep-management</id>
+            <activation>
+                <jdk>[11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.sun.xml.bind</groupId>
+                    <artifactId>jaxb-impl</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.javassist</groupId>
+                    <artifactId>javassist</artifactId>
+                    <version>3.25.0-GA</version>
+                </dependency>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
         <pmd.version>3.12.0</pmd.version>
         <log4j.version>1.2.17</log4j.version>
         <jaxb-api.version>2.3.1</jaxb-api.version>
+        <jaxb-impl.version>2.3.2</jaxb-impl.version>
         <annotation-api.version>1.3.1</annotation-api.version>
     </properties>
     <modules>
@@ -317,7 +318,7 @@
             <dependency>
                 <groupId>com.sun.xml.bind</groupId>
                 <artifactId>jaxb-impl</artifactId>
-                <version>2.3.2</version>
+                <version>${jaxb-impl.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -505,26 +506,20 @@
             <activation>
                 <jdk>[11,)</jdk>
             </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>com.sun.xml.bind</groupId>
-                    <artifactId>jaxb-impl</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>javax.xml.bind</groupId>
-                    <artifactId>jaxb-api</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>org.javassist</groupId>
-                    <artifactId>javassist</artifactId>
-                    <version>3.25.0-GA</version>
-                </dependency>
-                <dependency>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>javax.annotation-api</artifactId>
-                    <version>1.3.2</version>
-                </dependency>
-            </dependencies>
+            <dependencyManagement>
+	            <dependencies>
+	                <dependency>
+	                    <groupId>org.javassist</groupId>
+	                    <artifactId>javassist</artifactId>
+	                    <version>3.25.0-GA</version>
+	                </dependency>
+	                <dependency>
+	                    <groupId>javax.annotation</groupId>
+	                    <artifactId>javax.annotation-api</artifactId>
+	                    <version>1.3.2</version>
+	                </dependency>
+	            </dependencies>
+            </dependencyManagement>
         </profile>
     </profiles>
 

--- a/service-layer/pom.xml
+++ b/service-layer/pom.xml
@@ -52,4 +52,22 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <profiles>
+      <profile>
+          <id>jdk11-deps</id>
+          <activation>
+              <jdk>[11,)</jdk>
+          </activation>
+          <dependencies>
+              <dependency>
+                  <groupId>com.sun.xml.bind</groupId>
+                  <artifactId>jaxb-impl</artifactId>
+              </dependency>
+              <dependency>
+                  <groupId>javax.xml.bind</groupId>
+                  <artifactId>jaxb-api</artifactId>
+              </dependency>
+          </dependencies>
+      </profile>
+  </profiles>
 </project>

--- a/trampoline/pom.xml
+++ b/trampoline/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.16.18</version>
+            <version>1.18.10</version>
         </dependency>
 
 


### PR DESCRIPTION
Added maven profiles activated by jdk 11, wich will not break java 8 support.
Bumped lombok and datanucleus enhancer as the old versions dont work with 11.


Pull request title

- Clearly and concisely describes what it does
- Refer to the issue that it solves, if available


Pull request description

- Describes the main changes that come with the pull request
- Any relevant additional information is provided



> For detailed contributing instructions see https://github.com/iluwatar/java-design-patterns/wiki/01.-How-to-contribute
