### PR TITLE
fix: Issue #2459 fixed

### DIFF
--- a/singleton/src/main/java/com/iluwatar/singleton/ThreadSafeLazyLoadedIvoryTower.java
+++ b/singleton/src/main/java/com/iluwatar/singleton/ThreadSafeLazyLoadedIvoryTower.java
@@ -44,13 +44,9 @@ public final class ThreadSafeLazyLoadedIvoryTower {
    * The instance doesn't get created until the method is called for the first time.
    */
   public static synchronized ThreadSafeLazyLoadedIvoryTower getInstance() {
-    if (instance == null) {
-      synchronized (ThreadSafeLazyLoadedIvoryTower.class) {
-        if (instance == null) {
+      if (instance == null) {
           instance = new ThreadSafeLazyLoadedIvoryTower();
-        }
       }
-    }
     return instance;
   }
 }


### PR DESCRIPTION

- Removed Double-Checked Locking for com.iluwatar.singleton.ThreadSafeLazyLoadedIvoryTower and made it simpler with a Single Check for the instance object.
