### PR TITLE
Changes the description of the prototype pattern

### DIFF
--- a/prototype/README.md
+++ b/prototype/README.md
@@ -40,8 +40,12 @@ class Sheep implements Cloneable {
   public void setName(String name) { this.name = name; }
   public String getName() { return name; }
   @Override
-  public Sheep clone() throws CloneNotSupportedException {
-    return new Sheep(name);
+  public Sheep clone() {
+    try {
+      return (Sheep)super.clone();
+    } catch(CloneNotSuportedException) {
+      throw new InternalError();
+    }
   }
 }
 ```


### PR DESCRIPTION
You mention in the code example how the protoype pattern can be implemented in Java with the help of Java cloning (i.e. with support of Object.clone()), but then you should also invoke Object.clone.

With the implementation

    public Sheep clone() throws CloneNotSupportedException {
      return new Sheep(name);
    }

it would not be possible (in general) to override clone() in a subclass (e.g. SpecialSheep), because invoking super.clone would return an object of the wrong type, and if we create a new instance of SpecialSheep it is not always possible to copy over the private fields.

This problem can be fixed by using the mechanism provided by Object.clone, i.e. by invoking super.clone(). This creates a shallow copy (which is just fine in this example as the type of the name field (String) is immutable.
