### PR TITLE
Fix typo for leader-election pattern description

### DIFF
--- a/leader-election/README.md
+++ b/leader-election/README.md
@@ -9,7 +9,7 @@ tags:
 ---
 
 ## Intent
-Leader Election pattern is commonly used in cloud system design. It can help to ensure that task instances selec the leader instance correctly and do not conflict with each other, cause contention for shared resources, or inadvertently interfere with the work that other task instances are performing.
+Leader Election pattern is commonly used in cloud system design. It can help to ensure that task instances select the leader instance correctly and do not conflict with each other, cause contention for shared resources, or inadvertently interfere with the work that other task instances are performing.
 
 ## Class diagram
 ![alt text](./etc/leader-election.urm.png "Leader Election pattern class diagram")


### PR DESCRIPTION
Just fix a typo `selec` -> `select`
