### PR TITLE
https://github.com/iluwatar/java-design-patterns/issues/1009 - remove child poms overhead information

### DIFF
--- a/cqrs/pom.xml
+++ b/cqrs/pom.xml
@@ -51,7 +51,6 @@
 			<groupId>com.sun.xml.bind</groupId>
 			<artifactId>jaxb-impl</artifactId>
 			<scope>test</scope>
-			<version>2.1.17</version>
 		</dependency>
 		<dependency>
 			<groupId>javax.xml.bind</groupId>

--- a/cqrs/pom.xml
+++ b/cqrs/pom.xml
@@ -50,6 +50,7 @@
 		<dependency>
 			<groupId>com.sun.xml.bind</groupId>
 			<artifactId>jaxb-impl</artifactId>
+			<version>2.1.17</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/eip-aggregator/pom.xml
+++ b/eip-aggregator/pom.xml
@@ -43,7 +43,6 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-core</artifactId>
-            <version>${camel.version}</version>
         </dependency>
 
         <dependency>

--- a/eip-splitter/pom.xml
+++ b/eip-splitter/pom.xml
@@ -43,7 +43,6 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-core</artifactId>
-            <version>${camel.version}</version>
         </dependency>
 
         <dependency>

--- a/eip-wire-tap/pom.xml
+++ b/eip-wire-tap/pom.xml
@@ -43,7 +43,6 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-core</artifactId>
-            <version>${camel.version}</version>
         </dependency>
 
         <dependency>

--- a/trampoline/pom.xml
+++ b/trampoline/pom.xml
@@ -38,7 +38,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Remove from child pom not necessary information https://github.com/iluwatar/java-design-patterns/issues/1009 - according to maven dependency management https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Dependency_Management
