### PR TITLE
removed weird link from mvvm

### DIFF
--- a/model-view-viewmodel/README.md
+++ b/model-view-viewmodel/README.md
@@ -114,7 +114,6 @@ To deploy the example, go to model-view-viewmodel folder and run:
 ## Tutorials
 
 * [Zkoss Demo](https://www.zkoss.org/zkdemo/getting_started/mvvm)
-* [Learn MVVM](https://www.learnmvvm.com/)
 * [Data Binding in Android](https://developer.android.com/codelabs/android-databinding#0)
 
 ## Typical Use Case


### PR DESCRIPTION
- Removed a link  "Learn MVVM"  that takes us to a weird website from the tutorials section in mvvm pattern.
- https://java-design-patterns.com/patterns/model-view-viewmodel/#tutorials






