### PR TITLE
Fix #978: Update spring-boot-dependencies 2.0.9 to 2.7.5

### DIFF
--- a/cqrs/pom.xml
+++ b/cqrs/pom.xml
@@ -48,9 +48,8 @@
       <artifactId>hibernate-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-impl</artifactId>
-      <version>2.1.17</version>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-runtime</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/dirty-flag/pom.xml
+++ b/dirty-flag/pom.xml
@@ -48,7 +48,6 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
-      <version>3.5.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/eip-aggregator/pom.xml
+++ b/eip-aggregator/pom.xml
@@ -48,8 +48,8 @@
       <version>${camel.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-impl</artifactId>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-runtime</artifactId>
     </dependency>
     <dependency>
       <groupId>javax.xml.bind</groupId>

--- a/eip-splitter/pom.xml
+++ b/eip-splitter/pom.xml
@@ -48,8 +48,8 @@
       <version>${camel.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-impl</artifactId>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-runtime</artifactId>
     </dependency>
     <dependency>
       <groupId>javax.xml.bind</groupId>

--- a/eip-wire-tap/pom.xml
+++ b/eip-wire-tap/pom.xml
@@ -48,8 +48,8 @@
       <version>${camel.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-impl</artifactId>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-runtime</artifactId>
     </dependency>
     <dependency>
       <groupId>javax.xml.bind</groupId>

--- a/layers/src/main/resources/applicationContext.xml
+++ b/layers/src/main/resources/applicationContext.xml
@@ -49,4 +49,7 @@
       </map>
     </property>
   </bean>
+  <context:component-scan base-package="com.iluwatar.layers.dao">
+    <context:include-filter type="annotation" expression="org.springframework.stereotype.Repository" />
+  </context:component-scan>
 </beans>

--- a/metadata-mapping/pom.xml
+++ b/metadata-mapping/pom.xml
@@ -43,10 +43,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-core</artifactId>
     </dependency>
@@ -59,8 +55,8 @@
       <artifactId>jaxb-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-impl</artifactId>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-runtime</artifactId>
     </dependency>
     <dependency>
       <groupId>com.sun.istack</groupId>

--- a/naked-objects/dom/pom.xml
+++ b/naked-objects/dom/pom.xml
@@ -52,7 +52,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>${compiler.version}</version>
         <configuration>
           <source>8</source>
           <target>8</target>

--- a/page-object/pom.xml
+++ b/page-object/pom.xml
@@ -37,12 +37,6 @@
       <artifactId>htmlunit</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter</artifactId>
-      <version>RELEASE</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
   <parent>
     <groupId>com.iluwatar</groupId>

--- a/partial-response/pom.xml
+++ b/partial-response/pom.xml
@@ -37,7 +37,6 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
-      <version>3.5.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -36,15 +36,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <sonar-maven-plugin.version>3.8.0.2131</sonar-maven-plugin.version>
-    <hibernate.version>5.4.24.Final</hibernate.version>
-    <spring.version>5.0.17.RELEASE</spring.version>
-    <spring-boot.version>2.0.9.RELEASE</spring-boot.version>
-    <spring-data.version>2.0.14.RELEASE</spring-data.version>
+    <spring-boot.version>2.7.5</spring-boot.version>
     <h2.version>1.4.190</h2.version>
-    <junit.version>4.12</junit.version>
-    <junit-jupiter.version>5.7.1</junit-jupiter.version>
-    <junit-vintage.version>${junit-jupiter.version}</junit-vintage.version>
-    <compiler.version>3.8.1</compiler.version>
     <jacoco.version>0.8.8</jacoco.version>
     <commons-dbcp.version>1.4</commons-dbcp.version>
     <camel.version>2.25.1</camel.version>
@@ -53,20 +46,11 @@
     <htmlunit.version>2.22</htmlunit.version>
     <guice.version>4.0</guice.version>
     <mongo-java-driver.version>3.12.8</mongo-java-driver.version>
-    <slf4j.version>1.7.30</slf4j.version>
-    <logback.version>1.2.9</logback.version>
     <aws-lambda-core.version>1.1.0</aws-lambda-core.version>
     <aws-java-sdk-dynamodb.version>1.12.13</aws-java-sdk-dynamodb.version>
     <aws-lambda-java-events.version>2.0.1</aws-lambda-java-events.version>
-    <jackson.version>2.12.3</jackson.version>
-    <jaxb-api.version>2.3.1</jaxb-api.version>
-    <jaxb-impl.version>2.3.2</jaxb-impl.version>
-    <annotation-api.version>1.3.2</annotation-api.version>
     <system-lambda.version>1.1.0</system-lambda.version>
     <urm.version>2.0.0</urm.version>
-    <mockito-junit-jupiter.version>3.5.0</mockito-junit-jupiter.version>
-    <lombok.version>1.18.22</lombok.version>
-    <byte-buddy.version>1.11.5</byte-buddy.version>
     <javassist.version>3.27.0-GA</javassist.version>
     <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
     <maven-checkstyle-plugin.version>3.1.0</maven-checkstyle-plugin.version>
@@ -240,21 +224,19 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>net.bytebuddy</groupId>
-        <artifactId>byte-buddy</artifactId>
-        <version>${byte-buddy.version}</version>
-        <scope>test</scope>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>${mockito.version}</version>
       </dependency>
       <dependency>
-        <groupId>net.bytebuddy</groupId>
-        <artifactId>byte-buddy-agent</artifactId>
-        <version>${byte-buddy.version}</version>
-        <scope>test</scope>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-inline</artifactId>
+        <version>${mockito.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.hibernate</groupId>
-        <artifactId>hibernate-core</artifactId>
-        <version>${hibernate.version}</version>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-junit-jupiter</artifactId>
+        <version>${mockito.version}</version>
       </dependency>
       <dependency>
         <groupId>org.springframework.boot</groupId>
@@ -262,16 +244,6 @@
         <version>${spring-boot.version}</version>
         <type>pom</type>
         <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework.data</groupId>
-        <artifactId>spring-data-jpa</artifactId>
-        <version>${spring-data.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-webmvc</artifactId>
-        <version>${spring.version}</version>
       </dependency>
       <dependency>
         <groupId>com.h2database</groupId>
@@ -294,42 +266,6 @@
         <version>${camel.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-api</artifactId>
-        <version>${junit-jupiter.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-engine</artifactId>
-        <version>${junit-jupiter.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-params</artifactId>
-        <version>${junit-jupiter.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-migrationsupport</artifactId>
-        <version>${junit-jupiter.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.junit.vintage</groupId>
-        <artifactId>junit-vintage-engine</artifactId>
-        <version>${junit-vintage.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.mockito</groupId>
-        <artifactId>mockito-core</artifactId>
-        <version>${mockito.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
         <version>${guava.version}</version>
@@ -348,21 +284,6 @@
         <groupId>org.mongodb</groupId>
         <artifactId>mongo-java-driver</artifactId>
         <version>${mongo-java-driver.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>javax.xml.bind</groupId>
-        <artifactId>jaxb-api</artifactId>
-        <version>${jaxb-api.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>javax.annotation</groupId>
-        <artifactId>javax.annotation-api</artifactId>
-        <version>${annotation-api.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.sun.xml.bind</groupId>
-        <artifactId>jaxb-impl</artifactId>
-        <version>${jaxb-impl.version}</version>
       </dependency>
       <dependency>
         <groupId>org.javassist</groupId>
@@ -391,22 +312,18 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>${slf4j.version}</version>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>${logback.version}</version>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-core</artifactId>
-      <version>${logback.version}</version>
     </dependency>
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>${lombok.version}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>
@@ -416,7 +333,6 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>${compiler.version}</version>
           <configuration>
             <source>11</source>
             <target>11</target>
@@ -430,7 +346,6 @@
         <plugin>
           <groupId>org.springframework.boot</groupId>
           <artifactId>spring-boot-maven-plugin</artifactId>
-          <version>${spring-boot.version}</version>
         </plugin>
         <!-- Maven assembly plugin template for all child project to follow -->
         <plugin>

--- a/repository/src/main/resources/applicationContext.xml
+++ b/repository/src/main/resources/applicationContext.xml
@@ -24,7 +24,7 @@
 
 -->
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:aop="http://www.springframework.org/schema/aop" xmlns:context="http://www.springframework.org/schema/context" xmlns:jpa="http://www.springframework.org/schema/data/jpa" xmlns:security="http://www.springframework.org/schema/security" xmlns:tx="http://www.springframework.org/schema/tx" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.2.xsd http://www.springframework.org/schema/data/jpa http://www.springframework.org/schema/data/jpa/spring-jpa.xsd">
-  <jpa:repositories base-package="com.iluwatar" base-class="org.springframework.data.jpa.repository.support.SimpleJpaRepository" />
+  <jpa:repositories base-package="com.iluwatar" />
   <bean id="transactionManager" class="org.springframework.orm.jpa.JpaTransactionManager">
     <property name="entityManagerFactory" ref="entityManagerFactory" />
   </bean>
@@ -48,4 +48,7 @@
       </map>
     </property>
   </bean>
+  <context:component-scan base-package="com.iluwatar.repository">
+    <context:include-filter type="annotation" expression="org.springframework.stereotype.Repository" />
+  </context:component-scan>
 </beans>

--- a/serverless/pom.xml
+++ b/serverless/pom.xml
@@ -52,17 +52,14 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/service-layer/pom.xml
+++ b/service-layer/pom.xml
@@ -43,8 +43,8 @@
       <artifactId>h2</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-impl</artifactId>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-runtime</artifactId>
     </dependency>
     <dependency>
       <groupId>javax.xml.bind</groupId>


### PR DESCRIPTION
Remove explicit dependencies that are covered by spring-boot-dependencies
hibernate 5.4.24 -> 5.6.12
spring-webmvc 5.0.17 -> 5.3.23
spring-data-jpa 2.0.14 -> 2.7.5
junit 4.12 -> 4.13.2
junit-jupiter 5.7.1 -> 5.8.2
slf4j 1.7.30 -> 1.7.36
logback 1.2.9 -> 1.2.11
jackson 2.12.3 -> 2.13.4
lombok 1.18.22 -> 1.18.24
byte-buddy 1.11.5 -> 1.12.8
jaxb-impl 2.3.2 -> 2.3.7

Fix #978 