### PR TITLE
Upgrade JaCoCo plugin for JDK 17 compatibility (#2033)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <junit-jupiter.version>5.7.1</junit-jupiter.version>
     <junit-vintage.version>${junit-jupiter.version}</junit-vintage.version>
     <compiler.version>3.8.1</compiler.version>
-    <jacoco.version>0.8.6</jacoco.version>
+    <jacoco.version>0.8.8</jacoco.version>
     <commons-dbcp.version>1.4</commons-dbcp.version>
     <camel.version>2.24.0</camel.version>
     <guava.version>19.0</guava.version>


### PR DESCRIPTION
This PR aims to solve #2033 by bumping JaCoCo plugin to 0.8.8, as attempting to run `mvn clean install` on the design modules under JDK 17 with the current version will result in the `java.lang.IllegalArgumentException: Unsupported class file major version 61` error.

For testing I've ran an overall `mvn clean install` on the entire project under JDK 17 with source and target also set to 17 in the `pom.xml`, and only the `naked-objects` pattern module produced an error (although there were warnings with other modules). It looks like the problem is rooted in an error running the `Datanucleus` enhancer inside `dom` (not much more error info) and errors inside `integtests` with using versions of the `Cucumber` library that's also too old from the Apache Isis dependency. I've tinkered with it a lot by updating dependencies and plugins inside `naked-objects` and still couldn't solve the errors, which is why I'm making this PR a draft.

I see there have already been discussions with `naked-objects` having some problems and being outdated from #1683 and #1669, and I'm happy to try rewrite the `naked-objects` to be more up-to-date and see if it can work with JDK 17 then. If it's crucial to have `naked-objects` build without errors under JDK 17 I'm happy to keep this PR in draft until the refactor is done.