### PR TITLE
Build with Java 17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,14 +26,14 @@ version: 2
 jobs:
   sonar-pr:
     docker:
-      - image: cimg/openjdk:11.0-node
+      - image: cimg/openjdk:17.0-node
     steps:
     - checkout
     - restore_cache:
         key: jdp-sonar-pr-{{ checksum "pom.xml" }}
     - run: |
         sudo apt-get update
-        sudo apt-get install -y openjdk-11-jdk xvfb
+        sudo apt-get install -y openjdk-17-jdk xvfb
         if [ -n "${CIRCLE_PR_NUMBER}" ]; then
           MAVEN_OPTS="-Xmx3000m" xvfb-run ./mvnw -B clean verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar \
              -Dsonar.pullrequest.key=${CIRCLE_PR_NUMBER} \

--- a/.github/workflows/maven-ci.yml
+++ b/.github/workflows/maven-ci.yml
@@ -39,7 +39,7 @@ jobs:
   # This Workflow Job will build this project and run Sonar analysis using JDK 11.0.3
   build-and-analyze:
 
-    name: Build and Run Sonar analysis on JDK 11.0.3
+    name: Build and Run Sonar analysis on JDK 17
     runs-on: ubuntu-20.04
     steps:
 
@@ -49,11 +49,11 @@ jobs:
         # Disabling shallow clone for improving relevancy of SonarQube reporting
         fetch-depth: 0
 
-    - name: Set up JDK 11.0.3
+    - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
-        java-version: 11.0.3
-        distribution: 'zulu'
+        java-version: '17'
+        distribution: 'temurin'
         cache: 'maven'
 
     # Cache Sonar packages which as used to run anaylysis and collect metrics
@@ -79,18 +79,18 @@ jobs:
   # This Workflow Job is going to build the project on the latest stable JDK 11
   build:
 
-    name: Build and Test on JDK 11
+    name: Build and Test on JDK 17
     runs-on: ubuntu-20.04
     steps:
 
     - name: Checkout Code
       uses: actions/checkout@v3
 
-    - name: Set up JDK 11 (Latest)
+    - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
-        java-version: 11
-        distribution: 'zulu'
+        java-version: '17'
+        distribution: 'temurin'
         cache: 'maven'
 
     # Some tests need screen access

--- a/.github/workflows/maven-pr-builder.yml
+++ b/.github/workflows/maven-pr-builder.yml
@@ -34,21 +34,18 @@ on:
 jobs:
   build:
 
-    name: Build JDP
+    name: Build on JDK 17
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        java-version: [ 11.0.3, 11 ]
     steps:
     
     - name: Checkout Code
       uses: actions/checkout@v3
     
-    - name: Set up JDK ${{ matrix.java-version }}
+    - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
-        java-version: ${{ matrix.java-version }}
-        distribution: 'zulu'
+        java-version: '17'
+        distribution: 'temurin'
         cache: 'maven'
     
     # Some tests need screen access


### PR DESCRIPTION
The naked-objects pattern cannot be build with Java 17 because it use an ancient version of Cucumber.

Fixes #2035 