### PR TITLE
Bump java language to 11 #976 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: java
 dist: xenial
 jdk:
-- openjdk8
 - openjdk11
 
 env:

--- a/cqrs/pom.xml
+++ b/cqrs/pom.xml
@@ -38,26 +38,18 @@
 			<groupId>org.hibernate</groupId>
 			<artifactId>hibernate-core</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>com.sun.xml.bind</groupId>
+			<artifactId>jaxb-impl</artifactId>
+			<scope>test</scope>
+			<version>2.1.17</version>
+		</dependency>
+		<dependency>
+			<groupId>javax.xml.bind</groupId>
+			<artifactId>jaxb-api</artifactId>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
-	<profiles>
-		<profile>
-			<id>jdk11-deps</id>
-			<activation>
-				<jdk>[11,)</jdk>
-			</activation>
-			<dependencies>
-				<dependency>
-					<groupId>com.sun.xml.bind</groupId>
-					<artifactId>jaxb-impl</artifactId>
-					<scope>test</scope>
-					<version>2.1.17</version>
-				</dependency>
-				<dependency>
-					<groupId>javax.xml.bind</groupId>
-					<artifactId>jaxb-api</artifactId>
-					<scope>test</scope>
-				</dependency>
-			</dependencies>
-		</profile>
-	</profiles>
+
 </project>

--- a/eip-aggregator/pom.xml
+++ b/eip-aggregator/pom.xml
@@ -47,6 +47,15 @@
             <version>${camel.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+        </dependency>
+
         <!-- Testing -->
         <dependency>
             <groupId>com.github.sbrannen</groupId>
@@ -70,24 +79,5 @@
         </dependency>
 
     </dependencies>
-
-    <profiles>
-        <profile>
-            <id>jdk11-deps</id>
-            <activation>
-                <jdk>[11,)</jdk>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>com.sun.xml.bind</groupId>
-                    <artifactId>jaxb-impl</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>javax.xml.bind</groupId>
-                    <artifactId>jaxb-api</artifactId>
-                </dependency>
-            </dependencies>
-        </profile>
-    </profiles>
 
 </project>

--- a/eip-splitter/pom.xml
+++ b/eip-splitter/pom.xml
@@ -47,6 +47,16 @@
             <version>${camel.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+        </dependency>
+
+
         <!-- Testing -->
         <dependency>
             <groupId>com.github.sbrannen</groupId>
@@ -70,25 +80,5 @@
         </dependency>
 
     </dependencies>
-
-    <profiles>
-        <profile>
-            <id>jdk11-deps</id>
-            <activation>
-                <jdk>[11,)</jdk>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>com.sun.xml.bind</groupId>
-                    <artifactId>jaxb-impl</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>javax.xml.bind</groupId>
-                    <artifactId>jaxb-api</artifactId>
-                </dependency>
-            </dependencies>
-        </profile>
-    </profiles>
-
 
 </project>

--- a/eip-wire-tap/pom.xml
+++ b/eip-wire-tap/pom.xml
@@ -47,6 +47,16 @@
             <version>${camel.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+        </dependency>
+
+
         <!-- Testing -->
         <dependency>
             <groupId>com.github.sbrannen</groupId>
@@ -71,22 +81,4 @@
 
     </dependencies>
 
-    <profiles>
-        <profile>
-            <id>jdk11-deps</id>
-            <activation>
-                <jdk>[11,)</jdk>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>com.sun.xml.bind</groupId>
-                    <artifactId>jaxb-impl</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>javax.xml.bind</groupId>
-                    <artifactId>jaxb-api</artifactId>
-                </dependency>
-            </dependencies>
-        </profile>
-    </profiles>
 </project>

--- a/naked-objects/dom/pom.xml
+++ b/naked-objects/dom/pom.xml
@@ -36,6 +36,17 @@
 				</excludes>
 			</resource>
 		</resources>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>${compiler.version}</version>
+				<configuration>
+					<source>8</source>
+					<target>8</target>
+				</configuration>
+			</plugin>
+		</plugins>
 	</build>
 
 	<dependencies>

--- a/naked-objects/integtests/pom.xml
+++ b/naked-objects/integtests/pom.xml
@@ -90,6 +90,11 @@
 			<artifactId>hsqldb</artifactId>
 		</dependency>
 
+		<dependency>
+			<groupId>javax.annotation</groupId>
+			<artifactId>javax.annotation-api</artifactId>
+		</dependency>
+
         <!-- 
         uncomment to enable enhanced cucumber-jvm reporting
         http://www.masterthought.net/section/cucumber-reporting
@@ -122,20 +127,5 @@
         </repository>  
     </repositories>  
      -->
-	<profiles>
-		<profile>
-			<id>jdk11-deps</id>
-			<activation>
-				<jdk>[11,)</jdk>
-			</activation>
-			<dependencies>
-				<dependency>
-					<groupId>javax.annotation</groupId>
-					<artifactId>javax.annotation-api</artifactId>
-				</dependency>
-			</dependencies>
-		</profile>
-	</profiles>
-
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <log4j.version>1.2.17</log4j.version>
         <jaxb-api.version>2.3.1</jaxb-api.version>
         <jaxb-impl.version>2.3.2</jaxb-impl.version>
-        <annotation-api.version>1.3.1</annotation-api.version>
+        <annotation-api.version>1.3.2</annotation-api.version>
     </properties>
     <modules>
         <module>abstract-factory</module>
@@ -320,6 +320,11 @@
                 <artifactId>jaxb-impl</artifactId>
                 <version>${jaxb-impl.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.javassist</groupId>
+                <artifactId>javassist</artifactId>
+                <version>3.25.0-GA</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -380,8 +385,8 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${compiler.version}</version>
                     <configuration>
-                        <source>1.8</source>
-                        <target>1.8</target>
+                        <source>11</source>
+                        <target>11</target>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -499,28 +504,5 @@
             </plugin>
         </plugins>
     </reporting>
-
-    <profiles>
-        <profile>
-            <id>jdk11-dep-management</id>
-            <activation>
-                <jdk>[11,)</jdk>
-            </activation>
-            <dependencyManagement>
-	            <dependencies>
-	                <dependency>
-	                    <groupId>org.javassist</groupId>
-	                    <artifactId>javassist</artifactId>
-	                    <version>3.25.0-GA</version>
-	                </dependency>
-	                <dependency>
-	                    <groupId>javax.annotation</groupId>
-	                    <artifactId>javax.annotation-api</artifactId>
-	                    <version>1.3.2</version>
-	                </dependency>
-	            </dependencies>
-            </dependencyManagement>
-        </profile>
-    </profiles>
 
 </project>

--- a/service-layer/pom.xml
+++ b/service-layer/pom.xml
@@ -42,6 +42,14 @@
 		<artifactId>h2</artifactId>
 	</dependency>
     <dependency>
+        <groupId>com.sun.xml.bind</groupId>
+        <artifactId>jaxb-impl</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>javax.xml.bind</groupId>
+        <artifactId>jaxb-api</artifactId>
+    </dependency>
+    <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter-engine</artifactId>
         <scope>test</scope>
@@ -52,22 +60,5 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  <profiles>
-      <profile>
-          <id>jdk11-deps</id>
-          <activation>
-              <jdk>[11,)</jdk>
-          </activation>
-          <dependencies>
-              <dependency>
-                  <groupId>com.sun.xml.bind</groupId>
-                  <artifactId>jaxb-impl</artifactId>
-              </dependency>
-              <dependency>
-                  <groupId>javax.xml.bind</groupId>
-                  <artifactId>jaxb-api</artifactId>
-              </dependency>
-          </dependencies>
-      </profile>
-  </profiles>
+
 </project>


### PR DESCRIPTION
* Moved java XML and annotations dependencies to project level instead
of as profiles
* Set compiler language level to 11
* Removed jdk8 from travis build

* Kept java level 8 in naked-objects/dom for datanucleus enhancer, for
now.


Pull request title

- Clearly and concisely describes what it does
- Refer to the issue that it solves, if available


Pull request description

- Describes the main changes that come with the pull request
- Any relevant additional information is provided



> For detailed contributing instructions see https://github.com/iluwatar/java-design-patterns/wiki/01.-How-to-contribute
