### PR TITLE
Remove labeling trigger for PR and actions set to master

### DIFF
--- a/.github/workflows/maven-ci.yml
+++ b/.github/workflows/maven-ci.yml
@@ -40,25 +40,25 @@ jobs:
     steps:
 
     - name: Checkout Code
-      uses: actions/checkout@v2
+      uses: actions/checkout@master
       with:
         # Disabling shallow clone for improving relevancy of SonarQube reporting
         fetch-depth: 0
 
     - name: Set up JDK 11
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@master
       with:
         java-version: 11
 
     - name: Cache SonarCloud packages
-      uses: actions/cache@v2
+      uses: actions/cache@master
       with:
         path: ~/.sonar/cache
         key: ${{ runner.os }}-sonar
         restore-keys: ${{ runner.os }}-sonar
 
     - name: Cache Maven dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@master
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -69,9 +69,6 @@ jobs:
     - name: Install xvfb
       run: sudo apt-get install -y xvfb
 
-    # The SonarQube analysis is only for the master branch of the main repository.
-    # SonarQube scan does not work for forked repositories try changing it to xvfb-run mvn clean verify
-    # See https://jira.sonarsource.com/browse/MMF-1371
     - name: Build with Maven and run SonarQube analysis
       run: xvfb-run ./mvnw clean verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
       env:

--- a/.github/workflows/maven-pr-builder.yml
+++ b/.github/workflows/maven-pr-builder.yml
@@ -29,7 +29,7 @@ name: Java PR Builder
 on:
   pull_request:
     branches: [ master ]
-    types: [ opened, reopened, synchronize, labeled, unlabeled ]
+    types: [ opened, reopened, synchronize ]
 
 jobs:
   build:
@@ -38,15 +38,15 @@ jobs:
 
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v2
+      uses: actions/checkout@master
     
     - name: Set up JDK 11
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@master
       with:
         java-version: 11
     
     - name: Cache Maven Dependecies
-      uses: actions/cache@v2
+      uses: actions/cache@master
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -57,8 +57,5 @@ jobs:
     - name: Install xvfb
       run: sudo apt-get install -y xvfb
     
-    # This worflow is only for building Pull Requests, the master branch runs Sonar analysis on the main repository.
-    # SonarQube scan does not work for forked repositories.
-    # See https://jira.sonarsource.com/browse/MMF-1371
     - name: Build with Maven
       run: xvfb-run ./mvnw clean verify


### PR DESCRIPTION
- [x] Removed ❌ the 🏷️  **labeled** and **unlabeled** behavior of triggering builds for Pull Requests.

- [x] Updated the versions of actions by GitHub to refer to the latest release directly by pointing to master