### PR TITLE
Updated Lombok version to 1.18.22

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <system-lambda.version>1.1.0</system-lambda.version>
     <urm.version>2.0.0</urm.version>
     <mockito-junit-jupiter.version>3.5.0</mockito-junit-jupiter.version>
-    <lombok.version>1.18.20</lombok.version>
+    <lombok.version>1.18.22</lombok.version>
     <byte-buddy.version>1.11.5</byte-buddy.version>
     <javassist.version>3.27.0-GA</javassist.version>
     <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>


### PR DESCRIPTION
Ticket issue : https://github.com/iluwatar/java-design-patterns/issues/2034

Changed the version of Lombok from 1.18.20 to 1.18.22 which will support Java 17 LTS.


> For detailed contributing instructions see https://github.com/iluwatar/java-design-patterns/wiki/01.-How-to-contribute
