### PR TITLE
update gitignore for checkstyle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,8 @@ target
 .classpath
 .project
 *.class
-# Package Files #
+
+### Package Files ###
 *.jar
 *.war
 *.ear
@@ -13,7 +14,8 @@ target
 *.swp
 datanucleus.log
 /bin/
-/bin/
-/bin/
 *.log
 event-sourcing/Journal.json
+
+### Checkstyle ###
+.checkstyle


### PR DESCRIPTION
Tried with Eclipse Java EE 2020-09 on Linux and 2020-12 on Windows platform.

**.checkstyle** files are being tracked which should not be