### PR TITLE
Update Spring Boot and Spring Data version to 2.1, fix #978

### DIFF
--- a/layers/src/main/resources/applicationContext.xml
+++ b/layers/src/main/resources/applicationContext.xml
@@ -49,4 +49,7 @@
       </map>
     </property>
   </bean>
+  <context:component-scan base-package="com.iluwatar.layers.dao">
+    <context:include-filter type="annotation" expression="org.springframework.stereotype.Repository" />
+  </context:component-scan>
 </beans>

--- a/pom.xml
+++ b/pom.xml
@@ -37,13 +37,12 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <sonar-maven-plugin.version>3.8.0.2131</sonar-maven-plugin.version>
     <hibernate.version>5.4.24.Final</hibernate.version>
-    <spring.version>5.0.17.RELEASE</spring.version>
-    <spring-boot.version>2.0.9.RELEASE</spring-boot.version>
-    <spring-data.version>2.0.14.RELEASE</spring-data.version>
+    <spring-framework.version>5.1.19.RELEASE</spring-framework.version>
+    <spring-boot.version>2.1.18.RELEASE</spring-boot.version>
+    <spring-data.version>2.1.21.RELEASE</spring-data.version>
     <h2.version>1.4.190</h2.version>
     <junit.version>4.12</junit.version>
     <junit-jupiter.version>5.7.1</junit-jupiter.version>
-    <junit-vintage.version>${junit-jupiter.version}</junit-vintage.version>
     <compiler.version>3.8.1</compiler.version>
     <jacoco.version>0.8.8</jacoco.version>
     <commons-dbcp.version>1.4</commons-dbcp.version>
@@ -64,7 +63,6 @@
     <annotation-api.version>1.3.2</annotation-api.version>
     <system-lambda.version>1.1.0</system-lambda.version>
     <urm.version>2.0.0</urm.version>
-    <mockito-junit-jupiter.version>3.5.0</mockito-junit-jupiter.version>
     <lombok.version>1.18.22</lombok.version>
     <byte-buddy.version>1.11.5</byte-buddy.version>
     <javassist.version>3.27.0-GA</javassist.version>
@@ -257,6 +255,28 @@
         <version>${hibernate.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>${junit-jupiter.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>${mockito.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-inline</artifactId>
+        <version>${mockito.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-junit-jupiter</artifactId>
+        <version>${mockito.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
         <version>${spring-boot.version}</version>
@@ -271,7 +291,7 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-webmvc</artifactId>
-        <version>${spring.version}</version>
+        <version>${spring-framework.version}</version>
       </dependency>
       <dependency>
         <groupId>com.h2database</groupId>
@@ -292,42 +312,6 @@
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-stream</artifactId>
         <version>${camel.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-api</artifactId>
-        <version>${junit-jupiter.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-engine</artifactId>
-        <version>${junit-jupiter.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-params</artifactId>
-        <version>${junit-jupiter.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-migrationsupport</artifactId>
-        <version>${junit-jupiter.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.junit.vintage</groupId>
-        <artifactId>junit-vintage-engine</artifactId>
-        <version>${junit-vintage.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.mockito</groupId>
-        <artifactId>mockito-core</artifactId>
-        <version>${mockito.version}</version>
-        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>com.google.guava</groupId>

--- a/repository/src/main/resources/applicationContext.xml
+++ b/repository/src/main/resources/applicationContext.xml
@@ -24,7 +24,7 @@
 
 -->
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:aop="http://www.springframework.org/schema/aop" xmlns:context="http://www.springframework.org/schema/context" xmlns:jpa="http://www.springframework.org/schema/data/jpa" xmlns:security="http://www.springframework.org/schema/security" xmlns:tx="http://www.springframework.org/schema/tx" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.2.xsd http://www.springframework.org/schema/data/jpa http://www.springframework.org/schema/data/jpa/spring-jpa.xsd">
-  <jpa:repositories base-package="com.iluwatar" base-class="org.springframework.data.jpa.repository.support.SimpleJpaRepository" />
+  <jpa:repositories base-package="com.iluwatar" />
   <bean id="transactionManager" class="org.springframework.orm.jpa.JpaTransactionManager">
     <property name="entityManagerFactory" ref="entityManagerFactory" />
   </bean>
@@ -48,4 +48,7 @@
       </map>
     </property>
   </bean>
+  <context:component-scan base-package="com.iluwatar.repository">
+    <context:include-filter type="annotation" expression="org.springframework.stereotype.Repository" />
+  </context:component-scan>
 </beans>


### PR DESCRIPTION
Import Jupiter BOM before Spring dependencies BOM to override some dependencies of the latter one.

https://github.com/spring-gradle-plugins/dependency-management-plugin/issues/208#issuecomment-372151684

https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.1-Release-Notes#spring-version-pom-property

Closes #978 