### PR TITLE
Declares the template method as final (Issue 1099)

### DIFF
--- a/template-method/README.md
+++ b/template-method/README.md
@@ -39,6 +39,10 @@ Wikipedia says
 **Programmatic Example**
 
 Let's first introduce the template method class along with its concrete implementations.
+To make sure that subclasses don’t override the template method, the template method (in our case
+method `steal`) should be declared `final`, otherwise the skeleton defined in the base class could
+be overridden in subclasses.
+
 
 ```java
 @Slf4j
@@ -50,7 +54,7 @@ public abstract class StealingMethod {
 
   protected abstract void stealTheItem(String target);
 
-  public void steal() {
+  public final void steal() {
     var target = pickTarget();
     LOGGER.info("The target has been chosen as {}.", target);
     confuseTarget(target);

--- a/template-method/pom.xml
+++ b/template-method/pom.xml
@@ -41,7 +41,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
+      <artifactId>mockito-inline</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/template-method/src/main/java/com/iluwatar/templatemethod/StealingMethod.java
+++ b/template-method/src/main/java/com/iluwatar/templatemethod/StealingMethod.java
@@ -41,7 +41,7 @@ public abstract class StealingMethod {
   /**
    * Steal.
    */
-  public void steal() {
+  public final void steal() {
     var target = pickTarget();
     LOGGER.info("The target has been chosen as {}.", target);
     confuseTarget(target);

--- a/template-method/src/test/java/com/iluwatar/templatemethod/HalflingThiefTest.java
+++ b/template-method/src/test/java/com/iluwatar/templatemethod/HalflingThiefTest.java
@@ -24,7 +24,7 @@
  */
 package com.iluwatar.templatemethod;
 
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
@@ -42,11 +42,14 @@ public class HalflingThiefTest {
    */
   @Test
   void testSteal() {
-    final var method = mock(StealingMethod.class);
+    final var method = spy(StealingMethod.class);
     final var thief = new HalflingThief(method);
 
     thief.steal();
     verify(method).steal();
+    String target = verify(method).pickTarget();
+    verify(method).confuseTarget(target);
+    verify(method).stealTheItem(target);
 
     verifyNoMoreInteractions(method);
   }
@@ -56,19 +59,23 @@ public class HalflingThiefTest {
    */
   @Test
   void testChangeMethod() {
-    final var initialMethod = mock(StealingMethod.class);
+    final var initialMethod = spy(StealingMethod.class);
     final var thief = new HalflingThief(initialMethod);
 
     thief.steal();
     verify(initialMethod).steal();
+    String target = verify(initialMethod).pickTarget();
+    verify(initialMethod).confuseTarget(target);
+    verify(initialMethod).stealTheItem(target);
 
-    final var newMethod = mock(StealingMethod.class);
+    final var newMethod = spy(StealingMethod.class);
     thief.changeMethod(newMethod);
 
     thief.steal();
     verify(newMethod).steal();
-
+    String newTarget = verify(newMethod).pickTarget();
+    verify(newMethod).confuseTarget(newTarget);
+    verify(newMethod).stealTheItem(newTarget);
     verifyNoMoreInteractions(initialMethod, newMethod);
-
   }
 }


### PR DESCRIPTION
As described in Issue #1099 it is recommended to declare the template method as final.
This pull request changes the implementation in the sample code of the template method pattern.

This change is applied both in the sample code and in the documentation.

Moreover, the tests was adjusted. As Mockito has problems with `final` methods, the Mockito dependency had to be changed from `mockito-core` to `mockito-inline`.

The tests pass:

	[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in com.iluwatar.templatemethod.SubtleMethodTest
	[INFO]
	[INFO] Results:
	[INFO]
	[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0
	[INFO]
	[INFO] ------------------------------------------------------------------------
	[INFO] BUILD SUCCESS
	[INFO] ------------------------------------------------------------------------
	[INFO] Total time:  3.938 s
	[INFO] Finished at: 2022-10-05T11:21:34+02:00
	[INFO] ------------------------------------------------------------------------

