### PR TITLE
Fix for maven warnings

### DIFF
--- a/metadata-mapping/pom.xml
+++ b/metadata-mapping/pom.xml
@@ -51,10 +51,6 @@
       <artifactId>hibernate-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
-    </dependency>
-    <dependency>
       <groupId>javax.xml.bind</groupId>
       <artifactId>jaxb-api</artifactId>
     </dependency>

--- a/page-object/pom.xml
+++ b/page-object/pom.xml
@@ -37,11 +37,6 @@
       <artifactId>htmlunit</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
   <parent>
     <groupId>com.iluwatar</groupId>

--- a/page-object/pom.xml
+++ b/page-object/pom.xml
@@ -39,8 +39,7 @@
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter</artifactId>
-      <version>RELEASE</version>
+      <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/page-object/test-automation/pom.xml
+++ b/page-object/test-automation/pom.xml
@@ -36,7 +36,7 @@
   <dependencies>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
+      <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/page-object/test-automation/src/main/java/com/iluwatar/pageobject/AlbumListPage.java
+++ b/page-object/test-automation/src/main/java/com/iluwatar/pageobject/AlbumListPage.java
@@ -80,11 +80,11 @@ public class AlbumListPage extends Page {
    */
   public AlbumPage selectAlbum(String albumTitle) {
     // uses XPath to find list of html anchor tags with the class album in it
-    var albumLinks = (List<HtmlAnchor>) page.getByXPath("//tr[@class='album']//a");
+    var albumLinks = (List<Object>) page.getByXPath("//tr[@class='album']//a");
     for (var anchor : albumLinks) {
-      if (anchor.getTextContent().equals(albumTitle)) {
+      if (((HtmlAnchor) anchor).getTextContent().equals(albumTitle)) {
         try {
-          anchor.click();
+          ((HtmlAnchor) anchor).click();
           return new AlbumPage(webClient);
         } catch (IOException e) {
           LOGGER.error("An error occured on selectAlbum", e);

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <camel.version>2.25.1</camel.version>
     <guava.version>19.0</guava.version>
     <mockito.version>3.5.6</mockito.version>
-    <htmlunit.version>2.22</htmlunit.version>
+    <htmlunit.version>2.66.0</htmlunit.version>
     <guice.version>4.0</guice.version>
     <mongo-java-driver.version>3.12.8</mongo-java-driver.version>
     <slf4j.version>1.7.30</slf4j.version>


### PR DESCRIPTION
Resolve maven warning

![image](https://user-images.githubusercontent.com/1470114/197611201-73dff7cf-dab7-4f0c-a4c8-6f32a3293104.png)

Pull request description

- Removed duplicated dependency declaration
- Updated `junit-jupiter-api` junit dependency co-ordinates 



> For detailed contributing instructions see https://github.com/iluwatar/java-design-patterns/wiki/01.-How-to-contribute
