### PR TITLE
fix(sec): upgrade com.h2database:h2 to 2.1.210

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,8 +24,7 @@
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
     THE SOFTWARE.
 
--->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+--><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.iluwatar</groupId>
   <artifactId>java-design-patterns</artifactId>
@@ -41,7 +40,7 @@
     <spring.version>5.0.17.RELEASE</spring.version>
     <spring-boot.version>2.0.9.RELEASE</spring-boot.version>
     <spring-data.version>2.0.14.RELEASE</spring-data.version>
-    <h2.version>1.4.190</h2.version>
+    <h2.version>2.1.210</h2.version>
     <junit.version>4.12</junit.version>
     <junit-jupiter.version>5.7.1</junit-jupiter.version>
     <junit-vintage.version>${junit-jupiter.version}</junit-vintage.version>


### PR DESCRIPTION
### What happened？
There are 4 security vulnerabilities found in com.h2database:h2 1.4.190
- [CVE-2018-14335](https://www.oscs1024.com/hd/CVE-2018-14335)
- [CVE-2021-42392](https://www.oscs1024.com/hd/CVE-2021-42392)
- [CVE-2022-23221](https://www.oscs1024.com/hd/CVE-2022-23221)
- [MPS-2022-52737](https://www.oscs1024.com/hd/MPS-2022-52737)


### What did I do？
Upgrade com.h2database:h2 from 1.4.190 to 2.1.210 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS