### PR TITLE
1010: Fixed all of the blocking and critical Sonarcloud errors

### DIFF
--- a/circuit-breaker/src/main/java/com/iluwatar/circuitbreaker/App.java
+++ b/circuit-breaker/src/main/java/com/iluwatar/circuitbreaker/App.java
@@ -66,6 +66,7 @@ public class App {
    * 
    * @param args command line args
    */
+  @SuppressWarnings("squid:S2189")
   public static void main(String[] args) {
     //Create an object of monitoring service which makes both local and remote calls
     var obj = new MonitoringService();

--- a/commander/src/main/java/com/iluwatar/commander/Order.java
+++ b/commander/src/main/java/com/iluwatar/commander/Order.java
@@ -44,6 +44,7 @@ public class Order { //can store all transactions ids also
   public final String id;
   final float price;
   final long createdTime;
+  private static final Random RANDOM = new Random();
   private static final String ALL_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
   private static final Hashtable<String, Boolean> USED_IDS = new Hashtable<String, Boolean>();
   PaymentStatus paid;
@@ -70,9 +71,8 @@ public class Order { //can store all transactions ids also
 
   String createUniqueId() {
     StringBuilder random = new StringBuilder();
-    Random rand = new Random();
     while (random.length() < 12) { // length of the random string.
-      int index = (int) (rand.nextFloat() * ALL_CHARS.length());
+      int index = (int) (RANDOM.nextFloat() * ALL_CHARS.length());
       random.append(ALL_CHARS.charAt(index));
     }
     return random.toString();

--- a/commander/src/main/java/com/iluwatar/commander/Retry.java
+++ b/commander/src/main/java/com/iluwatar/commander/Retry.java
@@ -51,6 +51,8 @@ public class Retry<T> {
   public interface HandleErrorIssue<T> {
     void handleIssue(T obj, Exception e);
   }
+  
+  private static final Random RANDOM = new Random();
 
   private final Operation op;
   private final HandleErrorIssue<T> handleError;
@@ -89,8 +91,7 @@ public class Retry<T> {
           return; //return here...dont go further
         }
         try {
-          Random rand = new Random();
-          long testDelay = (long) Math.pow(2, this.attempts.intValue()) * 1000 + rand.nextInt(1000);
+          long testDelay = (long) Math.pow(2, this.attempts.intValue()) * 1000 + RANDOM.nextInt(1000);
           long delay = testDelay < this.maxDelay ? testDelay : maxDelay;
           Thread.sleep(delay);
         } catch (InterruptedException f) {

--- a/commander/src/main/java/com/iluwatar/commander/Service.java
+++ b/commander/src/main/java/com/iluwatar/commander/Service.java
@@ -42,6 +42,7 @@ public abstract class Service {
   
   protected final Database database;
   public ArrayList<Exception> exceptionsList;
+  private static final Random RANDOM = new Random();
   private static final String ALL_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
   private static final Hashtable<String, Boolean> USED_IDS = new Hashtable<String, Boolean>();
 
@@ -55,9 +56,8 @@ public abstract class Service {
 
   protected String generateId() {
     StringBuilder random = new StringBuilder();
-    Random rand = new Random();
     while (random.length() < 12) { // length of the random string.
-      int index = (int) (rand.nextFloat() * ALL_CHARS.length());
+      int index = (int) (RANDOM.nextFloat() * ALL_CHARS.length());
       random.append(ALL_CHARS.charAt(index));
     }
     String id = random.toString();

--- a/hexagonal/src/main/java/com/iluwatar/hexagonal/sampledata/SampleData.java
+++ b/hexagonal/src/main/java/com/iluwatar/hexagonal/sampledata/SampleData.java
@@ -40,6 +40,7 @@ import java.util.Random;
 public class SampleData {
 
   private static final List<PlayerDetails> PLAYERS;
+  private static final Random RANDOM = new Random();
 
   static {
     PLAYERS = new ArrayList<>();
@@ -83,10 +84,9 @@ public class SampleData {
     PLAYERS.add(new PlayerDetails("xavier@google.com", "143-947", "+375245"));
     PLAYERS.add(new PlayerDetails("harriet@google.com", "842-404", "+131243252"));
     InMemoryBank wireTransfers = new InMemoryBank();
-    Random random = new Random();
     for (PlayerDetails player : PLAYERS) {
       wireTransfers.setFunds(player.getBankAccount(),
-          random.nextInt(LotteryConstants.PLAYER_MAX_BALANCE));
+          RANDOM.nextInt(LotteryConstants.PLAYER_MAX_BALANCE));
     }
   }
 

--- a/leader-election/src/main/java/com/iluwatar/leaderelection/AbstractInstance.java
+++ b/leader-election/src/main/java/com/iluwatar/leaderelection/AbstractInstance.java
@@ -58,6 +58,7 @@ public abstract class AbstractInstance implements Instance, Runnable {
    * The instance will execute the message in its message queue periodically once it is alive.
    */
   @Override
+  @SuppressWarnings("squid:S2189")
   public void run() {
     while (true) {
       if (!this.messageQueue.isEmpty()) {

--- a/master-worker-pattern/src/main/java/com/iluwatar/masterworker/ArrayUtilityMethods.java
+++ b/master-worker-pattern/src/main/java/com/iluwatar/masterworker/ArrayUtilityMethods.java
@@ -34,6 +34,8 @@ import java.util.Random;
 public class ArrayUtilityMethods {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ArrayUtilityMethods.class);
+  
+  private static final Random RANDOM = new Random();
   /**
    * Method arraysSame compares 2 arrays @param a1 and @param a2
    * and @return whether their values are equal (boolean).
@@ -86,11 +88,10 @@ public class ArrayUtilityMethods {
   
   public static int[][] createRandomIntMatrix(int rows, int columns) {
     int[][] matrix = new int[rows][columns];
-    Random rand = new Random();
     for (int i = 0; i < rows; i++) {
       for (int j = 0; j < columns; j++) {
         //filling cells in matrix
-        matrix[i][j] = rand.nextInt(10);
+        matrix[i][j] = RANDOM.nextInt(10);
       }
     }
     return matrix;

--- a/priority-queue/src/main/java/com/iluwatar/priority/queue/Worker.java
+++ b/priority-queue/src/main/java/com/iluwatar/priority/queue/Worker.java
@@ -41,6 +41,7 @@ public class Worker {
   /**
    * Keep checking queue for message
    */
+  @SuppressWarnings("squid:S2189")
   public void run() throws Exception {
     while (true) {
       Message message = queueManager.receiveMessage();

--- a/producer-consumer/src/main/java/com/iluwatar/producer/consumer/Producer.java
+++ b/producer-consumer/src/main/java/com/iluwatar/producer/consumer/Producer.java
@@ -29,6 +29,8 @@ import java.util.Random;
  * to queue
  */
 public class Producer {
+  
+  private static final Random RANDOM = new Random();
 
   private final ItemQueue queue;
 
@@ -48,7 +50,6 @@ public class Producer {
 
     Item item = new Item(name, itemId++);
     queue.put(item);
-    Random random = new Random();
-    Thread.sleep(random.nextInt(2000));
+    Thread.sleep(RANDOM.nextInt(2000));
   }
 }

--- a/retry/src/main/java/com/iluwatar/retry/RetryExponentialBackoff.java
+++ b/retry/src/main/java/com/iluwatar/retry/RetryExponentialBackoff.java
@@ -37,6 +37,7 @@ import java.util.function.Predicate;
  * @param <T> the remote op's return type
  */
 public final class RetryExponentialBackoff<T> implements BusinessOperation<T> {
+  private static final Random RANDOM = new Random();
   private final BusinessOperation<T> op;
   private final int maxAttempts;
   private final long maxDelay;
@@ -98,8 +99,7 @@ public final class RetryExponentialBackoff<T> implements BusinessOperation<T> {
         }
 
         try {
-          Random rand = new Random();
-          long testDelay = (long) Math.pow(2, this.attempts()) * 1000 + rand.nextInt(1000);
+          long testDelay = (long) Math.pow(2, this.attempts()) * 1000 + RANDOM.nextInt(1000);
           long delay = testDelay < this.maxDelay ? testDelay : maxDelay;
           Thread.sleep(delay);
         } catch (InterruptedException f) {

--- a/spatial-partition/src/main/java/com/iluwatar/spatialpartition/Bubble.java
+++ b/spatial-partition/src/main/java/com/iluwatar/spatialpartition/Bubble.java
@@ -36,6 +36,7 @@ import java.util.Random;
 
 public class Bubble extends Point<Bubble> {
   private static final Logger LOGGER = LoggerFactory.getLogger(Bubble.class);
+  private static final Random RANDOM = new Random();
 
   final int radius;
 
@@ -45,10 +46,9 @@ public class Bubble extends Point<Bubble> {
   }
 
   void move() {
-    Random rand = new Random();
     //moves by 1 unit in either direction
-    this.x += rand.nextInt(3) - 1;
-    this.y += rand.nextInt(3) - 1;
+    this.x += RANDOM.nextInt(3) - 1;
+    this.y += RANDOM.nextInt(3) - 1;
   }
 
   boolean touches(Bubble b) {

--- a/typeobjectpattern/src/main/java/com/iluwatar/typeobject/CellPool.java
+++ b/typeobjectpattern/src/main/java/com/iluwatar/typeobject/CellPool.java
@@ -37,6 +37,7 @@ import com.iluwatar.typeobject.Candy.Type;
  */
 
 public class CellPool {
+  private static final Random RANDOM = new Random();
   ArrayList<Cell> pool;
   int pointer;
   Candy[] randomCode;
@@ -57,8 +58,7 @@ public class CellPool {
     }
     for (int i = 0; i < num; i++) {
       Cell c = new Cell();
-      Random rand = new Random();
-      c.candy = randomCode[rand.nextInt(randomCode.length)];
+      c.candy = randomCode[RANDOM.nextInt(randomCode.length)];
       this.pool.add(c);
     }
     this.pointer = num - 1;


### PR DESCRIPTION
Fixed all of the blocking and critical Sonarcloud errors

There were 12 blocking and critical errors in Sonarcloud. They are:

- circuit-breaker/.../com/iluwatar/circuitbreaker/App.java: Add an end condition to this loop
- commander/.../java/com/iluwatar/commander/Order.java: Save and re-use this "Random"
- commander/.../java/com/iluwatar/commander/Retry.java: Save and re-use this "Random"
- commander/.../java/com/iluwatar/commander/Service.java: Save and re-use this "Random"
- hexagonal/.../iluwatar/hexagonal/sampledata/SampleData.java: Save and re-use this "Random"
- leader-election/.../com/iluwatar/leaderelection/AbstractInstance.java: Add an end condition to this loop
- master-worker-pattern/.../java/com/iluwatar/masterworker/ArrayUtilityMethods.java: Save and re-use this "Random"
- priority-queue/.../com/iluwatar/priority/queue/Worker.java: Add an end condition to this loop
- producer-consumer/.../com/iluwatar/producer/consumer/Producer.java: Save and re-use this "Random"
- retry/.../main/java/com/iluwatar/retry/RetryExponentialBackoff.java: Save and re-use this "Random"
- spatial-partition/.../com/iluwatar/spatialpartition/Bubble.java: Save and re-use this "Random"
- typeobjectpattern/.../java/com/iluwatar/typeobject/CellPool.java: Save and re-use this "Random"
- 

Since there were only two types of rules, the changes can be summarized as:

1. Add an end condition to this loop: put a SuppressWarning annotation so SonarCloud will ignore

1. Save and re-use this "Random": Make the random a constant in the file.