### PR TITLE
Change some codes to make it thread-safe.

### DIFF
--- a/event-asynchronous/src/main/java/com/iluwatar/event/asynchronous/EventManager.java
+++ b/event-asynchronous/src/main/java/com/iluwatar/event/asynchronous/EventManager.java
@@ -135,15 +135,16 @@ public class EventManager implements ThreadCompleteListener {
    * @throws EventDoesNotExistException If event does not exist in our eventPool.
    */
   public void cancel(int eventId) throws EventDoesNotExistException {
-    if (!eventPool.containsKey(eventId)) {
+    Event event = eventPool.get(eventId);
+    if (!event) {
       throw new EventDoesNotExistException(eventId + DOES_NOT_EXIST);
     }
-
+ee
     if (eventId == currentlyRunningSyncEvent) {
       currentlyRunningSyncEvent = -1;
     }
 
-    eventPool.get(eventId).stop();
+    event.stop();
     eventPool.remove(eventId);
   }
 
@@ -154,11 +155,12 @@ public class EventManager implements ThreadCompleteListener {
    * @throws EventDoesNotExistException If event does not exist in our eventPool.
    */
   public void status(int eventId) throws EventDoesNotExistException {
-    if (!eventPool.containsKey(eventId)) {
+    Event event = eventPool.get(eventId);
+    if (!event) {
       throw new EventDoesNotExistException(eventId + DOES_NOT_EXIST);
     }
 
-    eventPool.get(eventId).status();
+    event.status();
   }
 
   /**

--- a/reactor/src/main/java/com/iluwatar/reactor/framework/AbstractNioChannel.java
+++ b/reactor/src/main/java/com/iluwatar/reactor/framework/AbstractNioChannel.java
@@ -162,13 +162,11 @@ public abstract class AbstractNioChannel {
     if (pendingWrites == null) {
       synchronized (this.channelToPendingWrites) {
         pendingWrites = this.channelToPendingWrites.get(key.channel());
-        if (pendingWrites == null) {
-          pendingWrites = new ConcurrentLinkedQueue<>();
-          this.channelToPendingWrites.put(key.channel(), pendingWrites);
-        }
+        this.channelToPendingWrites.putIfAbsent(key.channel(), new ConcurrentLinkedQueue<>();
       }
     }
     pendingWrites.add(data);
     reactor.changeOps(key, SelectionKey.OP_WRITE);
   }
 }
+f


### PR DESCRIPTION
- containsKey() and get() may not be thread-safe. In between the check and the get() another thread can remove the key and the get() will return null. calling get(), checking instead of your current check if the returned object is null, and then using that object only, without calling get() again.
- Replacing the check and put() with putIfAbsent() and then removing the synchronization. putIfAbsent() is thread-safe and puts the value only if the ConcurrentHashMap does not contain the key. putIfAbsent() returns null if the value did not exist and returns the value in the map if one already exists.