### PR TITLE
Fix generic type for deques in command README.md files Ref: #2462

### DIFF
--- a/command/README.md
+++ b/command/README.md
@@ -40,8 +40,8 @@ Here's the sample code with wizard and goblin. Let's start from the `Wizard` cla
 @Slf4j
 public class Wizard {
 
-  private final Deque<Command> undoStack = new LinkedList<>();
-  private final Deque<Command> redoStack = new LinkedList<>();
+  private final Deque<Runnable> undoStack = new LinkedList<>();
+  private final Deque<Runnable> redoStack = new LinkedList<>();
 
   public Wizard() {}
 

--- a/localization/zh/command/README.md
+++ b/localization/zh/command/README.md
@@ -34,8 +34,8 @@ public class Wizard {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(Wizard.class);
 
-  private final Deque<Command> undoStack = new LinkedList<>();
-  private final Deque<Command> redoStack = new LinkedList<>();
+  private final Deque<Runnable> undoStack = new LinkedList<>();
+  private final Deque<Runnable> redoStack = new LinkedList<>();
 
   public Wizard() {}
 


### PR DESCRIPTION
Fix deques generic type

- Fix README files for command pattern
- Refences to #2462


Description

- Changes the generic type of deques fields in README files from 'Command' to 'Runnable' as in the source code files