### PR TITLE
Constant for log code in order to avoid repeating

### DIFF
--- a/acyclic-visitor/src/main/java/com/iluwatar/acyclicvisitor/ConfigureForDosVisitor.java
+++ b/acyclic-visitor/src/main/java/com/iluwatar/acyclicvisitor/ConfigureForDosVisitor.java
@@ -31,14 +31,16 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Slf4j
 public class ConfigureForDosVisitor implements AllModemVisitor {
+  
+  private static final String USED_WITH_DOS_CONFIGURATOR = " used with Dos configurator.";
 
   @Override
   public void visit(Hayes hayes) {
-    LOGGER.info(hayes + " used with Dos configurator.");
+    LOGGER.info(hayes + USED_WITH_DOS_CONFIGURATOR);
   }
 
   @Override
   public void visit(Zoom zoom) {
-    LOGGER.info(zoom + " used with Dos configurator.");
+    LOGGER.info(zoom + USED_WITH_DOS_CONFIGURATOR);
   }
 }


### PR DESCRIPTION

Constant for log code in order to avoid repeating

- In order to avoid repeating the same log line, we can extract a private constant for it.


Pull request description

Avoid repeating the same log line.



> For detailed contributing instructions see https://github.com/iluwatar/java-design-patterns/wiki/01.-How-to-contribute
