### PR TITLE
fixing typo

### DIFF
--- a/strategy/README.md
+++ b/strategy/README.md
@@ -13,7 +13,7 @@ Policy
 ## Intent
 
 Define a family of algorithms, encapsulate each one, and make them interchangeable. Strategy lets 
-the algorithm vary independently from the clients that use it.
+the algorithm vary independently of the clients that use it.
 
 ## Explanation
 


### PR DESCRIPTION
Fixes a typo in the strategy README

- This PR fixes a typo found in the strategy pattern README


Pull request description
"Define a family of algorithms, encapsulate each one, and make them interchangeable. Strategy lets 
the algorithm vary independently of the clients that use it." 

instead of 

"Define a family of algorithms, encapsulate each one, and make them interchangeable. Strategy lets 
the algorithm vary independently from the clients that use it."


> For detailed contributing instructions see https://github.com/iluwatar/java-design-patterns/wiki/01.-How-to-contribute
