### PR TITLE
Feat: reduce logs

### DIFF
--- a/monitor/src/main/java/com/iluwatar/monitor/Bank.java
+++ b/monitor/src/main/java/com/iluwatar/monitor/Bank.java
@@ -78,12 +78,14 @@ public class Bank {
     if (accounts[accountA] >= amount) {
       accounts[accountB] += amount;
       accounts[accountA] -= amount;
-      LOGGER.info(
-          "Transferred from account: {} to account: {} , amount: {} , balance: {}",
-          accountA,
-          accountB,
-          amount,
-          getBalance());
+      if (LOGGER.isDebugEnabled()) {
+        LOGGER.debug(
+            "Transferred from account: {} to account: {} , amount: {} , balance: {}",
+            accountA,
+            accountB,
+            amount,
+            getBalance());
+      }
     }
   }
 

--- a/monitor/src/main/java/com/iluwatar/monitor/Main.java
+++ b/monitor/src/main/java/com/iluwatar/monitor/Main.java
@@ -49,11 +49,13 @@ public class Main {
     try {
       SecureRandom random = new SecureRandom();
       Thread.sleep(random.nextInt(1000));
+      LOGGER.info("Start transferring...");
       for (int i = 0; i < 1000000; i++) {
         bank.transfer(random.nextInt(4), random.nextInt(4), random.nextInt());
       }
+      LOGGER.info("Finished transferring.");
     } catch (InterruptedException e) {
-      LOGGER.info(e.getMessage());
+      LOGGER.error(e.getMessage());
       Thread.currentThread().interrupt();
     }
   }

--- a/monitor/src/main/java/com/iluwatar/monitor/Main.java
+++ b/monitor/src/main/java/com/iluwatar/monitor/Main.java
@@ -25,7 +25,7 @@
 package com.iluwatar.monitor;
 
 import java.security.SecureRandom;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import lombok.extern.slf4j.Slf4j;
 
@@ -40,12 +40,15 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class Main {
 
+  private static final int NUMBER_OF_THREADS = 5;
+
   /**
    * Runner to perform a bunch of transfers and handle exception.
    *
-   * @param bank bank object
+   * @param bank  bank object
+   * @param latch signal finished execution
    */
-  public static void runner(Bank bank) {
+  public static void runner(Bank bank, CountDownLatch latch) {
     try {
       SecureRandom random = new SecureRandom();
       Thread.sleep(random.nextInt(1000));
@@ -54,6 +57,7 @@ public class Main {
         bank.transfer(random.nextInt(4), random.nextInt(4), random.nextInt());
       }
       LOGGER.info("Finished transferring.");
+      latch.countDown();
     } catch (InterruptedException e) {
       LOGGER.error(e.getMessage());
       Thread.currentThread().interrupt();
@@ -65,12 +69,15 @@ public class Main {
    *
    * @param args command line args
    */
-  public static void main(String[] args) {
+  public static void main(String[] args) throws InterruptedException {
     var bank = new Bank(4, 1000);
-    Runnable runnable = () -> runner(bank);
-    ExecutorService executorService = Executors.newFixedThreadPool(5);
-    for (int i = 0; i < 5; i++) {
-      executorService.execute(runnable);
+    var latch = new CountDownLatch(NUMBER_OF_THREADS);
+    var executorService = Executors.newFixedThreadPool(NUMBER_OF_THREADS);
+
+    for (int i = 0; i < NUMBER_OF_THREADS; i++) {
+      executorService.execute(() -> runner(bank, latch));
     }
+
+    latch.await();
   }
 }

--- a/monitor/src/test/java/com/iluwatar/monitor/MainTest.java
+++ b/monitor/src/test/java/com/iluwatar/monitor/MainTest.java
@@ -25,6 +25,7 @@
 package com.iluwatar.monitor;
 
 import org.junit.jupiter.api.Test;
+import java.util.concurrent.CountDownLatch;
 import static org.junit.jupiter.api.Assertions.*;
 
 /** Test if the application starts without throwing an exception. */
@@ -38,6 +39,9 @@ class MainTest {
   @Test
   void RunnerExecuteWithoutException() {
     var bank = new Bank(4, 1000);
-    assertDoesNotThrow(() -> Main.runner(bank));
+    var latch = new CountDownLatch(1);
+
+    assertDoesNotThrow(() -> Main.runner(bank, latch));
+    assertEquals(0, latch.getCount());
   }
 }

--- a/monitor/src/test/resources/logback.xml
+++ b/monitor/src/test/resources/logback.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    The MIT License
+    Copyright © 2014-2022 Ilkka Seppälä
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+
+-->
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>


### PR DESCRIPTION
Reduced the logs generated during text execution from over 100 MB to under 4 MB by adjusting the monitor pattern.

I further ensure that the main thread wait until all child threads finished.

Fixes #2369 