### PR TITLE
Refactor Prototype pattern (Closes #584)

### DIFF
--- a/lombok.config
+++ b/lombok.config
@@ -1,2 +1,2 @@
 lombok.log.fieldName = LOGGER
-
+lombok.addLombokGeneratedAnnotation = true

--- a/prototype/README.md
+++ b/prototype/README.md
@@ -22,7 +22,7 @@ used for creating new objects from prototype instances.
 
 Real-world example
 
-> Remember Dolly? The sheep that was cloned! Lets not get into the details but the key point here is 
+> Remember Dolly? The sheep that was cloned! Let's not get into the details but the key point here is 
 > that it is all about cloning.
 
 In plain words
@@ -45,8 +45,11 @@ interface with a method for cloning objects. In this example, `Prototype` interf
 this with its `copy` method.
 
 ```java
-public interface Prototype {
-  Object copy();
+public abstract class Prototype<T> implements Cloneable {
+    @SneakyThrows
+    public T copy() {
+        return (T) super.clone();
+    }
 }
 ```
 
@@ -54,15 +57,13 @@ Our example contains a hierarchy of different creatures. For example, let's look
 `OrcBeast` classes.
 
 ```java
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 @NoArgsConstructor
-public abstract class Beast implements Prototype {
+public abstract class Beast extends Prototype<Beast> {
 
   public Beast(Beast source) {
   }
 
-  @Override
-  public abstract Beast copy();
 }
 
 @EqualsAndHashCode(callSuper = false)
@@ -77,18 +78,14 @@ public class OrcBeast extends Beast {
   }
 
   @Override
-  public OrcBeast copy() {
-    return new OrcBeast(this);
-  }
-
-  @Override
   public String toString() {
     return "Orcish wolf attacks with " + weapon;
   }
+
 }
 ```
 
-We don't want to go into too much details, but the full example contains also base classes `Mage`
+We don't want to go into too many details, but the full example contains also base classes `Mage`
 and `Warlord` and there are specialized implementations for those for elves in addition to orcs.
 
 To take full advantage of the prototype pattern, we create `HeroFactory` and `HeroFactoryImpl`

--- a/prototype/src/main/java/com/iluwatar/prototype/Beast.java
+++ b/prototype/src/main/java/com/iluwatar/prototype/Beast.java
@@ -29,14 +29,11 @@ import lombok.NoArgsConstructor;
 /**
  * Beast.
  */
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 @NoArgsConstructor
-public abstract class Beast implements Prototype {
+public abstract class Beast extends Prototype<Beast> {
 
   public Beast(Beast source) {
   }
-
-  @Override
-  public abstract Beast copy();
 
 }

--- a/prototype/src/main/java/com/iluwatar/prototype/ElfBeast.java
+++ b/prototype/src/main/java/com/iluwatar/prototype/ElfBeast.java
@@ -41,11 +41,6 @@ public class ElfBeast extends Beast {
   }
 
   @Override
-  public ElfBeast copy() {
-    return new ElfBeast(this);
-  }
-
-  @Override
   public String toString() {
     return "Elven eagle helps in " + helpType;
   }

--- a/prototype/src/main/java/com/iluwatar/prototype/ElfMage.java
+++ b/prototype/src/main/java/com/iluwatar/prototype/ElfMage.java
@@ -41,11 +41,6 @@ public class ElfMage extends Mage {
   }
 
   @Override
-  public ElfMage copy() {
-    return new ElfMage(this);
-  }
-
-  @Override
   public String toString() {
     return "Elven mage helps in " + helpType;
   }

--- a/prototype/src/main/java/com/iluwatar/prototype/ElfWarlord.java
+++ b/prototype/src/main/java/com/iluwatar/prototype/ElfWarlord.java
@@ -24,27 +24,20 @@
 package com.iluwatar.prototype;
 
 import lombok.EqualsAndHashCode;
+import lombok.RequiredArgsConstructor;
 
 /**
  * ElfWarlord.
  */
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
+@RequiredArgsConstructor
 public class ElfWarlord extends Warlord {
 
   private final String helpType;
 
-  public ElfWarlord(String helpType) {
-    this.helpType = helpType;
-  }
-
   public ElfWarlord(ElfWarlord elfWarlord) {
     super(elfWarlord);
     this.helpType = elfWarlord.helpType;
-  }
-
-  @Override
-  public ElfWarlord copy() {
-    return new ElfWarlord(this);
   }
 
   @Override

--- a/prototype/src/main/java/com/iluwatar/prototype/Mage.java
+++ b/prototype/src/main/java/com/iluwatar/prototype/Mage.java
@@ -29,14 +29,11 @@ import lombok.NoArgsConstructor;
 /**
  * Mage.
  */
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 @NoArgsConstructor
-public abstract class Mage implements Prototype {
+public abstract class Mage extends Prototype<Mage> {
 
   public Mage(Mage source) {
   }
-
-  @Override
-  public abstract Mage copy();
 
 }

--- a/prototype/src/main/java/com/iluwatar/prototype/OrcBeast.java
+++ b/prototype/src/main/java/com/iluwatar/prototype/OrcBeast.java
@@ -41,11 +41,6 @@ public class OrcBeast extends Beast {
   }
 
   @Override
-  public OrcBeast copy() {
-    return new OrcBeast(this);
-  }
-
-  @Override
   public String toString() {
     return "Orcish wolf attacks with " + weapon;
   }

--- a/prototype/src/main/java/com/iluwatar/prototype/OrcMage.java
+++ b/prototype/src/main/java/com/iluwatar/prototype/OrcMage.java
@@ -41,11 +41,6 @@ public class OrcMage extends Mage {
   }
 
   @Override
-  public OrcMage copy() {
-    return new OrcMage(this);
-  }
-
-  @Override
   public String toString() {
     return "Orcish mage attacks with " + weapon;
   }

--- a/prototype/src/main/java/com/iluwatar/prototype/OrcWarlord.java
+++ b/prototype/src/main/java/com/iluwatar/prototype/OrcWarlord.java
@@ -41,11 +41,6 @@ public class OrcWarlord extends Warlord {
   }
 
   @Override
-  public OrcWarlord copy() {
-    return new OrcWarlord(this);
-  }
-
-  @Override
   public String toString() {
     return "Orcish warlord attacks with " + weapon;
   }

--- a/prototype/src/main/java/com/iluwatar/prototype/Prototype.java
+++ b/prototype/src/main/java/com/iluwatar/prototype/Prototype.java
@@ -23,11 +23,21 @@
 
 package com.iluwatar.prototype;
 
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+
 /**
  * Prototype.
  */
-public interface Prototype {
+@Slf4j
+public abstract class Prototype<T> implements Cloneable {
 
-  Object copy();
-
+  /**
+   * Object a shallow copy of this object or null if this object is not Cloneable.
+   */
+  @SuppressWarnings("unchecked")
+  @SneakyThrows
+  public T copy() {
+    return (T) super.clone();
+  }
 }

--- a/prototype/src/main/java/com/iluwatar/prototype/Warlord.java
+++ b/prototype/src/main/java/com/iluwatar/prototype/Warlord.java
@@ -29,14 +29,11 @@ import lombok.NoArgsConstructor;
 /**
  * Warlord.
  */
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 @NoArgsConstructor
-public abstract class Warlord implements Prototype {
+public abstract class Warlord extends Prototype<Warlord> {
 
   public Warlord(Warlord source) {
   }
-
-  @Override
-  public abstract Warlord copy();
 
 }

--- a/prototype/src/test/java/com/iluwatar/prototype/PrototypeTest.java
+++ b/prototype/src/test/java/com/iluwatar/prototype/PrototypeTest.java
@@ -39,7 +39,7 @@ import org.junit.jupiter.params.provider.MethodSource;
  * @param <P> Prototype
  * @author Jeroen Meulemeester
  */
-class PrototypeTest<P extends Prototype> {
+class PrototypeTest<P extends Prototype<P>> {
   static Collection<Object[]> dataProvider() {
     return List.of(
         new Object[]{new OrcBeast("axe"), "Orcish wolf attacks with axe"},


### PR DESCRIPTION
This PR refactors the Prototype pattern by making it `Cloneable` and thus inheriting the `clone()` method to its subclasses which removes code duplications.

* Fixes [Prototype pattern re-factor #584](https://github.com/iluwatar/java-design-patterns/issues/584)