### PR TITLE
Adding back labelling build triggers to PR

### DIFF
--- a/.github/workflows/maven-pr-builder.yml
+++ b/.github/workflows/maven-pr-builder.yml
@@ -29,7 +29,7 @@ name: Java PR Builder
 on:
   pull_request:
     branches: [ master ]
-    types: [ opened, reopened, synchronize ]
+    types: [ opened, reopened, synchronize, labeled, unlabeled ]
 
 jobs:
   build:


### PR DESCRIPTION
labeling PR should trigger builds again for all-contributors bot as this is creating a problem.