### PR TITLE
refactoring #1012: Remove deprecated method to ease Hibernate upgrade

### DIFF
--- a/service-layer/src/main/java/com/iluwatar/servicelayer/common/DaoBaseImpl.java
+++ b/service-layer/src/main/java/com/iluwatar/servicelayer/common/DaoBaseImpl.java
@@ -25,12 +25,14 @@
 package com.iluwatar.servicelayer.common;
 
 import com.iluwatar.servicelayer.hibernate.HibernateUtil;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Root;
 import java.lang.reflect.ParameterizedType;
 import java.util.List;
-import org.hibernate.Criteria;
 import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
-import org.hibernate.criterion.Restrictions;
+import org.hibernate.query.Query;
 
 /**
  * Base class for Dao implementations.
@@ -57,9 +59,12 @@ public abstract class DaoBaseImpl<E extends BaseEntity> implements Dao<E> {
     E result;
     try (var session = getSessionFactory().openSession()) {
       tx = session.beginTransaction();
-      var criteria = session.createCriteria(persistentClass);
-      criteria.add(Restrictions.idEq(id));
-      result = (E) criteria.uniqueResult();
+      CriteriaBuilder criteriaBuilder = session.getCriteriaBuilder();
+      CriteriaQuery<E> builderQuery = criteriaBuilder.createQuery(persistentClass);
+      Root<E> root = builderQuery.from(persistentClass);
+      builderQuery.select(root).where(criteriaBuilder.equal(root.get("id"), id));
+      Query<E> query = session.createQuery(builderQuery);
+      result = query.uniqueResult();
       tx.commit();
     } catch (Exception e) {
       if (tx != null) {
@@ -123,8 +128,12 @@ public abstract class DaoBaseImpl<E extends BaseEntity> implements Dao<E> {
     List<E> result;
     try (var session = getSessionFactory().openSession()) {
       tx = session.beginTransaction();
-      Criteria criteria = session.createCriteria(persistentClass);
-      result = criteria.list();
+      CriteriaBuilder criteriaBuilder = session.getCriteriaBuilder();
+      CriteriaQuery<E> builderQuery = criteriaBuilder.createQuery(persistentClass);
+      Root<E> root = builderQuery.from(persistentClass);
+      builderQuery.select(root);
+      Query<E> query = session.createQuery(builderQuery);
+      result = query.getResultList();
     } catch (Exception e) {
       if (tx != null) {
         tx.rollback();

--- a/service-layer/src/main/java/com/iluwatar/servicelayer/common/DaoBaseImpl.java
+++ b/service-layer/src/main/java/com/iluwatar/servicelayer/common/DaoBaseImpl.java
@@ -25,11 +25,11 @@
 package com.iluwatar.servicelayer.common;
 
 import com.iluwatar.servicelayer.hibernate.HibernateUtil;
+import java.lang.reflect.ParameterizedType;
+import java.util.List;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Root;
-import java.lang.reflect.ParameterizedType;
-import java.util.List;
 import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
 import org.hibernate.query.Query;

--- a/service-layer/src/main/java/com/iluwatar/servicelayer/spell/SpellDaoImpl.java
+++ b/service-layer/src/main/java/com/iluwatar/servicelayer/spell/SpellDaoImpl.java
@@ -25,8 +25,12 @@
 package com.iluwatar.servicelayer.spell;
 
 import com.iluwatar.servicelayer.common.DaoBaseImpl;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Root;
 import org.hibernate.Transaction;
-import org.hibernate.criterion.Restrictions;
+import org.hibernate.query.Query;
+
 
 /**
  * SpellDao implementation.
@@ -39,9 +43,12 @@ public class SpellDaoImpl extends DaoBaseImpl<Spell> implements SpellDao {
     Spell result;
     try (var session = getSessionFactory().openSession()) {
       tx = session.beginTransaction();
-      var criteria = session.createCriteria(persistentClass);
-      criteria.add(Restrictions.eq("name", name));
-      result = (Spell) criteria.uniqueResult();
+      CriteriaBuilder criteriaBuilder = session.getCriteriaBuilder();
+      CriteriaQuery<Spell> builderQuery = criteriaBuilder.createQuery(Spell.class);
+      Root<Spell> root = builderQuery.from(Spell.class);
+      builderQuery.select(root).where(criteriaBuilder.equal(root.get("name"), name));
+      Query<Spell> query = session.createQuery(builderQuery);
+      result = query.uniqueResult();
       tx.commit();
     } catch (Exception e) {
       if (tx != null) {

--- a/service-layer/src/main/java/com/iluwatar/servicelayer/spellbook/SpellbookDaoImpl.java
+++ b/service-layer/src/main/java/com/iluwatar/servicelayer/spellbook/SpellbookDaoImpl.java
@@ -25,12 +25,11 @@
 package com.iluwatar.servicelayer.spellbook;
 
 import com.iluwatar.servicelayer.common.DaoBaseImpl;
-import org.hibernate.Transaction;
-import org.hibernate.query.Query;
-
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Root;
+import org.hibernate.Transaction;
+import org.hibernate.query.Query;
 
 
 /**

--- a/service-layer/src/main/java/com/iluwatar/servicelayer/spellbook/SpellbookDaoImpl.java
+++ b/service-layer/src/main/java/com/iluwatar/servicelayer/spellbook/SpellbookDaoImpl.java
@@ -26,7 +26,12 @@ package com.iluwatar.servicelayer.spellbook;
 
 import com.iluwatar.servicelayer.common.DaoBaseImpl;
 import org.hibernate.Transaction;
-import org.hibernate.criterion.Restrictions;
+import org.hibernate.query.Query;
+
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Root;
+
 
 /**
  * SpellbookDao implementation.
@@ -39,9 +44,12 @@ public class SpellbookDaoImpl extends DaoBaseImpl<Spellbook> implements Spellboo
     Spellbook result;
     try (var session = getSessionFactory().openSession()) {
       tx = session.beginTransaction();
-      var criteria = session.createCriteria(persistentClass);
-      criteria.add(Restrictions.eq("name", name));
-      result = (Spellbook) criteria.uniqueResult();
+      CriteriaBuilder criteriaBuilder = session.getCriteriaBuilder();
+      CriteriaQuery<Spellbook> builderQuery = criteriaBuilder.createQuery(Spellbook.class);
+      Root<Spellbook> root = builderQuery.from(Spellbook.class);
+      builderQuery.select(root).where(criteriaBuilder.equal(root.get("name"), name));
+      Query<Spellbook> query = session.createQuery(builderQuery);
+      result = query.uniqueResult();
       tx.commit();
     } catch (Exception e) {
       if (tx != null) {

--- a/service-layer/src/main/java/com/iluwatar/servicelayer/wizard/WizardDaoImpl.java
+++ b/service-layer/src/main/java/com/iluwatar/servicelayer/wizard/WizardDaoImpl.java
@@ -25,8 +25,11 @@
 package com.iluwatar.servicelayer.wizard;
 
 import com.iluwatar.servicelayer.common.DaoBaseImpl;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Root;
 import org.hibernate.Transaction;
-import org.hibernate.criterion.Restrictions;
+import org.hibernate.query.Query;
 
 /**
  * WizardDao implementation.
@@ -39,9 +42,12 @@ public class WizardDaoImpl extends DaoBaseImpl<Wizard> implements WizardDao {
     Wizard result;
     try (var session = getSessionFactory().openSession()) {
       tx = session.beginTransaction();
-      var criteria = session.createCriteria(persistentClass);
-      criteria.add(Restrictions.eq("name", name));
-      result = (Wizard) criteria.uniqueResult();
+      CriteriaBuilder criteriaBuilder = session.getCriteriaBuilder();
+      CriteriaQuery<Wizard> builderQuery = criteriaBuilder.createQuery(Wizard.class);
+      Root<Wizard> root = builderQuery.from(Wizard.class);
+      builderQuery.select(root).where(criteriaBuilder.equal(root.get("name"), name));
+      Query<Wizard> query = session.createQuery(builderQuery);
+      result = query.uniqueResult();
       tx.commit();
     } catch (Exception e) {
       if (tx != null) {

--- a/service-layer/src/test/java/com/iluwatar/servicelayer/magic/MagicServiceImplTest.java
+++ b/service-layer/src/test/java/com/iluwatar/servicelayer/magic/MagicServiceImplTest.java
@@ -26,11 +26,10 @@ package com.iluwatar.servicelayer.magic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 import com.iluwatar.servicelayer.spell.Spell;
@@ -56,7 +55,7 @@ class MagicServiceImplTest {
     final var spellDao = mock(SpellDao.class);
 
     final var service = new MagicServiceImpl(wizardDao, spellbookDao, spellDao);
-    verifyZeroInteractions(wizardDao, spellbookDao, spellDao);
+    verifyNoInteractions(wizardDao, spellbookDao, spellDao);
 
     service.findAllWizards();
     verify(wizardDao).findAll();
@@ -70,7 +69,7 @@ class MagicServiceImplTest {
     final var spellDao = mock(SpellDao.class);
 
     final var service = new MagicServiceImpl(wizardDao, spellbookDao, spellDao);
-    verifyZeroInteractions(wizardDao, spellbookDao, spellDao);
+    verifyNoInteractions(wizardDao, spellbookDao, spellDao);
 
     service.findAllSpellbooks();
     verify(spellbookDao).findAll();
@@ -84,7 +83,7 @@ class MagicServiceImplTest {
     final var spellDao = mock(SpellDao.class);
 
     final var service = new MagicServiceImpl(wizardDao, spellbookDao, spellDao);
-    verifyZeroInteractions(wizardDao, spellbookDao, spellDao);
+    verifyNoInteractions(wizardDao, spellbookDao, spellDao);
 
     service.findAllSpells();
     verify(spellDao).findAll();
@@ -103,17 +102,17 @@ class MagicServiceImplTest {
     when(spellbook.getWizards()).thenReturn(wizards);
 
     final var spellbookDao = mock(SpellbookDao.class);
-    when(spellbookDao.findByName(eq(bookname))).thenReturn(spellbook);
+    when(spellbookDao.findByName(bookname)).thenReturn(spellbook);
 
     final var wizardDao = mock(WizardDao.class);
     final var spellDao = mock(SpellDao.class);
 
 
     final var service = new MagicServiceImpl(wizardDao, spellbookDao, spellDao);
-    verifyZeroInteractions(wizardDao, spellbookDao, spellDao, spellbook);
+    verifyNoInteractions(wizardDao, spellbookDao, spellDao, spellbook);
 
     final var result = service.findWizardsWithSpellbook(bookname);
-    verify(spellbookDao).findByName(eq(bookname));
+    verify(spellbookDao).findByName(bookname);
     verify(spellbook).getWizards();
 
     assertNotNull(result);
@@ -140,13 +139,13 @@ class MagicServiceImplTest {
 
     final var spellName = "spellname";
     final var spellDao = mock(SpellDao.class);
-    when(spellDao.findByName(eq(spellName))).thenReturn(spell);
+    when(spellDao.findByName(spellName)).thenReturn(spell);
 
     final var service = new MagicServiceImpl(wizardDao, spellbookDao, spellDao);
-    verifyZeroInteractions(wizardDao, spellbookDao, spellDao, spellbook);
+    verifyNoInteractions(wizardDao, spellbookDao, spellDao, spellbook);
 
     final var result = service.findWizardsWithSpell(spellName);
-    verify(spellDao).findByName(eq(spellName));
+    verify(spellDao).findByName(spellName);
     verify(spellbook).getWizards();
 
     assertNotNull(result);


### PR DESCRIPTION
Remove deprecated method to ease Hibernate upgrade.
Fix the following deprecated method reported by Sonar #1012 in this [link](https://sonarcloud.io/project/issues?fileUuids=AW3G0SexwB6UiZzQNqdf%2CAW3G0SexwB6UiZzQNqdj%2CAW3G0SexwB6UiZzQNqds%2CAW3G0SexwB6UiZzQNqdy&resolved=false&rules=java%3AS1874&id=iluwatar_java-design-patterns).