### PR TITLE
refactor: Eliminate Optional from fields and parameters for async method invocation

### DIFF
--- a/async-method-invocation/README.md
+++ b/async-method-invocation/README.md
@@ -57,7 +57,8 @@ public interface AsyncResult<T> {
 
 ```java
 public interface AsyncCallback<T> {
-  void onComplete(T value, Optional<Exception> ex);
+    void onComplete(T value);
+    void onError(Exception ex);
 }
 ```
 

--- a/async-method-invocation/etc/async-method-invocation.urm.puml
+++ b/async-method-invocation/etc/async-method-invocation.urm.puml
@@ -9,7 +9,8 @@ package com.iluwatar.async.method.invocation {
     + main(args : String[]) {static}
   }
   interface AsyncCallback<T> {
-    + onComplete(T, Optional<Exception>) {abstract}
+    + onComplete(T) {abstract}
+    + onError(Exception) {abstract}
   }
   interface AsyncExecutor {
     + endProcess(AsyncResult<T>) : T {abstract}
@@ -32,7 +33,7 @@ package com.iluwatar.async.method.invocation {
     ~ COMPLETED : int {static}
     ~ FAILED : int {static}
     ~ RUNNING : int {static}
-    ~ callback : Optional<AsyncCallback<T>>
+    ~ callback : AsyncCallback<T>
     ~ exception : Exception
     ~ lock : Object
     ~ state : int
@@ -40,12 +41,15 @@ package com.iluwatar.async.method.invocation {
     ~ CompletableResult<T>(callback : AsyncCallback<T>)
     + await()
     + getValue() : T
+    ~ hasCallback() : boolean
     + isCompleted() : boolean
     ~ setException(exception : Exception)
     ~ setValue(value : T)
   }
 }
+ThreadAsyncExecutor ..|> AsyncCallback
+ThreadAsyncExecutor ..|> AsyncResult
+ThreadAsyncExecutor ..|> AsyncExecutor
 CompletableResult ..+ ThreadAsyncExecutor
-ThreadAsyncExecutor ..|> AsyncExecutor 
-CompletableResult ..|> AsyncResult 
+CompletableResult ..|> AsyncResult
 @enduml

--- a/async-method-invocation/src/main/java/com/iluwatar/async/method/invocation/App.java
+++ b/async-method-invocation/src/main/java/com/iluwatar/async/method/invocation/App.java
@@ -118,11 +118,15 @@ public class App {
    * @return new async callback
    */
   private static <T> AsyncCallback<T> callback(String name) {
-    return (value, ex) -> {
-      if (ex.isPresent()) {
-        log(name + " failed: " + ex.map(Exception::getMessage).orElse(""));
-      } else {
+    return new AsyncCallback<>() {
+      @Override
+      public void onComplete(T value) {
         log(name + " <" + value + ">");
+      }
+
+      @Override
+      public void onError(Exception ex) {
+        log(name + " failed: " + ex.getMessage());
       }
     };
   }

--- a/async-method-invocation/src/main/java/com/iluwatar/async/method/invocation/AsyncCallback.java
+++ b/async-method-invocation/src/main/java/com/iluwatar/async/method/invocation/AsyncCallback.java
@@ -24,8 +24,6 @@
  */
 package com.iluwatar.async.method.invocation;
 
-import java.util.Optional;
-
 /**
  * AsyncCallback interface.
  *
@@ -34,10 +32,16 @@ import java.util.Optional;
 public interface AsyncCallback<T> {
 
   /**
-   * Complete handler which is executed when async task is completed or fails execution.
+   * Complete handler which is executed when async task is completed.
    *
-   * @param value the evaluated value from async task, undefined when execution fails
-   * @param ex    empty value if execution succeeds, some exception if executions fails
+   * @param value the evaluated value from async task
    */
-  void onComplete(T value, Optional<Exception> ex);
+  void onComplete(T value);
+
+  /**
+   * Error handler which is executed when async task fails execution.
+   *
+   * @param ex exception which was thrown during async task execution(non-null)
+   */
+  void onError(Exception ex);
 }


### PR DESCRIPTION
### What this PR does?
Eliminate Optional from fields and parameters

This commit addresses the misuse of the Optional class within our Async Method Invocation pattern. Following #2829 , we have removed Optional from being used as class fields and method parameters.

**Key Changes:**
- Class fields previously typed as Optional have been converted to nullable types, with added documentation comments to indicate potential nullability.
- Method parameters that were Optional have been refactored.Removed `Optional<Exception>` from the `onComplete` method parameter of `AsyncCallback` and added an additional `onError(Exception)` method to call when an exception occurs

**Rationale:**
- Enhances serialization compatibility by removing non-serializable Optional fields.
- Reduces code complexity and improves readability by eliminating the ambiguity of Optional fields and parameters.
- Decreases performance overhead associated with the unnecessary object creation of Optional wrappers.

Fixes #2829