### PR TITLE
MongoDB tests enabled using test containers. Resolves #2368

### DIFF
--- a/hexagonal/pom.xml
+++ b/hexagonal/pom.xml
@@ -51,6 +51,12 @@
       <groupId>org.mongodb</groupId>
       <artifactId>mongodb-driver-legacy</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>mongodb</artifactId>
+      <version>1.18.1</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>


### PR DESCRIPTION
MongoDB tests now use test container which does require docker to be running.   This allows a mongodb container to start up before tests run. The host and port of the mongodb test container is injected into the system properties (existing pattern used by the tests) which is then used by the tests.
