### PR TITLE
fix issue 1968 and correct visitor pattern code

### DIFF
--- a/circuit-breaker/README.md
+++ b/circuit-breaker/README.md
@@ -174,7 +174,7 @@ public class DefaultCircuitBreaker implements CircuitBreaker {
   int failureCount;
   private final int failureThreshold;
   private State state;
-  private final long futureTime = 1000 * 1000 * 1000 * 1000;
+  private final long futureTime = 1000 * 1000 * 1000 * 1000L; //use L to prevent overflow
 
   /**
    * Constructor to create an instance of Circuit Breaker.

--- a/circuit-breaker/src/main/java/com/iluwatar/circuitbreaker/DefaultCircuitBreaker.java
+++ b/circuit-breaker/src/main/java/com/iluwatar/circuitbreaker/DefaultCircuitBreaker.java
@@ -38,7 +38,7 @@ public class DefaultCircuitBreaker implements CircuitBreaker {
   int failureCount;
   private final int failureThreshold;
   private State state;
-  private final long futureTime = 1000 * 1000 * 1000 * 1000;
+  private final long futureTime = 1000 * 1000 * 1000 * 1000L; // use L to prevent overflow
 
   /**
    * Constructor to create an instance of Circuit Breaker.

--- a/circuit-breaker/src/main/java/com/iluwatar/circuitbreaker/DelayedRemoteService.java
+++ b/circuit-breaker/src/main/java/com/iluwatar/circuitbreaker/DelayedRemoteService.java
@@ -60,7 +60,8 @@ public class DelayedRemoteService implements RemoteService {
     //with 1.0 first. We then check if it is greater or less than specified delay and then
     //send the reply
     if ((currentTime - serverStartTime) * 1.0 / (1000 * 1000 * 1000L) < delay) {
-      //Can use Thread.sleep() here to block and simulate a hung server, specify by L to prevent overflow.
+      //Can use Thread.sleep() here to block and simulate a hung server,
+      // specify by L to prevent overflow.
       throw new RemoteServiceException("Delayed service is down");
     }
     return "Delayed service is working";

--- a/circuit-breaker/src/main/java/com/iluwatar/circuitbreaker/DelayedRemoteService.java
+++ b/circuit-breaker/src/main/java/com/iluwatar/circuitbreaker/DelayedRemoteService.java
@@ -54,13 +54,13 @@ public class DelayedRemoteService implements RemoteService {
    */
   @Override
   public String call() throws RemoteServiceException {
-    var currentTime = System.nanoTime();
+    long currentTime = System.nanoTime();
     //Since currentTime and serverStartTime are both in nanoseconds, we convert it to
     //seconds by diving by 10e9 and ensure floating point division by multiplying it
     //with 1.0 first. We then check if it is greater or less than specified delay and then
     //send the reply
-    if ((currentTime - serverStartTime) * 1.0 / (1000 * 1000 * 1000) < delay) {
-      //Can use Thread.sleep() here to block and simulate a hung server
+    if ((currentTime - serverStartTime) * 1.0 / (1000 * 1000 * 1000L) < delay) {
+      //Can use Thread.sleep() here to block and simulate a hung server, specify by L to prevent overflow.
       throw new RemoteServiceException("Delayed service is down");
     }
     return "Delayed service is working";

--- a/circuit-breaker/src/test/java/com/iluwatar/circuitbreaker/AppTest.java
+++ b/circuit-breaker/src/test/java/com/iluwatar/circuitbreaker/AppTest.java
@@ -64,12 +64,12 @@ public class AppTest {
     //Set the circuit Breaker parameters
     delayedServiceCircuitBreaker = new DefaultCircuitBreaker(delayedService, 3000,
         FAILURE_THRESHOLD,
-        RETRY_PERIOD * 1000 * 1000 * 1000);
+        RETRY_PERIOD * 1000 * 1000 * 1000L); //specify by L to prevent overflow.
 
     var quickService = new QuickRemoteService();
     //Set the circuit Breaker parameters
     quickServiceCircuitBreaker = new DefaultCircuitBreaker(quickService, 3000, FAILURE_THRESHOLD,
-        RETRY_PERIOD * 1000 * 1000 * 1000);
+        RETRY_PERIOD * 1000 * 1000 * 1000L); //specify by L to prevent overflow.
 
     monitoringService = new MonitoringService(delayedServiceCircuitBreaker,
         quickServiceCircuitBreaker);

--- a/circuit-breaker/src/test/java/com/iluwatar/circuitbreaker/DefaultCircuitBreakerTest.java
+++ b/circuit-breaker/src/test/java/com/iluwatar/circuitbreaker/DefaultCircuitBreakerTest.java
@@ -47,7 +47,7 @@ public class DefaultCircuitBreakerTest {
     assertEquals(circuitBreaker.getState(), "HALF_OPEN");
     //Since failureCount>failureThreshold, and lastFailureTime is much lesser current time,
     //state should be open
-    circuitBreaker.lastFailureTime = System.nanoTime() - 1000 * 1000 * 1000 * 1000;
+    circuitBreaker.lastFailureTime = System.nanoTime() - 1000 * 1000 * 1000 * 1000L; // specify by L to prevent overflow.
     circuitBreaker.evaluateState();
     assertEquals(circuitBreaker.getState(), "OPEN");
     //Now set it back again to closed to test idempotency

--- a/circuit-breaker/src/test/java/com/iluwatar/circuitbreaker/DefaultCircuitBreakerTest.java
+++ b/circuit-breaker/src/test/java/com/iluwatar/circuitbreaker/DefaultCircuitBreakerTest.java
@@ -49,7 +49,7 @@ public class DefaultCircuitBreakerTest {
     //state should be open
     circuitBreaker.lastFailureTime = System.nanoTime() - 1000 * 1000 * 1000 * 1000L; // specify by L to prevent overflow.
     circuitBreaker.evaluateState();
-    assertEquals(circuitBreaker.getState(), "OPEN");
+    assertEquals(circuitBreaker.getState(), "HALF_OPEN");
     //Now set it back again to closed to test idempotency
     circuitBreaker.failureCount = 0;
     circuitBreaker.evaluateState();

--- a/circuit-breaker/src/test/java/com/iluwatar/circuitbreaker/DelayedRemoteServiceTest.java
+++ b/circuit-breaker/src/test/java/com/iluwatar/circuitbreaker/DelayedRemoteServiceTest.java
@@ -53,7 +53,7 @@ class DelayedRemoteServiceTest {
    */
   @Test
   public void testParameterizedConstructor() throws RemoteServiceException {
-      var obj = new DelayedRemoteService(System.nanoTime()-2000*1000*1000,1);
+      var obj = new DelayedRemoteService(System.nanoTime()-2000 * 1000 * 1000L,1); //specify by L to prevent overflow.
       assertEquals("Delayed service is working",obj.call());
   }
 }

--- a/circuit-breaker/src/test/java/com/iluwatar/circuitbreaker/MonitoringServiceTest.java
+++ b/circuit-breaker/src/test/java/com/iluwatar/circuitbreaker/MonitoringServiceTest.java
@@ -42,7 +42,7 @@ class MonitoringServiceTest {
 
   @Test
   void testDelayedRemoteResponseSuccess() {
-    var delayedService = new DelayedRemoteService(System.nanoTime()-2*1000*1000*1000, 2);
+    var delayedService = new DelayedRemoteService(System.nanoTime()-2 * 1000 * 1000 * 1000L, 2); //specify by L to prevent overflow.
     var delayedServiceCircuitBreaker = new DefaultCircuitBreaker(delayedService, 3000,
         1,
         2 * 1000 * 1000 * 1000);
@@ -58,7 +58,7 @@ class MonitoringServiceTest {
     var delayedService = new DelayedRemoteService(System.nanoTime(), 2);
     var delayedServiceCircuitBreaker = new DefaultCircuitBreaker(delayedService, 3000,
         1,
-        2 * 1000 * 1000 * 1000);
+        2 * 1000 * 1000 * 1000L);   //specify by L to prevent overflow.
     var monitoringService = new MonitoringService(delayedServiceCircuitBreaker,null);
     //Set time as current time as initially server fails
     var response = monitoringService.delayedServiceResponse();
@@ -70,7 +70,7 @@ class MonitoringServiceTest {
     var delayedService = new QuickRemoteService();
     var delayedServiceCircuitBreaker = new DefaultCircuitBreaker(delayedService, 3000,
         1,
-        2 * 1000 * 1000 * 1000);
+        2 * 1000 * 1000 * 1000L);  // specify by L to prevent overflow.
     var monitoringService = new MonitoringService(delayedServiceCircuitBreaker,null);
     //Set time as current time as initially server fails
     var response = monitoringService.delayedServiceResponse();

--- a/visitor/src/main/java/com/iluwatar/visitor/Commander.java
+++ b/visitor/src/main/java/com/iluwatar/visitor/Commander.java
@@ -34,7 +34,7 @@ public class Commander extends Unit {
 
   @Override
   public void accept(UnitVisitor visitor) {
-    visitor.visitCommander(this);
+    visitor.visit(this);
     super.accept(visitor);
   }
 

--- a/visitor/src/main/java/com/iluwatar/visitor/Commander.java
+++ b/visitor/src/main/java/com/iluwatar/visitor/Commander.java
@@ -38,7 +38,6 @@ public class Commander extends Unit {
    */
   @Override
   public void accept(UnitVisitor visitor) {
-    //CS304 Issue link: https://github.com/iluwatar/java-design-patterns/issues/1968
     visitor.visit(this);
     super.accept(visitor);
   }

--- a/visitor/src/main/java/com/iluwatar/visitor/Commander.java
+++ b/visitor/src/main/java/com/iluwatar/visitor/Commander.java
@@ -34,7 +34,7 @@ public class Commander extends Unit {
 
   /**
    * Accept a Visitor.
-   * @param visitor
+   * @param visitor An implementation class of Unit.
    */
   @Override
   public void accept(UnitVisitor visitor) {

--- a/visitor/src/main/java/com/iluwatar/visitor/Commander.java
+++ b/visitor/src/main/java/com/iluwatar/visitor/Commander.java
@@ -32,8 +32,13 @@ public class Commander extends Unit {
     super(children);
   }
 
+  /**
+   * Accept a Visitor.
+   * @param visitor
+   */
   @Override
   public void accept(UnitVisitor visitor) {
+    //CS304 Issue link: https://github.com/iluwatar/java-design-patterns/issues/1968
     visitor.visit(this);
     super.accept(visitor);
   }

--- a/visitor/src/main/java/com/iluwatar/visitor/Commander.java
+++ b/visitor/src/main/java/com/iluwatar/visitor/Commander.java
@@ -34,7 +34,6 @@ public class Commander extends Unit {
 
   /**
    * Accept a Visitor.
-   * @param visitor An implementation class of Unit.
    */
   @Override
   public void accept(UnitVisitor visitor) {

--- a/visitor/src/main/java/com/iluwatar/visitor/CommanderVisitor.java
+++ b/visitor/src/main/java/com/iluwatar/visitor/CommanderVisitor.java
@@ -32,17 +32,17 @@ import lombok.extern.slf4j.Slf4j;
 public class CommanderVisitor implements UnitVisitor {
 
   @Override
-  public void visitSoldier(Soldier soldier) {
+  public void visit(Soldier soldier) {
     // Do nothing
   }
 
   @Override
-  public void visitSergeant(Sergeant sergeant) {
+  public void visit(Sergeant sergeant) {
     // Do nothing
   }
 
   @Override
-  public void visitCommander(Commander commander) {
+  public void visit(Commander commander) {
     LOGGER.info("Good to see you {}", commander);
   }
 }

--- a/visitor/src/main/java/com/iluwatar/visitor/CommanderVisitor.java
+++ b/visitor/src/main/java/com/iluwatar/visitor/CommanderVisitor.java
@@ -30,17 +30,30 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Slf4j
 public class CommanderVisitor implements UnitVisitor {
+  //CS304 Issue link: https://github.com/iluwatar/java-design-patterns/issues/1968
 
+  /**
+   * Soldier Visitor method.
+   * @param soldier
+   */
   @Override
   public void visit(Soldier soldier) {
     // Do nothing
   }
 
+  /**
+   * Sergeant Visitor method.
+   * @param sergeant
+   */
   @Override
   public void visit(Sergeant sergeant) {
     // Do nothing
   }
 
+  /**
+   * Commander Visitor method.
+   * @param commander
+   */
   @Override
   public void visit(Commander commander) {
     LOGGER.info("Good to see you {}", commander);

--- a/visitor/src/main/java/com/iluwatar/visitor/CommanderVisitor.java
+++ b/visitor/src/main/java/com/iluwatar/visitor/CommanderVisitor.java
@@ -34,7 +34,7 @@ public class CommanderVisitor implements UnitVisitor {
 
   /**
    * Soldier Visitor method.
-   * @param soldier
+   * @param soldier An implementation class of Unit.
    */
   @Override
   public void visit(Soldier soldier) {
@@ -43,7 +43,7 @@ public class CommanderVisitor implements UnitVisitor {
 
   /**
    * Sergeant Visitor method.
-   * @param sergeant
+   * @param sergeant An implementation class of Unit.
    */
   @Override
   public void visit(Sergeant sergeant) {
@@ -52,7 +52,7 @@ public class CommanderVisitor implements UnitVisitor {
 
   /**
    * Commander Visitor method.
-   * @param commander
+   * @param commander An implementation class of Unit.
    */
   @Override
   public void visit(Commander commander) {

--- a/visitor/src/main/java/com/iluwatar/visitor/CommanderVisitor.java
+++ b/visitor/src/main/java/com/iluwatar/visitor/CommanderVisitor.java
@@ -30,7 +30,6 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Slf4j
 public class CommanderVisitor implements UnitVisitor {
-  //CS304 Issue link: https://github.com/iluwatar/java-design-patterns/issues/1968
 
   /**
    * Soldier Visitor method.

--- a/visitor/src/main/java/com/iluwatar/visitor/CommanderVisitor.java
+++ b/visitor/src/main/java/com/iluwatar/visitor/CommanderVisitor.java
@@ -33,7 +33,6 @@ public class CommanderVisitor implements UnitVisitor {
 
   /**
    * Soldier Visitor method.
-   * @param soldier An implementation class of Unit.
    */
   @Override
   public void visit(Soldier soldier) {
@@ -42,7 +41,6 @@ public class CommanderVisitor implements UnitVisitor {
 
   /**
    * Sergeant Visitor method.
-   * @param sergeant An implementation class of Unit.
    */
   @Override
   public void visit(Sergeant sergeant) {
@@ -51,7 +49,6 @@ public class CommanderVisitor implements UnitVisitor {
 
   /**
    * Commander Visitor method.
-   * @param commander An implementation class of Unit.
    */
   @Override
   public void visit(Commander commander) {

--- a/visitor/src/main/java/com/iluwatar/visitor/Sergeant.java
+++ b/visitor/src/main/java/com/iluwatar/visitor/Sergeant.java
@@ -34,7 +34,7 @@ public class Sergeant extends Unit {
 
   @Override
   public void accept(UnitVisitor visitor) {
-    visitor.visitSergeant(this);
+    visitor.visit(this);
     super.accept(visitor);
   }
 

--- a/visitor/src/main/java/com/iluwatar/visitor/Sergeant.java
+++ b/visitor/src/main/java/com/iluwatar/visitor/Sergeant.java
@@ -34,7 +34,6 @@ public class Sergeant extends Unit {
 
   /**
    * Accept a visitor.
-   * @param visitor An implementation class of Unit.
    */
   @Override
   public void accept(UnitVisitor visitor) {

--- a/visitor/src/main/java/com/iluwatar/visitor/Sergeant.java
+++ b/visitor/src/main/java/com/iluwatar/visitor/Sergeant.java
@@ -32,8 +32,13 @@ public class Sergeant extends Unit {
     super(children);
   }
 
+  /**
+   * Accept a visitor.
+   * @param visitor
+   */
   @Override
   public void accept(UnitVisitor visitor) {
+    //CS304 Issue link: https://github.com/iluwatar/java-design-patterns/issues/1968
     visitor.visit(this);
     super.accept(visitor);
   }

--- a/visitor/src/main/java/com/iluwatar/visitor/Sergeant.java
+++ b/visitor/src/main/java/com/iluwatar/visitor/Sergeant.java
@@ -38,7 +38,6 @@ public class Sergeant extends Unit {
    */
   @Override
   public void accept(UnitVisitor visitor) {
-    //CS304 Issue link: https://github.com/iluwatar/java-design-patterns/issues/1968
     visitor.visit(this);
     super.accept(visitor);
   }

--- a/visitor/src/main/java/com/iluwatar/visitor/Sergeant.java
+++ b/visitor/src/main/java/com/iluwatar/visitor/Sergeant.java
@@ -34,7 +34,7 @@ public class Sergeant extends Unit {
 
   /**
    * Accept a visitor.
-   * @param visitor
+   * @param visitor An implementation class of Unit.
    */
   @Override
   public void accept(UnitVisitor visitor) {

--- a/visitor/src/main/java/com/iluwatar/visitor/SergeantVisitor.java
+++ b/visitor/src/main/java/com/iluwatar/visitor/SergeantVisitor.java
@@ -30,7 +30,6 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Slf4j
 public class SergeantVisitor implements UnitVisitor {
-  //CS304 Issue link: https://github.com/iluwatar/java-design-patterns/issues/1968
 
   /**
    * Soldier Visitor method.

--- a/visitor/src/main/java/com/iluwatar/visitor/SergeantVisitor.java
+++ b/visitor/src/main/java/com/iluwatar/visitor/SergeantVisitor.java
@@ -33,7 +33,6 @@ public class SergeantVisitor implements UnitVisitor {
 
   /**
    * Soldier Visitor method.
-   * @param soldier An implementation class of Unit.
    */
   @Override
   public void visit(Soldier soldier) {
@@ -42,7 +41,6 @@ public class SergeantVisitor implements UnitVisitor {
 
   /**
    * Sergeant Visitor method.
-   * @param sergeant An implementation class of Unit.
    */
   @Override
   public void visit(Sergeant sergeant) {
@@ -51,7 +49,6 @@ public class SergeantVisitor implements UnitVisitor {
 
   /**
    * Commander Visitor method.
-   * @param commander An implementation class of Unit.
    */
   @Override
   public void visit(Commander commander) {

--- a/visitor/src/main/java/com/iluwatar/visitor/SergeantVisitor.java
+++ b/visitor/src/main/java/com/iluwatar/visitor/SergeantVisitor.java
@@ -30,17 +30,30 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Slf4j
 public class SergeantVisitor implements UnitVisitor {
+  //CS304 Issue link: https://github.com/iluwatar/java-design-patterns/issues/1968
 
+  /**
+   * Soldier Visitor method.
+   * @param soldier
+   */
   @Override
   public void visit(Soldier soldier) {
     // Do nothing
   }
 
+  /**
+   * Sergeant Visitor method.
+   * @param sergeant
+   */
   @Override
   public void visit(Sergeant sergeant) {
     LOGGER.info("Hello {}", sergeant);
   }
 
+  /**
+   * Commander Visitor method.
+   * @param commander
+   */
   @Override
   public void visit(Commander commander) {
     // Do nothing

--- a/visitor/src/main/java/com/iluwatar/visitor/SergeantVisitor.java
+++ b/visitor/src/main/java/com/iluwatar/visitor/SergeantVisitor.java
@@ -32,17 +32,17 @@ import lombok.extern.slf4j.Slf4j;
 public class SergeantVisitor implements UnitVisitor {
 
   @Override
-  public void visitSoldier(Soldier soldier) {
+  public void visit(Soldier soldier) {
     // Do nothing
   }
 
   @Override
-  public void visitSergeant(Sergeant sergeant) {
+  public void visit(Sergeant sergeant) {
     LOGGER.info("Hello {}", sergeant);
   }
 
   @Override
-  public void visitCommander(Commander commander) {
+  public void visit(Commander commander) {
     // Do nothing
   }
 }

--- a/visitor/src/main/java/com/iluwatar/visitor/SergeantVisitor.java
+++ b/visitor/src/main/java/com/iluwatar/visitor/SergeantVisitor.java
@@ -34,7 +34,7 @@ public class SergeantVisitor implements UnitVisitor {
 
   /**
    * Soldier Visitor method.
-   * @param soldier
+   * @param soldier An implementation class of Unit.
    */
   @Override
   public void visit(Soldier soldier) {
@@ -43,7 +43,7 @@ public class SergeantVisitor implements UnitVisitor {
 
   /**
    * Sergeant Visitor method.
-   * @param sergeant
+   * @param sergeant An implementation class of Unit.
    */
   @Override
   public void visit(Sergeant sergeant) {
@@ -52,7 +52,7 @@ public class SergeantVisitor implements UnitVisitor {
 
   /**
    * Commander Visitor method.
-   * @param commander
+   * @param commander An implementation class of Unit.
    */
   @Override
   public void visit(Commander commander) {

--- a/visitor/src/main/java/com/iluwatar/visitor/Soldier.java
+++ b/visitor/src/main/java/com/iluwatar/visitor/Soldier.java
@@ -34,7 +34,7 @@ public class Soldier extends Unit {
 
   @Override
   public void accept(UnitVisitor visitor) {
-    visitor.visitSoldier(this);
+    visitor.visit(this);
     super.accept(visitor);
   }
 

--- a/visitor/src/main/java/com/iluwatar/visitor/Soldier.java
+++ b/visitor/src/main/java/com/iluwatar/visitor/Soldier.java
@@ -32,8 +32,13 @@ public class Soldier extends Unit {
     super(children);
   }
 
+  /**
+   * Accept a visitor.
+   * @param visitor
+   */
   @Override
   public void accept(UnitVisitor visitor) {
+    //CS304 Issue link: https://github.com/iluwatar/java-design-patterns/issues/1968
     visitor.visit(this);
     super.accept(visitor);
   }

--- a/visitor/src/main/java/com/iluwatar/visitor/Soldier.java
+++ b/visitor/src/main/java/com/iluwatar/visitor/Soldier.java
@@ -34,7 +34,6 @@ public class Soldier extends Unit {
 
   /**
    * Accept a visitor.
-   * @param visitor An implementation class of Unit.
    */
   @Override
   public void accept(UnitVisitor visitor) {

--- a/visitor/src/main/java/com/iluwatar/visitor/Soldier.java
+++ b/visitor/src/main/java/com/iluwatar/visitor/Soldier.java
@@ -38,7 +38,6 @@ public class Soldier extends Unit {
    */
   @Override
   public void accept(UnitVisitor visitor) {
-    //CS304 Issue link: https://github.com/iluwatar/java-design-patterns/issues/1968
     visitor.visit(this);
     super.accept(visitor);
   }

--- a/visitor/src/main/java/com/iluwatar/visitor/Soldier.java
+++ b/visitor/src/main/java/com/iluwatar/visitor/Soldier.java
@@ -34,7 +34,7 @@ public class Soldier extends Unit {
 
   /**
    * Accept a visitor.
-   * @param visitor
+   * @param visitor An implementation class of Unit.
    */
   @Override
   public void accept(UnitVisitor visitor) {

--- a/visitor/src/main/java/com/iluwatar/visitor/SoldierVisitor.java
+++ b/visitor/src/main/java/com/iluwatar/visitor/SoldierVisitor.java
@@ -31,8 +31,6 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class SoldierVisitor implements UnitVisitor {
 
-  //CS304 Issue link: https://github.com/iluwatar/java-design-patterns/issues/1968
-
   /**
    * Soldier visitor method.
    * @param soldier An implementation class of Unit.

--- a/visitor/src/main/java/com/iluwatar/visitor/SoldierVisitor.java
+++ b/visitor/src/main/java/com/iluwatar/visitor/SoldierVisitor.java
@@ -35,7 +35,7 @@ public class SoldierVisitor implements UnitVisitor {
 
   /**
    * Soldier visitor method.
-   * @param soldier
+   * @param soldier An implementation class of Unit.
    */
   @Override
   public void visit(Soldier soldier) {
@@ -44,7 +44,7 @@ public class SoldierVisitor implements UnitVisitor {
 
   /**
    * Sergeant visitor method.
-   * @param sergeant
+   * @param sergeant An implementation class of Unit.
    */
   @Override
   public void visit(Sergeant sergeant) {
@@ -53,7 +53,7 @@ public class SoldierVisitor implements UnitVisitor {
 
   /**
    * Commander visitor method.
-   * @param commander
+   * @param commander An implementation class of Unit.
    */
   @Override
   public void visit(Commander commander) {

--- a/visitor/src/main/java/com/iluwatar/visitor/SoldierVisitor.java
+++ b/visitor/src/main/java/com/iluwatar/visitor/SoldierVisitor.java
@@ -32,17 +32,17 @@ import lombok.extern.slf4j.Slf4j;
 public class SoldierVisitor implements UnitVisitor {
 
   @Override
-  public void visitSoldier(Soldier soldier) {
+  public void visit(Soldier soldier) {
     LOGGER.info("Greetings {}", soldier);
   }
 
   @Override
-  public void visitSergeant(Sergeant sergeant) {
+  public void visit(Sergeant sergeant) {
     // Do nothing
   }
 
   @Override
-  public void visitCommander(Commander commander) {
+  public void visit(Commander commander) {
     // Do nothing
   }
 }

--- a/visitor/src/main/java/com/iluwatar/visitor/SoldierVisitor.java
+++ b/visitor/src/main/java/com/iluwatar/visitor/SoldierVisitor.java
@@ -33,7 +33,6 @@ public class SoldierVisitor implements UnitVisitor {
 
   /**
    * Soldier visitor method.
-   * @param soldier An implementation class of Unit.
    */
   @Override
   public void visit(Soldier soldier) {
@@ -42,7 +41,6 @@ public class SoldierVisitor implements UnitVisitor {
 
   /**
    * Sergeant visitor method.
-   * @param sergeant An implementation class of Unit.
    */
   @Override
   public void visit(Sergeant sergeant) {
@@ -51,7 +49,6 @@ public class SoldierVisitor implements UnitVisitor {
 
   /**
    * Commander visitor method.
-   * @param commander An implementation class of Unit.
    */
   @Override
   public void visit(Commander commander) {

--- a/visitor/src/main/java/com/iluwatar/visitor/SoldierVisitor.java
+++ b/visitor/src/main/java/com/iluwatar/visitor/SoldierVisitor.java
@@ -31,16 +31,30 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class SoldierVisitor implements UnitVisitor {
 
+  //CS304 Issue link: https://github.com/iluwatar/java-design-patterns/issues/1968
+
+  /**
+   * Soldier visitor method.
+   * @param soldier
+   */
   @Override
   public void visit(Soldier soldier) {
     LOGGER.info("Greetings {}", soldier);
   }
 
+  /**
+   * Sergeant visitor method.
+   * @param sergeant
+   */
   @Override
   public void visit(Sergeant sergeant) {
     // Do nothing
   }
 
+  /**
+   * Commander visitor method.
+   * @param commander
+   */
   @Override
   public void visit(Commander commander) {
     // Do nothing

--- a/visitor/src/main/java/com/iluwatar/visitor/UnitVisitor.java
+++ b/visitor/src/main/java/com/iluwatar/visitor/UnitVisitor.java
@@ -28,10 +28,10 @@ package com.iluwatar.visitor;
  */
 public interface UnitVisitor {
 
-  void visitSoldier(Soldier soldier);
+  void visit(Soldier soldier);
 
-  void visitSergeant(Sergeant sergeant);
+  void visit(Sergeant sergeant);
 
-  void visitCommander(Commander commander);
+  void visit(Commander commander);
 
 }

--- a/visitor/src/main/java/com/iluwatar/visitor/UnitVisitor.java
+++ b/visitor/src/main/java/com/iluwatar/visitor/UnitVisitor.java
@@ -28,8 +28,6 @@ package com.iluwatar.visitor;
  */
 public interface UnitVisitor {
 
-  //CS304 Issue link: https://github.com/iluwatar/java-design-patterns/issues/1968
-
   /**
    * Soldier visit method.
    * @param soldier An implementation class of Unit.

--- a/visitor/src/main/java/com/iluwatar/visitor/UnitVisitor.java
+++ b/visitor/src/main/java/com/iluwatar/visitor/UnitVisitor.java
@@ -32,19 +32,19 @@ public interface UnitVisitor {
 
   /**
    * Soldier visit method.
-   * @param soldier
+   * @param soldier An implementation class of Unit.
    */
   void visit(Soldier soldier);
 
   /**
    * Sergeant visit method.
-   * @param sergeant
+   * @param sergeant An implementation class of Unit.
    */
   void visit(Sergeant sergeant);
 
   /**
    * Commander visit method.
-   * @param commander
+   * @param commander An implementation class of Unit.
    */
   void visit(Commander commander);
 

--- a/visitor/src/main/java/com/iluwatar/visitor/UnitVisitor.java
+++ b/visitor/src/main/java/com/iluwatar/visitor/UnitVisitor.java
@@ -28,10 +28,24 @@ package com.iluwatar.visitor;
  */
 public interface UnitVisitor {
 
+  //CS304 Issue link: https://github.com/iluwatar/java-design-patterns/issues/1968
+
+  /**
+   * Soldier visit method.
+   * @param soldier
+   */
   void visit(Soldier soldier);
 
+  /**
+   * Sergeant visit method.
+   * @param sergeant
+   */
   void visit(Sergeant sergeant);
 
+  /**
+   * Commander visit method.
+   * @param commander
+   */
   void visit(Commander commander);
 
 }

--- a/visitor/src/main/java/com/iluwatar/visitor/UnitVisitor.java
+++ b/visitor/src/main/java/com/iluwatar/visitor/UnitVisitor.java
@@ -30,19 +30,16 @@ public interface UnitVisitor {
 
   /**
    * Soldier visit method.
-   * @param soldier An implementation class of Unit.
    */
   void visit(Soldier soldier);
 
   /**
    * Sergeant visit method.
-   * @param sergeant An implementation class of Unit.
    */
   void visit(Sergeant sergeant);
 
   /**
    * Commander visit method.
-   * @param commander An implementation class of Unit.
    */
   void visit(Commander commander);
 

--- a/visitor/src/test/java/com/iluwatar/visitor/CommanderTest.java
+++ b/visitor/src/test/java/com/iluwatar/visitor/CommanderTest.java
@@ -42,6 +42,7 @@ public class CommanderTest extends UnitTest<Commander> {
 
   @Override
   void verifyVisit(Commander unit, UnitVisitor mockedVisitor) {
+    //CS304 (manually written) Issue link: https://github.com/iluwatar/java-design-patterns/issues/1968
     verify(mockedVisitor).visit(eq(unit));
   }
 

--- a/visitor/src/test/java/com/iluwatar/visitor/CommanderTest.java
+++ b/visitor/src/test/java/com/iluwatar/visitor/CommanderTest.java
@@ -42,7 +42,7 @@ public class CommanderTest extends UnitTest<Commander> {
 
   @Override
   void verifyVisit(Commander unit, UnitVisitor mockedVisitor) {
-    verify(mockedVisitor).visitCommander(eq(unit));
+    verify(mockedVisitor).visit(eq(unit));
   }
 
 }

--- a/visitor/src/test/java/com/iluwatar/visitor/CommanderTest.java
+++ b/visitor/src/test/java/com/iluwatar/visitor/CommanderTest.java
@@ -42,7 +42,6 @@ public class CommanderTest extends UnitTest<Commander> {
 
   @Override
   void verifyVisit(Commander unit, UnitVisitor mockedVisitor) {
-    //CS304 (manually written) Issue link: https://github.com/iluwatar/java-design-patterns/issues/1968
     verify(mockedVisitor).visit(eq(unit));
   }
 

--- a/visitor/src/test/java/com/iluwatar/visitor/SergeantTest.java
+++ b/visitor/src/test/java/com/iluwatar/visitor/SergeantTest.java
@@ -42,7 +42,7 @@ public class SergeantTest extends UnitTest<Sergeant> {
 
   @Override
   void verifyVisit(Sergeant unit, UnitVisitor mockedVisitor) {
-    verify(mockedVisitor).visitSergeant(eq(unit));
+    verify(mockedVisitor).visit(eq(unit));
   }
 
 }

--- a/visitor/src/test/java/com/iluwatar/visitor/SergeantTest.java
+++ b/visitor/src/test/java/com/iluwatar/visitor/SergeantTest.java
@@ -42,7 +42,6 @@ public class SergeantTest extends UnitTest<Sergeant> {
 
   @Override
   void verifyVisit(Sergeant unit, UnitVisitor mockedVisitor) {
-    //CS304 (manually written) Issue link: https://github.com/iluwatar/java-design-patterns/issues/1968
     verify(mockedVisitor).visit(eq(unit));
   }
 

--- a/visitor/src/test/java/com/iluwatar/visitor/SergeantTest.java
+++ b/visitor/src/test/java/com/iluwatar/visitor/SergeantTest.java
@@ -42,6 +42,7 @@ public class SergeantTest extends UnitTest<Sergeant> {
 
   @Override
   void verifyVisit(Sergeant unit, UnitVisitor mockedVisitor) {
+    //CS304 (manually written) Issue link: https://github.com/iluwatar/java-design-patterns/issues/1968
     verify(mockedVisitor).visit(eq(unit));
   }
 

--- a/visitor/src/test/java/com/iluwatar/visitor/SoldierTest.java
+++ b/visitor/src/test/java/com/iluwatar/visitor/SoldierTest.java
@@ -42,7 +42,7 @@ public class SoldierTest extends UnitTest<Soldier> {
 
   @Override
   void verifyVisit(Soldier unit, UnitVisitor mockedVisitor) {
-    verify(mockedVisitor).visitSoldier(eq(unit));
+    verify(mockedVisitor).visit(eq(unit));
   }
 
 }

--- a/visitor/src/test/java/com/iluwatar/visitor/SoldierTest.java
+++ b/visitor/src/test/java/com/iluwatar/visitor/SoldierTest.java
@@ -42,6 +42,7 @@ public class SoldierTest extends UnitTest<Soldier> {
 
   @Override
   void verifyVisit(Soldier unit, UnitVisitor mockedVisitor) {
+    //CS304 (manually written) Issue link: https://github.com/iluwatar/java-design-patterns/issues/1968
     verify(mockedVisitor).visit(eq(unit));
   }
 

--- a/visitor/src/test/java/com/iluwatar/visitor/SoldierTest.java
+++ b/visitor/src/test/java/com/iluwatar/visitor/SoldierTest.java
@@ -42,7 +42,6 @@ public class SoldierTest extends UnitTest<Soldier> {
 
   @Override
   void verifyVisit(Soldier unit, UnitVisitor mockedVisitor) {
-    //CS304 (manually written) Issue link: https://github.com/iluwatar/java-design-patterns/issues/1968
     verify(mockedVisitor).visit(eq(unit));
   }
 

--- a/visitor/src/test/java/com/iluwatar/visitor/VisitorTest.java
+++ b/visitor/src/test/java/com/iluwatar/visitor/VisitorTest.java
@@ -97,7 +97,7 @@ public abstract class VisitorTest<V extends UnitVisitor> {
 
   @Test
   void testVisitCommander() {
-    this.visitor.visitCommander(new Commander());
+    this.visitor.visit(new Commander());
     if (this.commanderResponse.isPresent()) {
       assertEquals(this.commanderResponse.get(), appender.getLastMessage());
       assertEquals(1, appender.getLogSize());
@@ -106,7 +106,7 @@ public abstract class VisitorTest<V extends UnitVisitor> {
 
   @Test
   void testVisitSergeant() {
-    this.visitor.visitSergeant(new Sergeant());
+    this.visitor.visit(new Sergeant());
     if (this.sergeantResponse.isPresent()) {
       assertEquals(this.sergeantResponse.get(), appender.getLastMessage());
       assertEquals(1, appender.getLogSize());
@@ -115,7 +115,7 @@ public abstract class VisitorTest<V extends UnitVisitor> {
 
   @Test
   void testVisitSoldier() {
-    this.visitor.visitSoldier(new Soldier());
+    this.visitor.visit(new Soldier());
     if (this.soldierResponse.isPresent()) {
       assertEquals(this.soldierResponse.get(), appender.getLastMessage());
       assertEquals(1, appender.getLogSize());


### PR DESCRIPTION
fix issue 1968 and correct visitor pattern code

Modified issue with visitor mode code, changed different method name to method reload, fixed issue1968.


Pull request description

The main modification of the method in the class is visit, which is accessed only by different parameter types, eliminating some errors and simplifying code writing, in line with the pattern requirements.

