### PR TITLE
task: remove labelling trigger

### DIFF
--- a/.github/workflows/maven-pr-builder.yml
+++ b/.github/workflows/maven-pr-builder.yml
@@ -29,7 +29,7 @@ name: Java PR Builder
 on:
   pull_request:
     branches: [ master ]
-    types: [ opened, reopened, synchronize, labeled, unlabeled ]
+    types: [ opened, reopened, synchronize ]
 
 jobs:
   build:


### PR DESCRIPTION
As labelling is not triggering builds we must revert back to this to avoid unnecessary triggers.