### PR TITLE
Fix typo in README for Observer pattern

### DIFF
--- a/observer/README.md
+++ b/observer/README.md
@@ -46,7 +46,7 @@ public class Orcs implements WeatherObserver {
 
   @Override
   public void update(WeatherType currentWeather) {
-    LOGGER.info("The hobbits are facing " + currentWeather.getDescription() + " weather now");
+    LOGGER.info("The orcs are facing " + currentWeather.getDescription() + " weather now");
   }
 }
 


### PR DESCRIPTION
### Pull request description

The log message in the Orcs class should say orcs instead of hobbits.
This is correct in the code example but wrong in the README.
