### PR TITLE
fix: #2366 Change h2 database usage to in mem

### DIFF
--- a/dao/src/main/java/com/iluwatar/dao/App.java
+++ b/dao/src/main/java/com/iluwatar/dao/App.java
@@ -44,7 +44,7 @@ import org.h2.jdbcx.JdbcDataSource;
  */
 @Slf4j
 public class App {
-  private static final String DB_URL = "jdbc:h2:~/dao";
+  private static final String DB_URL = "jdbc:h2:mem:dao;DB_CLOSE_DELAY=-1";
   private static final String ALL_CUSTOMERS = "customerDao.getAllCustomers(): ";
 
   /**

--- a/dao/src/test/java/com/iluwatar/dao/DbCustomerDaoTest.java
+++ b/dao/src/test/java/com/iluwatar/dao/DbCustomerDaoTest.java
@@ -49,7 +49,7 @@ import org.mockito.Mockito;
  */
 class DbCustomerDaoTest {
 
-  private static final String DB_URL = "jdbc:h2:~/dao";
+  private static final String DB_URL = "jdbc:h2:mem:dao;DB_CLOSE_DELAY=-1";
   private DbCustomerDao dao;
   private final Customer existingCustomer = new Customer(1, "Freddy", "Krueger");
 

--- a/domain-model/src/main/java/com/iluwatar/domainmodel/App.java
+++ b/domain-model/src/main/java/com/iluwatar/domainmodel/App.java
@@ -49,7 +49,7 @@ import org.joda.money.Money;
  */
 public class App {
 
-  public static final String H2_DB_URL = "jdbc:h2:~/test";
+  public static final String H2_DB_URL = "jdbc:h2:mem:testdb";
 
   public static final String CREATE_SCHEMA_SQL =
       "CREATE TABLE CUSTOMERS (name varchar primary key, money decimal);"

--- a/domain-model/src/main/java/com/iluwatar/domainmodel/App.java
+++ b/domain-model/src/main/java/com/iluwatar/domainmodel/App.java
@@ -49,7 +49,7 @@ import org.joda.money.Money;
  */
 public class App {
 
-  public static final String H2_DB_URL = "jdbc:h2:mem:testdb";
+  public static final String H2_DB_URL = "jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1";
 
   public static final String CREATE_SCHEMA_SQL =
       "CREATE TABLE CUSTOMERS (name varchar primary key, money decimal);"

--- a/layers/src/main/resources/application.properties
+++ b/layers/src/main/resources/application.properties
@@ -2,7 +2,7 @@
 spring.main.web-application-type=none
 
 #datasource settings
-spring.datasource.url=jdbc:h2:~/databases/cake
+spring.datasource.url=jdbc:h2:mem:databases-cake
 spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=sa

--- a/repository/src/main/java/com/iluwatar/repository/AppConfig.java
+++ b/repository/src/main/java/com/iluwatar/repository/AppConfig.java
@@ -54,7 +54,7 @@ public class AppConfig {
   public DataSource dataSource() {
     var basicDataSource = new BasicDataSource();
     basicDataSource.setDriverClassName("org.h2.Driver");
-    basicDataSource.setUrl("jdbc:h2:~/databases/person");
+    basicDataSource.setUrl("jdbc:h2:mem:databases-person");
     basicDataSource.setUsername("sa");
     basicDataSource.setPassword("sa");
     return basicDataSource;

--- a/repository/src/main/resources/applicationContext.xml
+++ b/repository/src/main/resources/applicationContext.xml
@@ -30,7 +30,7 @@
   </bean>
   <bean id="dataSource" class="org.apache.commons.dbcp.BasicDataSource" destroy-method="close">
     <property name="driverClassName" value="org.h2.Driver" />
-    <property name="url" value="jdbc:h2:~/databases/person" />
+    <property name="url" value="jdbc:h2:mem:databases-person;DB_CLOSE_DELAY=-1" />
     <property name="username" value="sa" />
     <property name="password" value="sa" />
   </bean>

--- a/serialized-entity/README.md
+++ b/serialized-entity/README.md
@@ -136,7 +136,7 @@ methods to read and deserialize data items to `Country` objects.
 ```java
 @Slf4j
 public class App {
-    private static final String DB_URL = "jdbc:h2:~/test";
+    private static final String DB_URL = "jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1";
 
     private App() {
 

--- a/serialized-entity/src/main/java/com/iluwatar/serializedentity/App.java
+++ b/serialized-entity/src/main/java/com/iluwatar/serializedentity/App.java
@@ -48,7 +48,7 @@ import org.h2.jdbcx.JdbcDataSource;
  */
 @Slf4j
 public class App {
-  private static final String DB_URL = "jdbc:h2:~/test";
+  private static final String DB_URL = "jdbc:h2:mem:testdb";
 
   private App() {
 

--- a/serialized-entity/src/test/java/com/iluwatar/serializedentity/AppTest.java
+++ b/serialized-entity/src/test/java/com/iluwatar/serializedentity/AppTest.java
@@ -1,3 +1,27 @@
+/*
+ * This project is licensed under the MIT license. Module model-view-viewmodel is using ZK framework licensed under LGPL (see lgpl-3.0.txt).
+ *
+ * The MIT License
+ * Copyright © 2014-2022 Ilkka Seppälä
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package com.iluwatar.serializedentity;
 
 import org.junit.jupiter.api.Test;

--- a/table-module/src/main/java/com/iluwatar/tablemodule/App.java
+++ b/table-module/src/main/java/com/iluwatar/tablemodule/App.java
@@ -45,7 +45,7 @@ import org.h2.jdbcx.JdbcDataSource;
  */
 @Slf4j
 public final class App {
-  private static final String DB_URL = "jdbc:h2:~/test";
+  private static final String DB_URL = "jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1";
 
   /**
    * Private constructor.

--- a/table-module/src/test/java/com/iluwatar/tablemodule/UserTableModuleTest.java
+++ b/table-module/src/test/java/com/iluwatar/tablemodule/UserTableModuleTest.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class UserTableModuleTest {
-  private static final String DB_URL = "jdbc:h2:~/test";
+  private static final String DB_URL = "jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1";
 
   private static DataSource createDataSource() {
     var dataSource = new JdbcDataSource();

--- a/transaction-script/src/main/java/com/iluwatar/transactionscript/App.java
+++ b/transaction-script/src/main/java/com/iluwatar/transactionscript/App.java
@@ -46,7 +46,7 @@ import org.slf4j.LoggerFactory;
  */
 public class App {
 
-  private static final String H2_DB_URL = "jdbc:h2:~/test";
+  private static final String H2_DB_URL = "jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1";
   private static final Logger LOGGER = LoggerFactory.getLogger(App.class);
 
   /**

--- a/transaction-script/src/test/java/com/iluwatar/transactionscript/HotelDaoImplTest.java
+++ b/transaction-script/src/test/java/com/iluwatar/transactionscript/HotelDaoImplTest.java
@@ -49,7 +49,7 @@ import org.mockito.Mockito;
  */
 class HotelDaoImplTest {
 
-  private static final String DB_URL = "jdbc:h2:~/test";
+  private static final String DB_URL = "jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1";
   private HotelDaoImpl dao;
   private Room existingRoom = new Room(1, "Single", 50, false);
 

--- a/transaction-script/src/test/java/com/iluwatar/transactionscript/HotelTest.java
+++ b/transaction-script/src/test/java/com/iluwatar/transactionscript/HotelTest.java
@@ -39,7 +39,7 @@ import org.junit.jupiter.api.Test;
  */
 class HotelTest {
 
-  private static final String H2_DB_URL = "jdbc:h2:~/test";
+  private static final String H2_DB_URL = "jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1";
 
   private Hotel hotel;
   private HotelDaoImpl dao;


### PR DESCRIPTION
Fix: [#2366 ](https://github.com/iluwatar/java-design-patterns/issues/2366)

Standardize the use of the h2 database in the project. The in-memory option will not affect the user drive.


Pull request description

Change file-based database usage to in-mem option. I am attaching a screenshot to verify that only h2 db in-mem is used in the project.

![image](https://github.com/iluwatar/java-design-patterns/assets/58841343/61b7575a-5c08-4586-8d71-3b165775a54a)


