### PR TITLE
fix(sec): upgrade net.sourceforge.htmlunit:htmlunit to 2.37.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,8 +24,7 @@
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
     THE SOFTWARE.
 
--->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+--><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.iluwatar</groupId>
   <artifactId>java-design-patterns</artifactId>
@@ -51,7 +50,7 @@
     <camel.version>2.24.0</camel.version>
     <guava.version>19.0</guava.version>
     <mockito.version>3.5.6</mockito.version>
-    <htmlunit.version>2.22</htmlunit.version>
+    <htmlunit.version>2.37.0</htmlunit.version>
     <guice.version>4.0</guice.version>
     <mongo-java-driver.version>3.12.1</mongo-java-driver.version>
     <slf4j.version>1.7.30</slf4j.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in net.sourceforge.htmlunit:htmlunit 2.22
- [CVE-2020-5529](https://www.oscs1024.com/hd/CVE-2020-5529)


### What did I do？
Upgrade net.sourceforge.htmlunit:htmlunit from 2.22 to 2.37.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS