### PR TITLE
updated workflows

### DIFF
--- a/.github/workflows/maven-ci.yml
+++ b/.github/workflows/maven-ci.yml
@@ -1,6 +1,6 @@
 #
 # The MIT License
-# Copyright © 2014-2020 Ilkka Seppälä
+# Copyright © 2014-2019 Ilkka Seppälä
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/.github/workflows/maven-ci.yml
+++ b/.github/workflows/maven-ci.yml
@@ -24,12 +24,10 @@
 # This workflow will build a Java project with Maven
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
-name: Java CI with Maven
+name: Java CI
 
 on:
   push:
-    branches: [ master ]
-  pull_request:
     branches: [ master ]
 
 jobs:
@@ -43,6 +41,12 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 11
+    - uses: actions/cache@v1
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
     # Some tests need screen access
     - name: Install xvfb
       run: sudo apt-get install xvfb

--- a/.github/workflows/maven-ci.yml
+++ b/.github/workflows/maven-ci.yml
@@ -1,6 +1,6 @@
 #
 # The MIT License
-# Copyright © 2014-2019 Ilkka Seppälä
+# Copyright © 2014-2020 Ilkka Seppälä
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/.github/workflows/maven-ci.yml
+++ b/.github/workflows/maven-ci.yml
@@ -41,7 +41,7 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 11
-    - uses: actions/cache@v1
+    - uses: actions/cache@v2
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/maven-pr-builder.yml
+++ b/.github/workflows/maven-pr-builder.yml
@@ -1,6 +1,6 @@
 #
 # The MIT License
-# Copyright © 2014-2020 Ilkka Seppälä
+# Copyright © 2014-2019 Ilkka Seppälä
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/.github/workflows/maven-pr-builder.yml
+++ b/.github/workflows/maven-pr-builder.yml
@@ -1,0 +1,64 @@
+#
+# The MIT License
+# Copyright © 2014-2019 Ilkka Seppälä
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Java PR Builder
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-18.04
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    - uses: actions/cache@v1
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
+    # Some tests need screen access
+    - name: Install xvfb
+      run: sudo apt-get install xvfb
+    # SonarQube scan does not work for forked repositories
+    # See https://jira.sonarsource.com/browse/MMF-1371
+    - name: Build with Maven
+      if: github.ref != 'refs/heads/master'
+      run: xvfb-run mvn clean verify
+    - name: Build with Maven and run SonarQube analysis
+      if: github.ref == 'refs/heads/master'
+      run: xvfb-run mvn clean verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
+      env:
+        # These two env variables are needed for sonar analysis
+        GITHUB_TOKEN: ${{ secrets.REPOSITORY_ACCESS_TOKEN }}
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/maven-pr-builder.yml
+++ b/.github/workflows/maven-pr-builder.yml
@@ -1,6 +1,6 @@
 #
 # The MIT License
-# Copyright © 2014-2019 Ilkka Seppälä
+# Copyright © 2014-2020 Ilkka Seppälä
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/.github/workflows/maven-pr-builder.yml
+++ b/.github/workflows/maven-pr-builder.yml
@@ -41,7 +41,7 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 11
-    - uses: actions/cache@v1
+    - uses: actions/cache@v2
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -55,10 +55,3 @@ jobs:
     - name: Build with Maven
       if: github.ref != 'refs/heads/master'
       run: xvfb-run mvn clean verify
-    - name: Build with Maven and run SonarQube analysis
-      if: github.ref == 'refs/heads/master'
-      run: xvfb-run mvn clean verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
-      env:
-        # These two env variables are needed for sonar analysis
-        GITHUB_TOKEN: ${{ secrets.REPOSITORY_ACCESS_TOKEN }}
-        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Updated Continuous Integration Workflows

- [x] Created a separate job named [Java PR Builder](https://github.com/iluwatar/java-design-patterns/compare/master...ohbus:master#diff-5ebc8c8e2c5faeb9c6834e98789d79be) for handling Pull Requests
- [x] Added caching of maven dependencies for both the jobs


### What's the improvement for having a seperate PR builder?
- PR builder job will not show the build as **failing** anymore in the [readme section badge](https://github.com/iluwatar/java-design-patterns/workflows/Java%20CI%20with%20Maven/badge.svg) for a faulty PR.

### How is caching going to help?
- Subsequent builds will be much faster reducing overall build time
- All artifacts from the previous build will be cached and need not be downloaded again for building the code.
- It will update the cache if newer dependencies are added to the **pom** files after completion of the job.