### PR TITLE
Fix domain model not showing on the web site

### DIFF
--- a/domain-model/README.md
+++ b/domain-model/README.md
@@ -4,11 +4,15 @@ title: Domain Model
 folder: domain-model
 permalink: /patterns/domain-model/
 categories: Architectural
+language: en
 tags:
  - Domain
 ---
+
 ## Intent
+
 Domain model pattern provides an object-oriented way of dealing with complicated logic. Instead of having one procedure that handles all business logic for a user action there are multiple objects and each of them handles a slice of domain logic that is relevant to it.
+
 ## Explanation
 
 Real world example


### PR DESCRIPTION
I noticed that the newly added domain model pattern doesn't show on the website https://java-design-patterns.com. The probable cause for this is the missing language definition from the YAML front matter.