### PR TITLE
Configure build to disable shallow clone

### DIFF
--- a/.github/workflows/maven-ci.yml
+++ b/.github/workflows/maven-ci.yml
@@ -37,6 +37,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        # Disabling shallow clone for improving relevancy of SonarQube reporting
+        fetch-depth: 0
     - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:


### PR DESCRIPTION
The message on Sonar Cloud displays the warning

> Shallow clone detected during the analysis. Some files will miss SCM information. This will affect features like auto-assignment of issues. Please configure your build to disable shallow clone.

- [x] To help eliminate this warning. I have made the changes to **disable** shallow clone.