### PR TITLE
fix(sec): upgrade org.apache.camel:camel-core to 2.25.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,8 +24,7 @@
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
     THE SOFTWARE.
 
--->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+--><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.iluwatar</groupId>
   <artifactId>java-design-patterns</artifactId>
@@ -48,7 +47,7 @@
     <compiler.version>3.8.1</compiler.version>
     <jacoco.version>0.8.8</jacoco.version>
     <commons-dbcp.version>1.4</commons-dbcp.version>
-    <camel.version>2.24.0</camel.version>
+    <camel.version>2.25.1</camel.version>
     <guava.version>19.0</guava.version>
     <mockito.version>3.5.6</mockito.version>
     <htmlunit.version>2.22</htmlunit.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.camel:camel-core 2.24.0
- [CVE-2020-11971](https://www.oscs1024.com/hd/CVE-2020-11971)


### What did I do？
Upgrade org.apache.camel:camel-core from 2.24.0 to 2.25.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS