### PR TITLE
Correcting the URL to fix #1747  -  Bugfix/1747

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=iluwatar_java-design-patterns&metric=coverage)](https://sonarcloud.io/dashboard?id=iluwatar_java-design-patterns)
 [![Join the chat at https://gitter.im/iluwatar/java-design-patterns](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/iluwatar/java-design-patterns?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-164-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-164-orange.svg?style=flat-square)](#contributors)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 <br/>

--- a/double-buffer/README.md
+++ b/double-buffer/README.md
@@ -25,4 +25,4 @@ This pattern is one of those ones where you’ll know when you need it. If you h
 
 ## Credits  
   
-* [Game Programming Patterns - Double Buffer]([http://gameprogrammingpatterns.com/double-buffer.html](http://gameprogrammingpatterns.com/double-buffer.html))
+* [Game Programming Patterns - Double Buffer](http://gameprogrammingpatterns.com/double-buffer.html)


### PR DESCRIPTION
This PR resolves #1747 .


An extra Hyphen( - )  was appended to the URL of contributors badge due to which the URL was not correctly routing to all contributors section . 

This PR deletes the hyphen and fixes the URL for `all contributors` badge.



