### PR TITLE
translation: translation of active object pattern to Italian

### DIFF
--- a/localization/it/active-object/README.md
+++ b/localization/it/active-object/README.md
@@ -1,0 +1,127 @@
+---
+title: Active Object
+category: Concurrency
+language: it
+tag:
+ - Performance
+---
+
+
+## Intento
+Il design pattern active object disaccoppia l'esecuzione del metodo dall'invocazione del metodo per gli oggetti che risiedono ciascuno nel proprio thread di controllo. L'obiettivo è introdurre la concorrenza utilizzando l'invocazione asincrona dei metodi e uno scheduler per gestire le richieste.
+
+## Spiegazione
+
+La classe che implementa il pattern active object conterrà un meccanismo di autosincronizzazione senza utilizzare metodi 'synchronized'.
+
+Esempio del mondo reale
+
+>Gli Orchi sono noti per la loro natura selvaggia e la loro anima indomabile. Sembra che abbiano il loro proprio thread di controllo basato su comportamenti precedenti.
+
+Per implementare una creatura che ha il suo meccanismo di thread di controllo e che esponga solo la sua API e non l'esecuzione stessa, possiamo utilizzare il pattern Active Object.
+
+
+**Esempio di codice**
+
+```java
+public abstract class ActiveCreature{
+  private final Logger logger = LoggerFactory.getLogger(ActiveCreature.class.getName());
+
+  private BlockingQueue<Runnable> requests;
+  
+  private String name;
+  
+  private Thread thread;
+
+  public ActiveCreature(String name) {
+    this.name = name;
+    this.requests = new LinkedBlockingQueue<Runnable>();
+    thread = new Thread(new Runnable() {
+        @Override
+        public void run() {
+          while (true) {
+            try {
+              requests.take().run();
+            } catch (InterruptedException e) { 
+              logger.error(e.getMessage());
+            }
+          }
+        }
+      }
+    );
+    thread.start();
+  }
+  
+  public void eat() throws InterruptedException {
+    requests.put(new Runnable() {
+        @Override
+        public void run() { 
+          logger.info("{} is eating!",name());
+          logger.info("{} has finished eating!",name());
+        }
+      }
+    );
+  }
+
+  public void roam() throws InterruptedException {
+    requests.put(new Runnable() {
+        @Override
+        public void run() { 
+          logger.info("{} has started to roam the wastelands.",name());
+        }
+      }
+    );
+  }
+  
+  public String name() {
+    return this.name;
+  }
+}
+```
+
+Possiamo vedere che qualsiasi classe che estenderà la classe ActiveCreature avrà il proprio thread di controllo per invocare ed eseguire i metodi.
+
+Ad esempio, la classe Orc:
+
+```java
+public class Orc extends ActiveCreature {
+
+  public Orc(String name) {
+    super(name);
+  }
+
+}
+```
+
+Ora possiamo creare diverse creature come gli Orchi, dir loro di mangiare e vagabondare, e loro eseguiranno queste azioni nel proprio thread di controllo:
+
+```java
+  public static void main(String[] args) {  
+    var app = new App();
+    app.run();
+  }
+  
+  @Override
+  public void run() {
+    ActiveCreature creature;
+    try {
+      for (int i = 0;i < creatures;i++) {
+        creature = new Orc(Orc.class.getSimpleName().toString() + i);
+        creature.eat();
+        creature.roam();
+      }
+      Thread.sleep(1000);
+    } catch (InterruptedException e) {
+      logger.error(e.getMessage());
+    }
+    Runtime.getRuntime().exit(1);
+  }
+```
+
+## Diagramma delle classi
+
+![alt text](../../../active-object/etc/active-object.urm.png "Active Object class diagram")
+
+## Tutorial
+
+* [Android and Java Concurrency: The Active Object Pattern](https://www.youtube.com/watch?v=Cd8t2u5Qmvc)


### PR DESCRIPTION
Translation of the 'Active Object' pattern README.md into Italian

This pull request adds the Italian translation of the README.md for the 'Active Object' design pattern, which explains the pattern itself.

This pull request is related to issue #2314

Changes made in this pull request:

- Created a new README.md file in Italian with the translation of the English README.md.
- Placed the new README.md file in the 'localization/it/active-object' directory.
- Ensured that the translation accurately conveys the content and meaning of the original document.
- Maintained the same format, style and layout of the English README.md.
- Checked for grammar and spelling errors in the translation.
- Provided the link diagram of the class structure in the Italian README.md, ensuring it aligns with the content of the original README.md.
- This contribution aims to make the project more accessible to Italian-speaking developers and users. It follows the guidelines provided in the project's contributing instructions.

>For detailed contributing instructions see https://github.com/iluwatar/java-design-patterns/wiki/01.-How-to-contribute

I look forward to your feedback and any necessary revisions to improve the quality of the Italian translation.

Allow edits by maintainers
Remember, contributions to this repository should follow its contributing guidelines.
