### PR TITLE
Fixes Issue #1462 - Unit Test assertEquals parameters are reversed

### DIFF
--- a/arrange-act-assert/src/test/java/com/iluwatar/arrangeactassert/CashAAATest.java
+++ b/arrange-act-assert/src/test/java/com/iluwatar/arrangeactassert/CashAAATest.java
@@ -60,7 +60,7 @@ public class CashAAATest {
     //Act
     cash.plus(4);
     //Assert
-    assertEquals(cash.count(), 7);
+    assertEquals(7, cash.count());
   }
 
   @Test
@@ -71,7 +71,7 @@ public class CashAAATest {
     var result = cash.minus(5);
     //Assert
     assertTrue(result);
-    assertEquals(cash.count(), 3);
+    assertEquals(3, cash.count());
   }
 
   @Test
@@ -82,7 +82,7 @@ public class CashAAATest {
     var result = cash.minus(6);
     //Assert
     assertFalse(result);
-    assertEquals(cash.count(), 1);
+    assertEquals(1, cash.count());
   }
 
   @Test
@@ -94,6 +94,6 @@ public class CashAAATest {
     var result = cash.minus(3);
     //Assert
     assertTrue(result);
-    assertEquals(cash.count(), 8);
+    assertEquals(8, cash.count());
   }
 }

--- a/arrange-act-assert/src/test/java/com/iluwatar/arrangeactassert/CashAntiAAATest.java
+++ b/arrange-act-assert/src/test/java/com/iluwatar/arrangeactassert/CashAntiAAATest.java
@@ -44,16 +44,16 @@ public class CashAntiAAATest {
     var cash = new Cash(3);
     //test plus
     cash.plus(4);
-    assertEquals(cash.count(), 7);
+    assertEquals(7, cash.count());
     //test minus
     cash = new Cash(8);
     assertTrue(cash.minus(5));
-    assertEquals(cash.count(), 3);
+    assertEquals(3, cash.count());
     assertFalse(cash.minus(6));
-    assertEquals(cash.count(), 3);
+    assertEquals(3, cash.count());
     //test update
     cash.plus(5);
     assertTrue(cash.minus(5));
-    assertEquals(cash.count(), 3);
+    assertEquals(3, cash.count());
   }
 }


### PR DESCRIPTION
Opened for issue https://github.com/iluwatar/java-design-patterns/issues/1462

This PR fixes the assertEquals parameter order in the arrange-act-assert module. 

assertEquals should be expected,  actual. Currently these are reversed and in the incorrect order. 