### PR TITLE
Refactor Prototype pattern

### DIFF
--- a/prototype/src/main/java/com/iluwatar/prototype/Beast.java
+++ b/prototype/src/main/java/com/iluwatar/prototype/Beast.java
@@ -37,6 +37,12 @@ public abstract class Beast implements Prototype {
   }
 
   @Override
-  public abstract Beast copy();
+  public Beast clone() {
+    try {
+      return (Beast) super.clone();
+    } catch (CloneNotSupportedException e) {
+      throw new RuntimeException(e);
+    }
+  }
 
 }

--- a/prototype/src/main/java/com/iluwatar/prototype/ElfBeast.java
+++ b/prototype/src/main/java/com/iluwatar/prototype/ElfBeast.java
@@ -41,8 +41,8 @@ public class ElfBeast extends Beast {
   }
 
   @Override
-  public ElfBeast copy() {
-    return new ElfBeast(this);
+  public ElfBeast clone() {
+    return (ElfBeast) super.clone();
   }
 
   @Override

--- a/prototype/src/main/java/com/iluwatar/prototype/ElfMage.java
+++ b/prototype/src/main/java/com/iluwatar/prototype/ElfMage.java
@@ -41,8 +41,8 @@ public class ElfMage extends Mage {
   }
 
   @Override
-  public ElfMage copy() {
-    return new ElfMage(this);
+  public ElfMage clone() {
+    return (ElfMage) super.clone();
   }
 
   @Override

--- a/prototype/src/main/java/com/iluwatar/prototype/ElfWarlord.java
+++ b/prototype/src/main/java/com/iluwatar/prototype/ElfWarlord.java
@@ -28,7 +28,7 @@ import lombok.EqualsAndHashCode;
 /**
  * ElfWarlord.
  */
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
 public class ElfWarlord extends Warlord {
 
   private final String helpType;
@@ -43,8 +43,8 @@ public class ElfWarlord extends Warlord {
   }
 
   @Override
-  public ElfWarlord copy() {
-    return new ElfWarlord(this);
+  public ElfWarlord clone() {
+    return (ElfWarlord) super.clone();
   }
 
   @Override

--- a/prototype/src/main/java/com/iluwatar/prototype/HeroFactoryImpl.java
+++ b/prototype/src/main/java/com/iluwatar/prototype/HeroFactoryImpl.java
@@ -39,21 +39,21 @@ public class HeroFactoryImpl implements HeroFactory {
    * Create mage.
    */
   public Mage createMage() {
-    return mage.copy();
+    return mage.clone();
   }
 
   /**
    * Create warlord.
    */
   public Warlord createWarlord() {
-    return warlord.copy();
+    return warlord.clone();
   }
 
   /**
    * Create beast.
    */
   public Beast createBeast() {
-    return beast.copy();
+    return beast.clone();
   }
 
 }

--- a/prototype/src/main/java/com/iluwatar/prototype/Mage.java
+++ b/prototype/src/main/java/com/iluwatar/prototype/Mage.java
@@ -37,6 +37,12 @@ public abstract class Mage implements Prototype {
   }
 
   @Override
-  public abstract Mage copy();
+  public Mage clone() {
+    try {
+      return (Mage) super.clone();
+    } catch (CloneNotSupportedException e) {
+      throw new RuntimeException(e);
+    }
+  }
 
 }

--- a/prototype/src/main/java/com/iluwatar/prototype/OrcBeast.java
+++ b/prototype/src/main/java/com/iluwatar/prototype/OrcBeast.java
@@ -29,7 +29,7 @@ import lombok.RequiredArgsConstructor;
 /**
  * OrcBeast.
  */
-@EqualsAndHashCode(callSuper = false)
+@EqualsAndHashCode(callSuper = true)
 @RequiredArgsConstructor
 public class OrcBeast extends Beast {
 
@@ -41,8 +41,8 @@ public class OrcBeast extends Beast {
   }
 
   @Override
-  public OrcBeast copy() {
-    return new OrcBeast(this);
+  public OrcBeast clone() {
+    return (OrcBeast) super.clone();
   }
 
   @Override

--- a/prototype/src/main/java/com/iluwatar/prototype/OrcMage.java
+++ b/prototype/src/main/java/com/iluwatar/prototype/OrcMage.java
@@ -41,8 +41,8 @@ public class OrcMage extends Mage {
   }
 
   @Override
-  public OrcMage copy() {
-    return new OrcMage(this);
+  public OrcMage clone() {
+    return (OrcMage) super.clone();
   }
 
   @Override

--- a/prototype/src/main/java/com/iluwatar/prototype/OrcWarlord.java
+++ b/prototype/src/main/java/com/iluwatar/prototype/OrcWarlord.java
@@ -41,8 +41,8 @@ public class OrcWarlord extends Warlord {
   }
 
   @Override
-  public OrcWarlord copy() {
-    return new OrcWarlord(this);
+  public OrcWarlord clone() {
+    return (OrcWarlord) super.clone();
   }
 
   @Override

--- a/prototype/src/main/java/com/iluwatar/prototype/Prototype.java
+++ b/prototype/src/main/java/com/iluwatar/prototype/Prototype.java
@@ -26,8 +26,8 @@ package com.iluwatar.prototype;
 /**
  * Prototype.
  */
-public interface Prototype {
+public interface Prototype extends Cloneable {
 
-  Object copy();
+  Prototype clone();
 
 }

--- a/prototype/src/main/java/com/iluwatar/prototype/Warlord.java
+++ b/prototype/src/main/java/com/iluwatar/prototype/Warlord.java
@@ -37,6 +37,12 @@ public abstract class Warlord implements Prototype {
   }
 
   @Override
-  public abstract Warlord copy();
+  public Warlord clone() {
+    try {
+      return (Warlord) super.clone();
+    } catch (CloneNotSupportedException e) {
+      throw new RuntimeException(e);
+    }
+  }
 
 }

--- a/prototype/src/test/java/com/iluwatar/prototype/PrototypeTest.java
+++ b/prototype/src/test/java/com/iluwatar/prototype/PrototypeTest.java
@@ -56,7 +56,7 @@ class PrototypeTest<P extends Prototype> {
   void testPrototype(P testedPrototype, String expectedToString) {
     assertEquals(expectedToString, testedPrototype.toString());
 
-    final var clone = testedPrototype.copy();
+    final var clone = testedPrototype.clone();
     assertNotNull(clone);
     assertNotSame(clone, testedPrototype);
     assertSame(testedPrototype.getClass(), clone.getClass());


### PR DESCRIPTION
This PR refactors parts of the Prototype pattern by making it `Cloneable` and thus inheriting the `clone()` method to its subclasses.

- Fixes #584
