### PR TITLE
Fixed #1193. Remove assertj-core from acyclic-visitor to prevent inconsistent library versions

### DIFF
--- a/acyclic-visitor/pom.xml
+++ b/acyclic-visitor/pom.xml
@@ -39,13 +39,6 @@
     <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
   <dependencies>
-    <!-- https://mvnrepository.com/artifact/org.assertj/assertj-core -->
-    <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <version>3.9.1</version>
-      <scope>test</scope>
-    </dependency>
     <!-- https://mvnrepository.com/artifact/uk.org.lidalia/slf4j-test -->
     <dependency>
       <groupId>uk.org.lidalia</groupId>

--- a/acyclic-visitor/src/test/java/com/iluwatar/acyclicvisitor/ConfigureForDosVisitorTest.java
+++ b/acyclic-visitor/src/test/java/com/iluwatar/acyclicvisitor/ConfigureForDosVisitorTest.java
@@ -24,12 +24,14 @@
  */
 package com.iluwatar.acyclicvisitor;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.groups.Tuple.tuple;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static uk.org.lidalia.slf4jext.Level.INFO;
 
+import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import uk.org.lidalia.slf4jtest.LoggingEvent;
 import uk.org.lidalia.slf4jtest.TestLogger;
 import uk.org.lidalia.slf4jtest.TestLoggerFactory;
 
@@ -47,9 +49,12 @@ class ConfigureForDosVisitorTest {
 
     conDos.visit(zoom);
 
-    assertThat(logger.getLoggingEvents())
-        .extracting("level", "message")
-        .contains(tuple(INFO, zoom + " used with Dos configurator."));
+    ImmutableList<LoggingEvent> loggingEvents = logger.getLoggingEvents();
+    assertEquals(1, loggingEvents.size());
+    for (LoggingEvent loggingEvent : loggingEvents) {
+      assertEquals(INFO, loggingEvent.getLevel());
+      assertEquals(zoom + " used with Dos configurator.", loggingEvent.getMessage());
+    }
   }
 
   @Test
@@ -59,11 +64,15 @@ class ConfigureForDosVisitorTest {
 
     conDos.visit(hayes);
 
-    assertThat(logger.getLoggingEvents())
-        .extracting("level", "message")
-        .contains(tuple(INFO, hayes + " used with Dos configurator."));
+    ImmutableList<LoggingEvent> loggingEvents = logger.getLoggingEvents();
+    assertEquals(1, loggingEvents.size());
+    for (LoggingEvent loggingEvent : loggingEvents) {
+      assertEquals(INFO, loggingEvent.getLevel());
+      assertEquals(hayes + " used with Dos configurator.", loggingEvent.getMessage());
+    }
   }
 
+  @BeforeEach
   @AfterEach
   public void clearLoggers() {
     TestLoggerFactory.clear();

--- a/acyclic-visitor/src/test/java/com/iluwatar/acyclicvisitor/ConfigureForUnixVisitorTest.java
+++ b/acyclic-visitor/src/test/java/com/iluwatar/acyclicvisitor/ConfigureForUnixVisitorTest.java
@@ -26,6 +26,7 @@ package com.iluwatar.acyclicvisitor;
 
 import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.org.lidalia.slf4jtest.LoggingEvent;
 import uk.org.lidalia.slf4jtest.TestLogger;
@@ -41,6 +42,7 @@ class ConfigureForUnixVisitorTest {
 
   private static final TestLogger LOGGER = TestLoggerFactory.getTestLogger(ConfigureForUnixVisitor.class);
 
+  @BeforeEach
   @AfterEach
   public void clearLoggers() {
     TestLoggerFactory.clear();

--- a/acyclic-visitor/src/test/java/com/iluwatar/acyclicvisitor/ConfigureForUnixVisitorTest.java
+++ b/acyclic-visitor/src/test/java/com/iluwatar/acyclicvisitor/ConfigureForUnixVisitorTest.java
@@ -24,13 +24,14 @@
  */
 package com.iluwatar.acyclicvisitor;
 
+import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import uk.org.lidalia.slf4jtest.LoggingEvent;
 import uk.org.lidalia.slf4jtest.TestLogger;
 import uk.org.lidalia.slf4jtest.TestLoggerFactory;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.groups.Tuple.tuple;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static uk.org.lidalia.slf4jext.Level.INFO;
 
 /**
@@ -52,8 +53,11 @@ class ConfigureForUnixVisitorTest {
 
     conUnix.visit(zoom);
 
-    assertThat(LOGGER.getLoggingEvents())
-        .extracting("level", "message")
-        .contains(tuple(INFO, zoom + " used with Unix configurator."));
+    ImmutableList<LoggingEvent> loggingEvents = LOGGER.getLoggingEvents();
+    assertEquals(1, loggingEvents.size());
+    for (LoggingEvent loggingEvent : loggingEvents) {
+      assertEquals(INFO, loggingEvent.getLevel());
+      assertEquals(zoom + " used with Unix configurator.", loggingEvent.getMessage());
+    }
   }
 }


### PR DESCRIPTION
Pull request title
Fix #1193. Remove assertj-core from acyclic-visitor to prevent inconsistent library versions


> For detailed contributing instructions see https://github.com/iluwatar/java-design-patterns/wiki/01.-How-to-contribute
