### PR TITLE
Fix links on the event sourcing page

### DIFF
--- a/event-sourcing/README.md
+++ b/event-sourcing/README.md
@@ -24,11 +24,11 @@ Use the Event Sourcing pattern when
 
 ## Real world examples
 
-* [The Lmax Architecture] (https://martinfowler.com/articles/lmax.html)
+* [The Lmax Architecture](https://martinfowler.com/articles/lmax.html)
 
 ## Credits
 
-* [Martin Fowler - Event Sourcing] (https://martinfowler.com/eaaDev/EventSourcing.html)
-* [Event Sourcing | Microsoft Docs] (https://docs.microsoft.com/en-us/azure/architecture/patterns/event-sourcing)
-* [Reference 3: Introducing Event Sourcing] (https://msdn.microsoft.com/en-us/library/jj591559.aspx)
+* [Martin Fowler - Event Sourcing](https://martinfowler.com/eaaDev/EventSourcing.html)
+* [Event Sourcing | Microsoft Docs](https://docs.microsoft.com/en-us/azure/architecture/patterns/event-sourcing)
+* [Reference 3: Introducing Event Sourcing](https://msdn.microsoft.com/en-us/library/jj591559.aspx)
 * [Event Sourcing pattern](https://docs.microsoft.com/en-us/azure/architecture/patterns/event-sourcing)


### PR DESCRIPTION
I saw that some of the links on the [event sourcing page](https://java-design-patterns.com/patterns/event-sourcing/) were broken due to spaces in the markdown between link description and link URL.
This simply removes the spaces to render the URLs correctly.
