### PR TITLE
Upgrade Camel 2.25.1 to 3.18.1

### DIFF
--- a/eip-aggregator/pom.xml
+++ b/eip-aggregator/pom.xml
@@ -43,7 +43,7 @@
       <artifactId>camel-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.camel</groupId>
+      <groupId>org.apache.camel.springboot</groupId>
       <artifactId>camel-spring-boot</artifactId>
       <version>${camel.version}</version>
     </dependency>

--- a/eip-aggregator/src/main/java/com/iluwatar/eip/aggregator/routes/MessageAggregationStrategy.java
+++ b/eip-aggregator/src/main/java/com/iluwatar/eip/aggregator/routes/MessageAggregationStrategy.java
@@ -24,8 +24,8 @@
  */
 package com.iluwatar.eip.aggregator.routes;
 
+import org.apache.camel.AggregationStrategy;
 import org.apache.camel.Exchange;
-import org.apache.camel.processor.aggregate.AggregationStrategy;
 import org.springframework.stereotype.Component;
 
 /**

--- a/eip-aggregator/src/test/java/com/iluwatar/eip/aggregator/routes/MessageAggregationStrategyTest.java
+++ b/eip-aggregator/src/test/java/com/iluwatar/eip/aggregator/routes/MessageAggregationStrategyTest.java
@@ -27,7 +27,8 @@ package com.iluwatar.eip.aggregator.routes;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.camel.CamelContext;
-import org.apache.camel.impl.DefaultExchange;
+import org.apache.camel.impl.engine.SimpleCamelContext;
+import org.apache.camel.support.DefaultExchange;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -35,13 +36,15 @@ import org.junit.jupiter.api.Test;
  */
 class MessageAggregationStrategyTest {
 
+  private final CamelContext context = new SimpleCamelContext();
+  
   @Test
   void testAggregate() {
     var mas = new MessageAggregationStrategy();
-    var oldExchange = new DefaultExchange((CamelContext) null);
+    var oldExchange = new DefaultExchange(context);
     oldExchange.getIn().setBody("TEST1");
 
-    var newExchange = new DefaultExchange((CamelContext) null);
+    var newExchange = new DefaultExchange(context);
     newExchange.getIn().setBody("TEST2");
 
     var output = mas.aggregate(oldExchange, newExchange);
@@ -53,7 +56,7 @@ class MessageAggregationStrategyTest {
   void testAggregateOldNull() {
     var mas = new MessageAggregationStrategy();
 
-    var newExchange = new DefaultExchange((CamelContext) null);
+    var newExchange = new DefaultExchange(context);
     newExchange.getIn().setBody("TEST2");
 
     var output = mas.aggregate(null, newExchange);

--- a/eip-splitter/pom.xml
+++ b/eip-splitter/pom.xml
@@ -43,7 +43,7 @@
       <artifactId>camel-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.camel</groupId>
+      <groupId>org.apache.camel.springboot</groupId>
       <artifactId>camel-spring-boot</artifactId>
       <version>${camel.version}</version>
     </dependency>

--- a/eip-wire-tap/pom.xml
+++ b/eip-wire-tap/pom.xml
@@ -43,7 +43,7 @@
       <artifactId>camel-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.camel</groupId>
+      <groupId>org.apache.camel.springboot</groupId>
       <artifactId>camel-spring-boot</artifactId>
       <version>${camel.version}</version>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <h2.version>1.4.190</h2.version>
     <jacoco.version>0.8.8</jacoco.version>
     <commons-dbcp.version>1.4</commons-dbcp.version>
-    <camel.version>2.25.1</camel.version>
+    <camel.version>3.18.3</camel.version>
     <guava.version>19.0</guava.version>
     <mockito.version>3.5.6</mockito.version>
     <htmlunit.version>2.66.0</htmlunit.version>


### PR DESCRIPTION
> Camel 3.17 is the first release where we have official support for Java 17,

https://camel.apache.org/blog/2022/05/camel317-whatsnew/

#2037 