### PR TITLE
Fix claim check frontmatter

### DIFF
--- a/cloud-claim-check-pattern/README.md
+++ b/cloud-claim-check-pattern/README.md
@@ -4,6 +4,7 @@ title: Claim Check Pattern
 folder: cloud-claim-check-pattern
 permalink: /patterns/cloud-claim-check-pattern/
 categories: Cloud
+language: en
 tags:
   - Cloud distributed
   - Microservices


### PR DESCRIPTION
The new claim check pattern is not visible on java-design-patterns.com. I suspect the reason is that the pattern's frontmatter is missing the language definition. I'm adding it in this pull request.
