### PR TITLE
Correcting the Hyperlink to redirect to correct URL.

### DIFF
--- a/double-buffer/README.md
+++ b/double-buffer/README.md
@@ -25,4 +25,4 @@ This pattern is one of those ones where you’ll know when you need it. If you h
 
 ## Credits  
   
-* [Game Programming Patterns - Double Buffer]([http://gameprogrammingpatterns.com/double-buffer.html](http://gameprogrammingpatterns.com/double-buffer.html))
+* [Game Programming Patterns - Double Buffer](http://gameprogrammingpatterns.com/double-buffer.html)


### PR DESCRIPTION
**This Pull request Corresponds to bug #1703**

**Corrected the Double Buffer Pattern Credits Link**

This PR updates the credits URL in Double Buffer Pattern to re-direct to the correct URL .
 

As a part of this PR , I have edited the `Readme.md` file source for `Credits` section . 
The problem was that it was containing additional braces due to which the URL was not being re-directed to the correct website.

Please could someone review the PR. Thanks.