### PR TITLE
#1037: Fix error when building from a submodule directory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -406,6 +406,31 @@
                 </executions>
             </plugin>
 
+            <!-- Resolves ${projectRoot} to the project root directory.
+                Used by the license-maven-plugin to find the correct location of
+                license-plugin-header-style.xml when built from a submodule directory. -->
+            <plugin>
+                <groupId>org.commonjava.maven.plugins</groupId>
+                <artifactId>directory-maven-plugin</artifactId>
+                <version>0.3.1</version>
+                <executions>
+                    <execution>
+                        <id>directories</id>
+                        <goals>
+                            <goal>directory-of</goal>
+                        </goals>
+                        <phase>initialize</phase>
+                        <configuration>
+                            <property>projectRoot</property>
+                            <project>
+                                <groupId>com.iluwatar</groupId>
+                                <artifactId>java-design-patterns</artifactId>
+                            </project>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
             <plugin>
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin</artifactId>
@@ -417,7 +442,7 @@
                     </properties>
                     <skipExistingHeaders>true</skipExistingHeaders>
                     <headerDefinitions>
-                        <headerDefinition>license-plugin-header-style.xml</headerDefinition>
+                        <headerDefinition>${projectRoot}${file.separator}license-plugin-header-style.xml</headerDefinition>
                     </headerDefinitions>
                     <mapping>
                         <java>SLASHSTAR_CUSTOM_STYLE</java>


### PR DESCRIPTION
Closes #1037 

The license-plugin-header-style.xml in the root directory was not resolved correctly when the project was built from a submodule directory, so I ended up adding a new plugin `directory-maven-plugin` which does that.

Other solutions were to use the `${maven.multiModuleProjectDirectory}` property, but I was not able to make it work, or to add a relative path property to each of the submodules `<properties><projectRoot>${parent.basedir}</projectRoot></properties>`, but this configuration would be difficult to maintain, as there are 120 submodules.