### PR TITLE
#1667: Fixing the serverless tests to use Junit5 and execute

### DIFF
--- a/aggregator-microservices/aggregator-service/src/test/java/com/iluwatar/aggregator/microservices/AggregatorTest.java
+++ b/aggregator-microservices/aggregator-service/src/test/java/com/iluwatar/aggregator/microservices/AggregatorTest.java
@@ -48,7 +48,7 @@ class AggregatorTest {
 
   @BeforeEach
   public void setup() {
-    MockitoAnnotations.initMocks(this);
+    MockitoAnnotations.openMocks(this);
   }
 
   /**

--- a/api-gateway/api-gateway-service/src/test/java/com/iluwatar/api/gateway/ApiGatewayTest.java
+++ b/api-gateway/api-gateway-service/src/test/java/com/iluwatar/api/gateway/ApiGatewayTest.java
@@ -48,7 +48,7 @@ class ApiGatewayTest {
 
   @BeforeEach
   public void setup() {
-    MockitoAnnotations.initMocks(this);
+    MockitoAnnotations.openMocks(this);
   }
 
   /**

--- a/async-method-invocation/src/test/java/com/iluwatar/async/method/invocation/ThreadAsyncExecutorTest.java
+++ b/async-method-invocation/src/test/java/com/iluwatar/async/method/invocation/ThreadAsyncExecutorTest.java
@@ -68,7 +68,7 @@ class ThreadAsyncExecutorTest {
 
   @BeforeEach
   void setUp() {
-    MockitoAnnotations.initMocks(this);
+    MockitoAnnotations.openMocks(this);
   }
 
   /**

--- a/data-bus/src/test/java/com/iluwatar/databus/DataBusTest.java
+++ b/data-bus/src/test/java/com/iluwatar/databus/DataBusTest.java
@@ -46,7 +46,7 @@ class DataBusTest {
 
   @BeforeEach
   void setUp() {
-    MockitoAnnotations.initMocks(this);
+    MockitoAnnotations.openMocks(this);
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <slf4j.version>1.7.30</slf4j.version>
         <logback.version>1.2.3</logback.version>
         <aws-lambda-core.version>1.1.0</aws-lambda-core.version>
-        <aws-java-sdk-dynamodb.version>1.11.289</aws-java-sdk-dynamodb.version>
+        <aws-java-sdk-dynamodb.version>1.12.13</aws-java-sdk-dynamodb.version>
         <aws-lambda-java-events.version>2.0.1</aws-lambda-java-events.version>
         <jackson.version>2.12.3</jackson.version>
         <jaxb-api.version>2.3.1</jaxb-api.version>
@@ -72,7 +72,7 @@
         <urm.version>2.0.0</urm.version>
         <mockito-junit-jupiter.version>3.5.0</mockito-junit-jupiter.version>
         <lombok.version>1.18.14</lombok.version>
-        <byte-buddy.version>1.10.21</byte-buddy.version>
+        <byte-buddy.version>1.11.5</byte-buddy.version>
         <javassist.version>3.27.0-GA</javassist.version>
         <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
         <maven-checkstyle-plugin.version>3.1.0</maven-checkstyle-plugin.version>

--- a/serverless/pom.xml
+++ b/serverless/pom.xml
@@ -44,16 +44,6 @@
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-dynamodb</artifactId>
             <version>${aws-java-sdk-dynamodb.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.amazonaws</groupId>
-                    <artifactId>aws-java-sdk-s3</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.amazonaws</groupId>
-                    <artifactId>aws-java-sdk-kms</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
@@ -80,15 +70,15 @@
             <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<scope>test</scope>
+		</dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
+          <groupId>org.hamcrest</groupId>
+          <artifactId>hamcrest-core</artifactId>
+          <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/serverless/src/test/java/com/iluwatar/serverless/baas/api/FindPersonApiHandlerTest.java
+++ b/serverless/src/test/java/com/iluwatar/serverless/baas/api/FindPersonApiHandlerTest.java
@@ -23,6 +23,9 @@
 
 package com.iluwatar.serverless.baas.api;
 
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -32,16 +35,13 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.iluwatar.serverless.baas.model.Person;
 import java.util.Map;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Unit tests for FindPersonApiHandler Created by dheeraj.mummar on 3/5/18.
  */
-@RunWith(MockitoJUnitRunner.class)
 public class FindPersonApiHandlerTest {
 
   private FindPersonApiHandler findPersonApiHandler;
@@ -49,8 +49,9 @@ public class FindPersonApiHandlerTest {
   @Mock
   private DynamoDBMapper dynamoDbMapper;
 
-  @Before
+  @BeforeEach
   public void setUp() {
+    MockitoAnnotations.openMocks(this);
     this.findPersonApiHandler = new FindPersonApiHandler();
     this.findPersonApiHandler.setDynamoDbMapper(dynamoDbMapper);
   }

--- a/serverless/src/test/java/com/iluwatar/serverless/baas/api/FindPersonApiHandlerTest.java
+++ b/serverless/src/test/java/com/iluwatar/serverless/baas/api/FindPersonApiHandlerTest.java
@@ -42,7 +42,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 /**
  * Unit tests for FindPersonApiHandler Created by dheeraj.mummar on 3/5/18.
  */
-public class FindPersonApiHandlerTest {
+class FindPersonApiHandlerTest {
 
   private FindPersonApiHandler findPersonApiHandler;
 
@@ -57,7 +57,7 @@ public class FindPersonApiHandlerTest {
   }
 
   @Test
-  public void handleRequest() {
+  void handleRequest() {
     findPersonApiHandler.handleRequest(apiGatewayProxyRequestEvent(), mock(Context.class));
     verify(dynamoDbMapper, times(1)).load(Person.class, "37e7a1fe-3544-473d-b764-18128f02d72d");
   }

--- a/serverless/src/test/java/com/iluwatar/serverless/baas/api/SavePersonApiHandlerTest.java
+++ b/serverless/src/test/java/com/iluwatar/serverless/baas/api/SavePersonApiHandlerTest.java
@@ -36,7 +36,6 @@ import com.iluwatar.serverless.baas.model.Address;
 import com.iluwatar.serverless.baas.model.Person;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -46,7 +45,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 /**
  * Unit tests for SavePersonApiHandler Created by dheeraj.mummar on 3/4/18.
  */
-public class SavePersonApiHandlerTest {
+class SavePersonApiHandlerTest {
 
   private SavePersonApiHandler savePersonApiHandler;
 
@@ -63,7 +62,7 @@ public class SavePersonApiHandlerTest {
   }
 
   @Test
-  public void handleRequestSavePersonSuccessful() throws JsonProcessingException {
+  void handleRequestSavePersonSuccessful() throws JsonProcessingException {
     var person = newPerson();
     var body = objectMapper.writeValueAsString(person);
     var request = apiGatewayProxyRequestEvent(body);
@@ -75,7 +74,7 @@ public class SavePersonApiHandlerTest {
   }
 
   @Test
-  public void handleRequestSavePersonException() {
+  void handleRequestSavePersonException() {
     var request = apiGatewayProxyRequestEvent("invalid sample request");
     var ctx = mock(Context.class);
     var apiGatewayProxyResponseEvent = this.savePersonApiHandler.handleRequest(request, ctx);

--- a/serverless/src/test/java/com/iluwatar/serverless/baas/api/SavePersonApiHandlerTest.java
+++ b/serverless/src/test/java/com/iluwatar/serverless/baas/api/SavePersonApiHandlerTest.java
@@ -34,17 +34,18 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.iluwatar.serverless.baas.model.Address;
 import com.iluwatar.serverless.baas.model.Person;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Unit tests for SavePersonApiHandler Created by dheeraj.mummar on 3/4/18.
  */
-@RunWith(MockitoJUnitRunner.class)
 public class SavePersonApiHandlerTest {
 
   private SavePersonApiHandler savePersonApiHandler;
@@ -54,8 +55,9 @@ public class SavePersonApiHandlerTest {
 
   private final ObjectMapper objectMapper = new ObjectMapper();
 
-  @Before
+  @BeforeEach
   public void setUp() {
+    MockitoAnnotations.openMocks(this);
     this.savePersonApiHandler = new SavePersonApiHandler();
     this.savePersonApiHandler.setDynamoDbMapper(dynamoDbMapper);
   }
@@ -68,8 +70,8 @@ public class SavePersonApiHandlerTest {
     var ctx = mock(Context.class);
     var apiGatewayProxyResponseEvent = this.savePersonApiHandler.handleRequest(request, ctx);
     verify(dynamoDbMapper, times(1)).save(person);
-    Assert.assertNotNull(apiGatewayProxyResponseEvent);
-    Assert.assertEquals(Integer.valueOf(201), apiGatewayProxyResponseEvent.getStatusCode());
+    assertNotNull(apiGatewayProxyResponseEvent);
+    assertEquals(Integer.valueOf(201), apiGatewayProxyResponseEvent.getStatusCode());
   }
 
   @Test
@@ -77,8 +79,8 @@ public class SavePersonApiHandlerTest {
     var request = apiGatewayProxyRequestEvent("invalid sample request");
     var ctx = mock(Context.class);
     var apiGatewayProxyResponseEvent = this.savePersonApiHandler.handleRequest(request, ctx);
-    Assert.assertNotNull(apiGatewayProxyResponseEvent);
-    Assert.assertEquals(Integer.valueOf(400), apiGatewayProxyResponseEvent.getStatusCode());
+    assertNotNull(apiGatewayProxyResponseEvent);
+    assertEquals(Integer.valueOf(400), apiGatewayProxyResponseEvent.getStatusCode());
   }
 
   private APIGatewayProxyRequestEvent apiGatewayProxyRequestEvent(String body) {


### PR DESCRIPTION
This issue fixes #1667

Here is what changed:

- Added JUnit5 libraries for serverless
- Removed the s3 SDK exclusions for serverless dependencies
- Replaced the deprecated `MockitoAnnotations.initMocks(this)` with `MockitoAnnotations.openMocks(this)`