### PR TITLE
fix(sec): upgrade com.google.guava:guava to 30.0-jre

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,8 +24,7 @@
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
     THE SOFTWARE.
 
--->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+--><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.iluwatar</groupId>
   <artifactId>java-design-patterns</artifactId>
@@ -49,7 +48,7 @@
     <jacoco.version>0.8.8</jacoco.version>
     <commons-dbcp.version>1.4</commons-dbcp.version>
     <camel.version>2.24.0</camel.version>
-    <guava.version>19.0</guava.version>
+    <guava.version>30.0-jre</guava.version>
     <mockito.version>3.5.6</mockito.version>
     <htmlunit.version>2.22</htmlunit.version>
     <guice.version>4.0</guice.version>


### PR DESCRIPTION
### What happened？
There are 2 security vulnerabilities found in com.google.guava:guava 19.0
- [CVE-2018-10237](https://www.oscs1024.com/hd/CVE-2018-10237)
- [CVE-2020-8908](https://www.oscs1024.com/hd/CVE-2020-8908)


### What did I do？
Upgrade com.google.guava:guava from 19.0 to 30.0-jre for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS