### PR TITLE
issue 1500 - using JUnit 5 and resolved a build issue

### DIFF
--- a/trampoline/pom.xml
+++ b/trampoline/pom.xml
@@ -35,11 +35,6 @@
     </parent>
     <artifactId>trampoline</artifactId>
     <dependencies>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/trampoline/src/main/java/com/iluwatar/trampoline/Trampoline.java
+++ b/trampoline/src/main/java/com/iluwatar/trampoline/Trampoline.java
@@ -98,12 +98,12 @@ public interface Trampoline<T> {
         return trampoline(this);
       }
 
-      T trampoline(final Trampoline<T> trampoline) {
+      private T trampoline(final Trampoline<T> trampoline) {
         return Stream.iterate(trampoline, Trampoline::jump)
             .filter(Trampoline::complete)
             .findFirst()
             .map(Trampoline::result)
-            .orElseThrow();
+            .get();
       }
     };
   }

--- a/trampoline/src/test/java/com/iluwatar/trampoline/TrampolineAppTest.java
+++ b/trampoline/src/test/java/com/iluwatar/trampoline/TrampolineAppTest.java
@@ -23,10 +23,9 @@
 
 package com.iluwatar.trampoline;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
-
+import org.junit.jupiter.api.Test;
 
 /**
  * Test for trampoline pattern.
@@ -37,7 +36,7 @@ public class TrampolineAppTest {
   @Test
   public void testTrampolineWithFactorialFunction() {
     long result = TrampolineApp.loop(10, 1).result();
-    assertEquals("Be equal", 3628800, result);
+    assertEquals(3_628_800, result);
   }
 
 }


### PR DESCRIPTION
### Using JUnit 5

## Reason
- [Build](https://github.com/iluwatar/java-design-patterns/pull/1528/checks?check_run_id=1172522129) failed with below error.
```
Error:  Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1:compile (default-compile) on project trampoline: Compilation failure
Error:  /home/runner/work/java-design-patterns/java-design-patterns/trampoline/src/main/java/com/iluwatar/trampoline/Trampoline.java:[101,9] method does not override or implement a method from a supertype
Error:    (due to <>, every non-private method declared in this anonymous class must override or implement a method from a supertype)
```

- Noticed using JUnit 4 and there is an issue for using JUnit 5.


## Pull request description

- Fixed the code to pass the build
- Used JUnit 5

## Sample Output

```
[INFO] Running com.iluwatar.trampoline.TrampolineAppTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.176 s - in com.iluwatar.trampoline.TrampolineAppTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
```