### PR TITLE
fix(sec): upgrade org.springframework.data:spring-data-jpa to 2.1.8.RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,8 +24,7 @@
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
     THE SOFTWARE.
 
--->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+--><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.iluwatar</groupId>
   <artifactId>java-design-patterns</artifactId>
@@ -40,7 +39,7 @@
     <hibernate.version>5.2.18.Final</hibernate.version>
     <spring.version>5.0.17.RELEASE</spring.version>
     <spring-boot.version>2.0.9.RELEASE</spring-boot.version>
-    <spring-data.version>2.0.14.RELEASE</spring-data.version>
+    <spring-data.version>2.1.8.RELEASE</spring-data.version>
     <h2.version>1.4.190</h2.version>
     <junit.version>4.12</junit.version>
     <junit-jupiter.version>5.7.1</junit-jupiter.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.springframework.data:spring-data-jpa 2.0.14.RELEASE
- [CVE-2019-3802](https://www.oscs1024.com/hd/CVE-2019-3802)


### What did I do？
Upgrade org.springframework.data:spring-data-jpa from 2.0.14.RELEASE to 2.1.8.RELEASE for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS