### PR TITLE
Simplify switch statement using Enums

### DIFF
--- a/flyweight/README.md
+++ b/flyweight/README.md
@@ -18,20 +18,20 @@ Use sharing to support large numbers of fine-grained objects efficiently.
 
 Real world example
 
-> Alchemist's shop has shelves full of magic potions. Many of the potions are the same so there is 
-> no need to create new object for each of them. Instead one object instance can represent multiple 
+> Alchemist's shop has shelves full of magic potions. Many of the potions are the same so there is
+> no need to create new object for each of them. Instead one object instance can represent multiple
 > shelf items so memory footprint remains small.
 
 In plain words
 
-> It is used to minimize memory usage or computational expenses by sharing as much as possible with 
+> It is used to minimize memory usage or computational expenses by sharing as much as possible with
 > similar objects.
 
 Wikipedia says
 
-> In computer programming, flyweight is a software design pattern. A flyweight is an object that 
-> minimizes memory use by sharing as much data as possible with other similar objects; it is a way 
-> to use objects in large numbers when a simple repeated representation would use an unacceptable 
+> In computer programming, flyweight is a software design pattern. A flyweight is an object that
+> minimizes memory use by sharing as much data as possible with other similar objects; it is a way
+> to use objects in large numbers when a simple repeated representation would use an unacceptable
 > amount of memory.
 
 **Programmatic example**
@@ -82,22 +82,8 @@ public class PotionFactory {
   Potion createPotion(PotionType type) {
     var potion = potions.get(type);
     if (potion == null) {
-      switch (type) {
-        case HEALING:
-          potion = new HealingPotion();
-          potions.put(type, potion);
-          break;
-        case HOLY_WATER:
-          potion = new HolyWaterPotion();
-          potions.put(type, potion);
-          break;
-        case INVISIBILITY:
-          potion = new InvisibilityPotion();
-          potions.put(type, potion);
-          break;
-        default:
-          break;
-      }
+      potion = type.getPotion();
+      potions.put(type, potion);
     }
     return potion;
   }
@@ -133,15 +119,15 @@ You feel healed. (Potion=648129364)
 
 ## Applicability
 
-The Flyweight pattern's effectiveness depends heavily on how and where it's used. Apply the 
+The Flyweight pattern's effectiveness depends heavily on how and where it's used. Apply the
 Flyweight pattern when all of the following are true:
 
 * An application uses a large number of objects.
 * Storage costs are high because of the sheer quantity of objects.
 * Most object state can be made extrinsic.
-* Many groups of objects may be replaced by relatively few shared objects once extrinsic state is 
+* Many groups of objects may be replaced by relatively few shared objects once extrinsic state is
 removed.
-* The application doesn't depend on object identity. Since flyweight objects may be shared, identity 
+* The application doesn't depend on object identity. Since flyweight objects may be shared, identity
 tests will return true for conceptually distinct objects.
 
 ## Real world examples

--- a/flyweight/etc/flyweight.urm.puml
+++ b/flyweight/etc/flyweight.urm.puml
@@ -49,6 +49,7 @@ package com.iluwatar.flyweight {
     + STRENGTH {static}
     + valueOf(name : String) : PotionType {static}
     + values() : PotionType[] {static}
+    + getPotion() : {abstract} Potion
   }
   class StrengthPotion {
     - LOGGER : Logger {static}
@@ -57,9 +58,9 @@ package com.iluwatar.flyweight {
   }
 }
 AlchemistShop -->  "-topShelf" Potion
-HealingPotion ..|> Potion 
-HolyWaterPotion ..|> Potion 
-InvisibilityPotion ..|> Potion 
-PoisonPotion ..|> Potion 
-StrengthPotion ..|> Potion 
+HealingPotion ..|> Potion
+HolyWaterPotion ..|> Potion
+InvisibilityPotion ..|> Potion
+PoisonPotion ..|> Potion
+StrengthPotion ..|> Potion
 @enduml

--- a/flyweight/src/main/java/com/iluwatar/flyweight/PotionFactory.java
+++ b/flyweight/src/main/java/com/iluwatar/flyweight/PotionFactory.java
@@ -24,6 +24,7 @@
 package com.iluwatar.flyweight;
 
 import java.util.EnumMap;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -41,31 +42,10 @@ public class PotionFactory {
 
   Potion createPotion(PotionType type) {
     var potion = potions.get(type);
+
     if (potion == null) {
-      switch (type) {
-        case HEALING:
-          potion = new HealingPotion();
-          potions.put(type, potion);
-          break;
-        case HOLY_WATER:
-          potion = new HolyWaterPotion();
-          potions.put(type, potion);
-          break;
-        case INVISIBILITY:
-          potion = new InvisibilityPotion();
-          potions.put(type, potion);
-          break;
-        case POISON:
-          potion = new PoisonPotion();
-          potions.put(type, potion);
-          break;
-        case STRENGTH:
-          potion = new StrengthPotion();
-          potions.put(type, potion);
-          break;
-        default:
-          break;
-      }
+      potion = type.getPotion();
+      potions.put(type, potion);
     }
     return potion;
   }

--- a/flyweight/src/main/java/com/iluwatar/flyweight/PotionType.java
+++ b/flyweight/src/main/java/com/iluwatar/flyweight/PotionType.java
@@ -28,5 +28,40 @@ package com.iluwatar.flyweight;
  */
 public enum PotionType {
 
-  HEALING, INVISIBILITY, STRENGTH, HOLY_WATER, POISON
+  HEALING {
+    @Override
+    public Potion getPotion() {
+      return new HealingPotion();
+    }
+  },
+
+  INVISIBILITY {
+    @Override
+    public Potion getPotion() {
+      return new InvisibilityPotion();
+    }
+  },
+  STRENGTH {
+    @Override
+    public Potion getPotion() {
+      return new StrengthPotion();
+    }
+  },
+
+  HOLY_WATER {
+    @Override
+    public Potion getPotion() {
+      return new HolyWaterPotion();
+    }
+  },
+
+  POISON {
+    @Override
+    public Potion getPotion() {
+      return new PoisonPotion();
+    }
+  }
+  ;
+
+  public abstract Potion getPotion();
 }


### PR DESCRIPTION
If we add more enums then we need to add more
switch cases which is not a good coding convention.
Instead using Enums abstract function feature to
provide the definition


Add a new abstract function in Enum to create a new Potion object rather
than having several switch cases to create one.