### PR TITLE
Fix typo, grammer and links

### DIFF
--- a/localization/de/README.md
+++ b/localization/de/README.md
@@ -13,43 +13,48 @@
 
 # Einführung
 
-Entwurfsmuster sind die besten formalisierten Praktiken, die ein Programmierer verwenden kann,
+Entwurfsmuster sind die besten formalisierten Methoden, die ein Programmierer verwenden kann,
 um allgemeine Probleme beim Entwurf einer Anwendung oder eines Systems zu lösen.
 
-Entwurfsmuster können den Entwicklungsprozess beschleunigen, indem sie getestete, bewährte
+Entwurfsmuster können den Entwicklungsprozess beschleunigen, indem sie getestete und bewährte
 Entwicklungsparadigmen bereitstellen.
 
 Die Wiederverwendung von Entwurfsmustern hilft, subtile Probleme zu vermeiden, die größere
-Probleme verursachen können, und es verbessert auch die Lesbarkeit des Codes für Programmierer und Architekten, 
-welche mit den Mustern vertraut sind.
+Probleme verursachen können. 
+Außerdem verbessert es auch die Lesbarkeit des Codes für Programmierer und Architekten, 
+welche mit den Prinzipien der Entwurfsmuster vertraut sind.
 
 # Erste Schritte
 
-Auf dieser Website werden Java Design Patterns vorgestellt, wobei die Etwurfsmuster von erfahrenen Programmierern und Architekten aus der Open-Source-Gemeinschaft entwickelt werden.
+Auf dieser Website werden Java Design Patterns vorgestellt, wobei die Etwurfsmuster von
+erfahrenen Programmierern und Architekten aus der Open-Source-Gemeinschaft entwickelt werden.
 Die Entwurfsmuster können anhand der übergeordneten Beschreibungen oder anhand des Quellcodes gesucht werden.
-Die Quellcode-Beispiele sind gut kommentiert und können als Programmiertutorials zur Implementierung eines bestimmten Entwurfmusters betrachtet werden. 
-Wir verwenden die bewährten Open-Source-Java-Technologien.
+Die Quellcode-Beispiele sind gut kommentiert und können als Programmiertutorials zur Implementierung 
+eines bestimmten Entwurfmusters betrachtet werden. 
+Wir verwenden hier die bewährten Open-Source-Java-Technologien.
 
-Bevor Sie in die Materie der Entwurfsmuster Eintauchen, sollten sie sich mit den verschiednen [Software-Entwurfsprinzipien](https://java-design-patterns.com/principles/) auseinandersetzen.
+Bevor Sie in die Materie der Entwurfsmuster eintauchen, sollten sie sich mit den verschiednen 
+[Software-Entwurfsprinzipien](https://java-design-patterns.com/principles/) auseinandersetzen.
 
 Alle Entwürfe sollten so einfach wie möglich gehalten werden. 
-Dafür sollten Sie sich zu beginnen mit den _KISS_ (Keep It Simple, Stupid), _YAGNI_ (You Ain’t Gonna Need It) und _Do The Simplest Thing That Could Possibly Work_ prinzipen vertraut machen.
+Dafür sollten Sie sich zu beginnen mit den _KISS_ (Keep It Simple, Stupid), 
+_YAGNI_ (You Ain’t Gonna Need It) und _Do The Simplest Thing That Could Possibly Work_ prinzipen vertraut machen.
 Komplexe Entwurfsmuster sollen nur eingesetzt werden, wenn diese für sinnvolle Erweiterungen benötigt werden.
 
-Sobald Sie mit diesen Konzepten vertraut sind, können Sie beginnen, sich mit den verfügbaren Entwurfsmuster durch einen der
-der folgenden Ansätze auseinanderzusetzen. 
+Sobald Sie mit diesen Konzepten vertraut sind, können Sie beginnen, sich mit den verfügbaren Entwurfsmuster auseinanderzusetzen. 
 
- - Suchen Sie nach einem bestimmten Muster anhand des Namens. Sie können keins finden? Bitte melden Sie [hier] ein neues Muster (https://github.com/iluwatar/java-design-patterns/issues).
+ - Suchen Sie nach einem bestimmten Muster anhand des Namens. 
+ Sie können keins finden? Bitte melden Sie ein neues Muster [hier](https://github.com/iluwatar/java-design-patterns/issues).
  - Verwendung von Tags wie `Performance`, `Gang of Four` oder `Data access`.
- - Verwendung von Musterkategorien wie `Creational`, `Behavioral` und andere.
+ - Verwendung von Entwurfsmuster-Kategorien wie `Creational`, `Behavioral` und andere.
 
 Ich hoffe, Sie finden die auf dieser Website vorgestellten objektorientierten Lösungen für Ihre Architekturen nützlich und dass Sie genauso viel Spaß beim Lernen haben, wie wir bei ihrer Entwicklung hatten.
 
 # Wie man etwas zu diesem Projekt beitragen kann
 
 Wenn Sie zu dem Projekt beitragen wollen, finden Sie die entsprechenden Informationen in
-unserem [Entwickler-Wiki] (https://github.com/iluwatar/java-design-patterns/wiki). Wir werden Ihnen helfen
-und beantworten Ihre Fragen im [Gitter chatroom](https://gitter.im/iluwatar/java-design-patterns).
+unserem [Entwickler-Wiki](https://github.com/iluwatar/java-design-patterns/wiki). 
+Wir helfen Ihnen gerne und beantworten Ihre Fragen im [Gitter chatroom](https://gitter.im/iluwatar/java-design-patterns).
 
 # Lizenz
 


### PR DESCRIPTION
Fix grammar typo issues in the German translation of the README
Fix the link visualization in the German README