### PR TITLE
A Chinese grammar error in zh version README.md.

### DIFF
--- a/localization/zh/README.md
+++ b/localization/zh/README.md
@@ -32,7 +32,7 @@
 
 # 如何做出贡献
 
-如果您愿意为该项目做出贡献，则可以在我们的[开发人员Wiki中](https://github.com/iluwatar/java-design-patterns/wiki)找到相关信息。我们将在[Gitter聊天室为](https://gitter.im/iluwatar/java-design-patterns)您提供帮助并回答您的问题。
+如果您愿意为该项目做出贡献，则可以在我们的[开发人员Wiki中](https://github.com/iluwatar/java-design-patterns/wiki)找到相关信息。我们将在[Gitter聊天室](https://gitter.im/iluwatar/java-design-patterns)为您提供帮助并回答您的问题。
 
 # 许可证
 


### PR DESCRIPTION
Line 35, the second bracket contains a redundant Chinese character “为”, which should be removed from bracket and put in front of the remain words.
"为" is a preposition, while the meaning of the word in the bracket should be a noun. Anyone who is familar with Chinese will find this problem.

在第35行，第二个网页超链接处，中括号包含了一个多余的汉字“为”。应该将这个汉字移出中括号。