### PR TITLE
Remove unnecessary and possibly not threadsafe flag

### DIFF
--- a/singleton/src/main/java/com/iluwatar/singleton/ThreadSafeDoubleCheckLocking.java
+++ b/singleton/src/main/java/com/iluwatar/singleton/ThreadSafeDoubleCheckLocking.java
@@ -36,16 +36,12 @@ public final class ThreadSafeDoubleCheckLocking {
 
   private static volatile ThreadSafeDoubleCheckLocking instance;
 
-  private static boolean flag = true;
-
   /**
    * private constructor to prevent client from instantiating.
    */
   private ThreadSafeDoubleCheckLocking() {
     // to prevent instantiating by Reflection call
-    if (flag) {
-      flag = false;
-    } else {
+    if (instance != null) {
       throw new IllegalStateException("Already initialized.");
     }
   }

--- a/singleton/src/main/java/com/iluwatar/singleton/ThreadSafeLazyLoadedIvoryTower.java
+++ b/singleton/src/main/java/com/iluwatar/singleton/ThreadSafeLazyLoadedIvoryTower.java
@@ -34,9 +34,7 @@ public final class ThreadSafeLazyLoadedIvoryTower {
 
   private ThreadSafeLazyLoadedIvoryTower() {
     // Protect against instantiation via reflection
-    if (instance == null) {
-      instance = this;
-    } else {
+    if (instance != null) {
       throw new IllegalStateException("Already initialized.");
     }
   }


### PR DESCRIPTION
Remove unnecessary flag.

Introducing a new static flag to prevent instantiation via reflection is unnecessary. It's been defined as a static variable and therefore it is a shared data, it most likely needs proper synchronization.

besides, I believe it lacks proper readability.

Pull request description

- remove the flag
- check the instance variable to prevent reflection call

