### PR TITLE
Fixes typo in twin pattern description (in the JavaDocs)

### DIFF
--- a/twin/src/main/java/com/iluwatar/twin/App.java
+++ b/twin/src/main/java/com/iluwatar/twin/App.java
@@ -25,10 +25,10 @@ package com.iluwatar.twin;
 
 /**
  * Twin pattern is a design pattern which provides a standard solution to simulate multiple
- * inheritance in java.
+ * inheritance in Java.
  *
  * <p>In this example, the essence of the Twin pattern is the {@link BallItem} class and {@link
- * BallThread} class represent the twin objects to coordinate with each other(via the twin
+ * BallThread} class represent the twin objects to coordinate with each other (via the twin
  * reference) like a single class inheriting from {@link GameItem} and {@link Thread}.
  */
 


### PR DESCRIPTION
Adds a blank in the sentence

> coordinate with each other(via the twin BallThread} class represent the twin objects to coordinate with each other (via the twin reference)

after "other".

Moreover, I capitalized Java.
