### PR TITLE
Resolves checkstyle errors for execute-around extension-objects

### DIFF
--- a/execute-around/src/main/java/com/iluwatar/execute/around/App.java
+++ b/execute-around/src/main/java/com/iluwatar/execute/around/App.java
@@ -29,16 +29,15 @@ import java.io.IOException;
  * The Execute Around idiom specifies some code to be executed before and after a method. Typically
  * the idiom is used when the API has methods to be executed in pairs, such as resource
  * allocation/deallocation or lock acquisition/release.
- * <p>
- * In this example, we have {@link SimpleFileWriter} class that opens and closes the file for the
- * user. The user specifies only what to do with the file by providing the {@link FileWriterAction}
- * implementation.
  *
+ * <p>In this example, we have {@link SimpleFileWriter} class that opens and closes the file for
+ * the user. The user specifies only what to do with the file by providing the {@link
+ * FileWriterAction} implementation.
  */
 public class App {
 
   /**
-   * Program entry point
+   * Program entry point.
    */
   public static void main(String[] args) throws IOException {
 

--- a/execute-around/src/main/java/com/iluwatar/execute/around/FileWriterAction.java
+++ b/execute-around/src/main/java/com/iluwatar/execute/around/FileWriterAction.java
@@ -27,9 +27,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 
 /**
- * 
  * Interface for specifying what to do with the file resource.
- *
  */
 @FunctionalInterface
 public interface FileWriterAction {

--- a/execute-around/src/main/java/com/iluwatar/execute/around/SimpleFileWriter.java
+++ b/execute-around/src/main/java/com/iluwatar/execute/around/SimpleFileWriter.java
@@ -27,15 +27,13 @@ import java.io.FileWriter;
 import java.io.IOException;
 
 /**
- * 
  * SimpleFileWriter handles opening and closing file for the user. The user only has to specify what
  * to do with the file resource through {@link FileWriterAction} parameter.
- *
  */
 public class SimpleFileWriter {
 
   /**
-   * Constructor
+   * Constructor.
    */
   public SimpleFileWriter(String filename, FileWriterAction action) throws IOException {
     try (FileWriter writer = new FileWriter(filename)) {

--- a/extension-objects/src/main/java/App.java
+++ b/extension-objects/src/main/java/App.java
@@ -24,21 +24,21 @@
 import abstractextensions.CommanderExtension;
 import abstractextensions.SergeantExtension;
 import abstractextensions.SoldierExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import units.CommanderUnit;
 import units.SergeantUnit;
 import units.SoldierUnit;
 import units.Unit;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
- * Anticipate that an object’s interface needs to be extended in the future.
- * Additional interfaces are defined by extension objects.
+ * Anticipate that an object’s interface needs to be extended in the future. Additional interfaces
+ * are defined by extension objects.
  */
 public class App {
 
   /**
-   * Program entry point
+   * Program entry point.
    *
    * @param args command line args
    */
@@ -59,9 +59,12 @@ public class App {
   private static void checkExtensionsForUnit(Unit unit) {
     final Logger logger = LoggerFactory.getLogger(App.class);
 
-    SoldierExtension soldierExtension = (SoldierExtension) unit.getUnitExtension("SoldierExtension");
-    SergeantExtension sergeantExtension = (SergeantExtension) unit.getUnitExtension("SergeantExtension");
-    CommanderExtension commanderExtension = (CommanderExtension) unit.getUnitExtension("CommanderExtension");
+    SoldierExtension soldierExtension =
+        (SoldierExtension) unit.getUnitExtension("SoldierExtension");
+    SergeantExtension sergeantExtension =
+        (SergeantExtension) unit.getUnitExtension("SergeantExtension");
+    CommanderExtension commanderExtension =
+        (CommanderExtension) unit.getUnitExtension("CommanderExtension");
 
     //if unit have extension call the method
     if (soldierExtension != null) {

--- a/extension-objects/src/main/java/abstractextensions/CommanderExtension.java
+++ b/extension-objects/src/main/java/abstractextensions/CommanderExtension.java
@@ -24,7 +24,7 @@
 package abstractextensions;
 
 /**
- * Interface with their method
+ * Interface with their method.
  */
 public interface CommanderExtension extends UnitExtension {
 

--- a/extension-objects/src/main/java/abstractextensions/SergeantExtension.java
+++ b/extension-objects/src/main/java/abstractextensions/SergeantExtension.java
@@ -24,7 +24,7 @@
 package abstractextensions;
 
 /**
- * Interface with their method
+ * Interface with their method.
  */
 public interface SergeantExtension extends UnitExtension {
 

--- a/extension-objects/src/main/java/abstractextensions/SoldierExtension.java
+++ b/extension-objects/src/main/java/abstractextensions/SoldierExtension.java
@@ -24,7 +24,7 @@
 package abstractextensions;
 
 /**
- * Interface with their method
+ * Interface with their method.
  */
 public interface SoldierExtension extends UnitExtension {
   void soldierReady();

--- a/extension-objects/src/main/java/abstractextensions/UnitExtension.java
+++ b/extension-objects/src/main/java/abstractextensions/UnitExtension.java
@@ -24,7 +24,7 @@
 package abstractextensions;
 
 /**
- * Other Extensions will extend this interface
+ * Other Extensions will extend this interface.
  */
 public interface UnitExtension {
 }

--- a/extension-objects/src/main/java/concreteextensions/Commander.java
+++ b/extension-objects/src/main/java/concreteextensions/Commander.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
 import units.CommanderUnit;
 
 /**
- * Class defining Commander
+ * Class defining Commander.
  */
 public class Commander implements CommanderExtension {
 

--- a/extension-objects/src/main/java/concreteextensions/Sergeant.java
+++ b/extension-objects/src/main/java/concreteextensions/Sergeant.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
 import units.SergeantUnit;
 
 /**
- * Class defining Sergeant
+ * Class defining Sergeant.
  */
 public class Sergeant implements SergeantExtension {
 

--- a/extension-objects/src/main/java/concreteextensions/Soldier.java
+++ b/extension-objects/src/main/java/concreteextensions/Soldier.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
 import units.SoldierUnit;
 
 /**
- * Class defining Soldier
+ * Class defining Soldier.
  */
 public class Soldier implements SoldierExtension {
   private static final Logger LOGGER = LoggerFactory.getLogger(Soldier.class);

--- a/extension-objects/src/main/java/units/CommanderUnit.java
+++ b/extension-objects/src/main/java/units/CommanderUnit.java
@@ -27,7 +27,7 @@ import abstractextensions.UnitExtension;
 import concreteextensions.Commander;
 
 /**
- * Class defining CommanderUnit
+ * Class defining CommanderUnit.
  */
 public class CommanderUnit extends Unit {
 

--- a/extension-objects/src/main/java/units/SergeantUnit.java
+++ b/extension-objects/src/main/java/units/SergeantUnit.java
@@ -27,7 +27,7 @@ import abstractextensions.UnitExtension;
 import concreteextensions.Sergeant;
 
 /**
- * Class defining SergeantUnit
+ * Class defining SergeantUnit.
  */
 public class SergeantUnit extends Unit {
 

--- a/extension-objects/src/main/java/units/SoldierUnit.java
+++ b/extension-objects/src/main/java/units/SoldierUnit.java
@@ -27,7 +27,7 @@ import abstractextensions.UnitExtension;
 import concreteextensions.Soldier;
 
 /**
- * Class defining SoldierUnit
+ * Class defining SoldierUnit.
  */
 public class SoldierUnit extends Unit {
 

--- a/extension-objects/src/main/java/units/Unit.java
+++ b/extension-objects/src/main/java/units/Unit.java
@@ -26,7 +26,7 @@ package units;
 import abstractextensions.UnitExtension;
 
 /**
- * Class defining Unit, other units will extend this class
+ * Class defining Unit, other units will extend this class.
  */
 public class Unit {
 


### PR DESCRIPTION
Reduces checkstyle errors for patterns:
* execute-around
* extension-objects

Changes Involved
- java docs
- reordering imports
- indentations
- line length issues