### PR TITLE
Improvement: multiple-assertions unit test into parameterized one

### DIFF
--- a/multiton/pom.xml
+++ b/multiton/pom.xml
@@ -38,6 +38,11 @@
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
+      <dependency>
+          <groupId>org.junit.jupiter</groupId>
+          <artifactId>junit-jupiter-params</artifactId>
+          <scope>test</scope>
+      </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/multiton/src/test/java/com/iluwatar/multiton/NazgulEnumTest.java
+++ b/multiton/src/test/java/com/iluwatar/multiton/NazgulEnumTest.java
@@ -25,7 +25,8 @@ package com.iluwatar.multiton;
 
 import static org.junit.jupiter.api.Assertions.assertSame;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 /**
  * @author anthony
@@ -37,15 +38,14 @@ class NazgulEnumTest {
    * Check that multiple calls to any one of the instances in the multiton returns
    * only that one particular instance, and do that for all instances in multiton
    */
-  @Test
-  void testTheSameObjectIsReturnedWithMultipleCalls() {
-    for (var i = 0; i < NazgulEnum.values().length; i++) {
-      var instance1 = NazgulEnum.values()[i];
-      var instance2 = NazgulEnum.values()[i];
-      var instance3 = NazgulEnum.values()[i];
-      assertSame(instance1, instance2);
-      assertSame(instance1, instance3);
-      assertSame(instance2, instance3);
-    }
+  @ParameterizedTest
+  @EnumSource
+  void testTheSameObjectIsReturnedWithMultipleCalls(NazgulEnum nazgulEnum) {
+    var instance1 = nazgulEnum;
+    var instance2 = nazgulEnum;
+    var instance3 = nazgulEnum;
+    assertSame(instance1, instance2);
+    assertSame(instance1, instance3);
+    assertSame(instance2, instance3);
   }
 }


### PR DESCRIPTION
Problem:
A test method with many individual assertions stops being executed on the first failed assertion, which prevents the remaining ones' execution. In the refactored method, the difference between the assertions lies within different arguments only.

Solution:
Parameterized tests make it possible to run a test multiple times, with different arguments, as individual and independent tests. This way, we were able to make 1 original test with 9 assertions become 9 independent ones, one for each enumeration element. 

Additional change:
Maven dependency concerning the JUnit params library was also added.