### PR TITLE
Update Pull Requests CI trigger behaviour

### DIFF
--- a/.github/workflows/maven-ci.yml
+++ b/.github/workflows/maven-ci.yml
@@ -39,7 +39,8 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v2
+    - name: Checkout Code
+      uses: actions/checkout@v2
       with:
         # Disabling shallow clone for improving relevancy of SonarQube reporting
         fetch-depth: 0
@@ -56,7 +57,8 @@ jobs:
         key: ${{ runner.os }}-sonar
         restore-keys: ${{ runner.os }}-sonar
 
-    - uses: actions/cache@v2
+    - name: Cache Maven dependencies
+      uses: actions/cache@v2
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/maven-pr-builder.yml
+++ b/.github/workflows/maven-pr-builder.yml
@@ -29,6 +29,7 @@ name: Java PR Builder
 on:
   pull_request:
     branches: [ master ]
+    types: [ opened, reopened, synchronize, labeled, unlabeled ]
 
 jobs:
   build:
@@ -36,20 +37,26 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout Code
+      uses: actions/checkout@v2
+    
     - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
         java-version: 11
-    - uses: actions/cache@v2
+    
+    - name: Cache Maven Dependecies
+      uses: actions/cache@v2
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
           ${{ runner.os }}-maven-
+    
     # Some tests need screen access
     - name: Install xvfb
       run: sudo apt-get install -y xvfb
+    
     # This worflow is only for building Pull Requests, the master branch runs Sonar analysis on the main repository.
     # SonarQube scan does not work for forked repositories.
     # See https://jira.sonarsource.com/browse/MMF-1371


### PR DESCRIPTION
# Improve Pull Request trigger behaviour

### Why does it need any improvement?
⛔ Reopened Pull Request will not start to build automatically
⛔ Labelling and unlabelling them will not start a build


### The Pull Request Builder will now automatically get triggered on the following events:
- [x] opened
- [x] reopened
- [x] synchronize
- [x] labeled
- [x] unlabeled


#### These additional behaviours will work on top of the existing behaviour of:
✔️  Opening a new Pull Request.
✔️  Pushing a new commit to existing Pull Request.

