### PR TITLE
Fix typos for factory pattern README

### DIFF
--- a/factory/README.md
+++ b/factory/README.md
@@ -60,7 +60,7 @@ public class CopperCoin implements Coin {
 }
 ```
 
-Enumeration above represents types of coins that we support (`GoldCoin` and `CopperCoin`).
+Enumeration below represents types of coins that we support (`GoldCoin` and `CopperCoin`).
 
 ```java
 @RequiredArgsConstructor
@@ -110,7 +110,7 @@ This is a gold coin.
 
 ## Applicability
 
-Use the factory pattern when you only care about the creation of a object, not how to create 
+Use the factory pattern when you only care about the creation of an object, not how to create 
 and manage it.
 
 Pros


### PR DESCRIPTION
### Fix some typos for the Factory pattern README

Fixed some typos I found in the english factory pattern README.