### PR TITLE
#1001 fix intermittent test failure - changing Rect coordinates to double.

### DIFF
--- a/spatial-partition/src/main/java/com/iluwatar/spatialpartition/Rect.java
+++ b/spatial-partition/src/main/java/com/iluwatar/spatialpartition/Rect.java
@@ -28,14 +28,14 @@ package com.iluwatar.spatialpartition;
  */
 
 public class Rect {
-  int x; 
-  int y; 
-  int width;
-  int height;
+  double x;
+  double y;
+  double width;
+  double height;
 
   //(x,y) - centre of rectangle
 
-  Rect(int x, int y, int width, int height) {
+  Rect(double x, double y, double width, double height) {
     this.x = x;
     this.y = y;
     this.width = width;


### PR DESCRIPTION
#1001 QuadTreeTest was showing intermittent failures. 

The problem was due to the Rect data structure using int to store values (x, y, height, width). 

Since the QuadTree divides its space in four, we need to either to change the Rect data structure or the divide algorithm. 

I find the former more readable and clear.
