### PR TITLE
Using TCK tested OpenJDK builds of the latest LTS and fixed (major) version releases in GH Actions.

### DIFF
--- a/.github/workflows/maven-ci.yml
+++ b/.github/workflows/maven-ci.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        java-version: [ 11.0.3, 11, 17 ]
+        java-version: [ 11.0.3, 11 ]
     steps:
 
     - name: Checkout Code

--- a/.github/workflows/maven-pr-builder.yml
+++ b/.github/workflows/maven-pr-builder.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        java-version: [ 11.0.3, 11, 17, 18-ea ]
+        java-version: [ 11.0.3, 11 ]
     steps:
     - name: Checkout Code
       uses: actions/checkout@v2


### PR DESCRIPTION
Signed-off-by: Carl Dea <carldea@gmail.com>


### Using the latest LTS and fixed (major) versions of the OpenJDK.

The AdoptOpenJDK has been discontinued since July 2021 (https://adoptopenjdk.net). This request is to switch the distribution from `adopt` to Azul `zulu`. When using Zulu you get all the latest updated (TCK Tested) builds for all versions of OpenJDK (even archived fixed versions and early access releases).

In the workflow (GH Action) I added a fixed (major) release version such as `JDK 11.0.3`. This is often a good practice whenever a build triggers to help determine if the latest (`JDK 11`) had failed and why. Usually you're trying to figure out what happened wheter it's from the **latest build** vs something in **your code** that caused (or introduced) the issue. 

**For example**, when building with `JDK 11.0.3` (fixed version) the build/tests passes (Green) and JDK 11 fails (Red) will mean that the latest `JDK 11` was the cause and not your code. Some customers/vendors typically have `JDK 11.0.3` and aren't ready to move to the latest.

**Note:** Other distributions such as Temurin do not support archived fixed releases prior to **Sept. 2021** and many of the non-LTS (long term support) releases (ie: 18-ea). This is often the case when/if you are planning to try out newer features in the Java language.
The following are benefits:

- Ensure backwards compatibility on fixed (major) releases of OpenJDK
- TCK tested builds of the OpenJDK
- Get the latest of LTS and non-LTS versions, means security updates.
- Experimentation with newer language features.

### Updating 2 Github Actions (workflows) 

- Changed the distribution to use Zulu
- Added a matrix (array) of JDK versions to provide coverage
The following is an excerpt of the changes in the workflow `maven-pr-builder.yml`
```yaml
   strategy:
      matrix:
        java-version: [ 11.0.3, 11, 17, 18-ea ]
        
... later in steps:

   - name: Set up JDK ${{ matrix.java-version }}
      uses: actions/setup-java@v2
      with:
        java-version: ${{ matrix.java-version }}
        distribution: 'zulu'        
        
```

## Sonar issue.
One minor issue in my fork, is when using my `SONAR_TOKEN` I'm not authorized, so my workflows (fork) fails.


Thank you, 
:-)

Carl
> For detailed contributing instructions see https://github.com/iluwatar/java-design-patterns/wiki/01.-How-to-contribute
