### PR TITLE
Fix Command pattern README generics

### DIFF
--- a/command/README.md
+++ b/command/README.md
@@ -40,8 +40,8 @@ Here's the sample code with wizard and goblin. Let's start from the `Wizard` cla
 @Slf4j
 public class Wizard {
 
-  private final Deque<Command> undoStack = new LinkedList<>();
-  private final Deque<Command> redoStack = new LinkedList<>();
+  private final Deque<Runnable> undoStack = new LinkedList<>();
+  private final Deque<Runnable> redoStack = new LinkedList<>();
 
   public Wizard() {}
 


### PR DESCRIPTION
Reference issue: https://github.com/iluwatar/java-design-patterns/issues/2462

This is a trivial change, it updates the README for the command pattern to include the same code as in the implementation. The current README, which uses the "Command" object in the Deque, does not make sense (nor does it compile). Tests and checkstyle pass successfully, as expected.