### PR TITLE
Update Gitignore for OSX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ tmp/
 local.properties
 .loadpath
 .recommenders
+.DS_Store
 
 #######  Java annotation processor (APT) ########
 .factorypath


### PR DESCRIPTION
Update gitignore to not include a commonly created file by OSX systems called `.DS_Store`