### PR TITLE
#2852: MaverickWingman

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,20 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+<<<<<<< Updated upstream
+=======
+    allow:
+      - dependency-name: "org.springframework.boot:spring-boot-dependencies"
+      - dependency-name: "commons-dbcp:commons-dbcp"
+      - dependency-name: "org.htmlunit.:htmlunit"
+      - dependency-name: "com.google.code.gson:gson"
+      - dependency-name: "com.google.inject:guice"
+      - dependency-name: "com.github.stefanbirkner:system-lambda"
+      - dependency-name: "org.apache.maven.plugins:maven-surefire-plugin"
+      - dependency-name: "org.apache.maven.plugins:maven-assembly-plugin"
+      - dependency-name: "org.sonarsource.scanner.maven:sonar-maven-plugin"
+      - dependency-name: "org.apache.maven.plugins:maven-checkstyle-plugin"
+      - dependency-name: "com.mycila:license-maven-plugin"
+      - dependency-name: "org.jacoco:jacoco-maven-plugin"
+      - dependency-name: "com.iluwatar.urm:urm-maven-plugin"
+>>>>>>> Stashed changes

--- a/page-object/pom.xml
+++ b/page-object/pom.xml
@@ -33,7 +33,7 @@
   </properties>
   <dependencies>
     <dependency>
-      <groupId>net.sourceforge.htmlunit</groupId>
+      <groupId>org.htmlunit</groupId>
       <artifactId>htmlunit</artifactId>
       <scope>test</scope>
     </dependency>

--- a/page-object/src/test/java/com/iluwatar/pageobject/AlbumListPageTest.java
+++ b/page-object/src/test/java/com/iluwatar/pageobject/AlbumListPageTest.java
@@ -26,7 +26,7 @@ package com.iluwatar.pageobject;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.gargoylesoftware.htmlunit.WebClient;
+import org.htmlunit.WebClient;
 import com.iluwatar.pageobject.pages.AlbumListPage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/page-object/src/test/java/com/iluwatar/pageobject/AlbumPageTest.java
+++ b/page-object/src/test/java/com/iluwatar/pageobject/AlbumPageTest.java
@@ -26,7 +26,7 @@ package com.iluwatar.pageobject;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.gargoylesoftware.htmlunit.WebClient;
+import org.htmlunit.WebClient;
 import com.iluwatar.pageobject.pages.AlbumPage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/page-object/src/test/java/com/iluwatar/pageobject/LoginPageTest.java
+++ b/page-object/src/test/java/com/iluwatar/pageobject/LoginPageTest.java
@@ -26,7 +26,7 @@ package com.iluwatar.pageobject;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.gargoylesoftware.htmlunit.WebClient;
+import org.htmlunit.WebClient;
 import com.iluwatar.pageobject.pages.LoginPage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/page-object/src/test/java/com/iluwatar/pageobject/pages/AlbumListPage.java
+++ b/page-object/src/test/java/com/iluwatar/pageobject/pages/AlbumListPage.java
@@ -24,9 +24,9 @@
  */
 package com.iluwatar.pageobject.pages;
 
-import com.gargoylesoftware.htmlunit.WebClient;
-import com.gargoylesoftware.htmlunit.html.HtmlAnchor;
-import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import org.htmlunit.WebClient;
+import org.htmlunit.html.HtmlAnchor;
+import org.htmlunit.html.HtmlPage;
 import java.io.IOException;
 import java.util.List;
 

--- a/page-object/src/test/java/com/iluwatar/pageobject/pages/AlbumPage.java
+++ b/page-object/src/test/java/com/iluwatar/pageobject/pages/AlbumPage.java
@@ -24,13 +24,13 @@
  */
 package com.iluwatar.pageobject.pages;
 
-import com.gargoylesoftware.htmlunit.WebClient;
-import com.gargoylesoftware.htmlunit.html.HtmlNumberInput;
-import com.gargoylesoftware.htmlunit.html.HtmlOption;
-import com.gargoylesoftware.htmlunit.html.HtmlPage;
-import com.gargoylesoftware.htmlunit.html.HtmlSelect;
-import com.gargoylesoftware.htmlunit.html.HtmlSubmitInput;
-import com.gargoylesoftware.htmlunit.html.HtmlTextInput;
+import org.htmlunit.WebClient;
+import org.htmlunit.html.HtmlNumberInput;
+import org.htmlunit.html.HtmlOption;
+import org.htmlunit.html.HtmlPage;
+import org.htmlunit.html.HtmlSelect;
+import org.htmlunit.html.HtmlSubmitInput;
+import org.htmlunit.html.HtmlTextInput;
 import java.io.IOException;
 
 /**

--- a/page-object/src/test/java/com/iluwatar/pageobject/pages/LoginPage.java
+++ b/page-object/src/test/java/com/iluwatar/pageobject/pages/LoginPage.java
@@ -24,11 +24,11 @@
  */
 package com.iluwatar.pageobject.pages;
 
-import com.gargoylesoftware.htmlunit.WebClient;
-import com.gargoylesoftware.htmlunit.html.HtmlPage;
-import com.gargoylesoftware.htmlunit.html.HtmlPasswordInput;
-import com.gargoylesoftware.htmlunit.html.HtmlSubmitInput;
-import com.gargoylesoftware.htmlunit.html.HtmlTextInput;
+import org.htmlunit.WebClient;
+import org.htmlunit.html.HtmlPage;
+import org.htmlunit.html.HtmlPasswordInput;
+import org.htmlunit.html.HtmlSubmitInput;
+import org.htmlunit.html.HtmlTextInput;
 import java.io.IOException;
 
 /**

--- a/page-object/src/test/java/com/iluwatar/pageobject/pages/Page.java
+++ b/page-object/src/test/java/com/iluwatar/pageobject/pages/Page.java
@@ -24,7 +24,7 @@
  */
 package com.iluwatar.pageobject.pages;
 
-import com.gargoylesoftware.htmlunit.WebClient;
+import org.htmlunit.WebClient;
 
 /**
  * Encapsulation for a generic 'Page'

--- a/page-object/test-automation/pom.xml
+++ b/page-object/test-automation/pom.xml
@@ -40,7 +40,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>net.sourceforge.htmlunit</groupId>
+      <groupId>org.htmlunit</groupId>
       <artifactId>htmlunit</artifactId>
     </dependency>
   </dependencies>

--- a/page-object/test-automation/src/main/java/com/iluwatar/pageobject/AlbumListPage.java
+++ b/page-object/test-automation/src/main/java/com/iluwatar/pageobject/AlbumListPage.java
@@ -24,9 +24,9 @@
  */
 package com.iluwatar.pageobject;
 
-import com.gargoylesoftware.htmlunit.WebClient;
-import com.gargoylesoftware.htmlunit.html.HtmlAnchor;
-import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import org.htmlunit.WebClient;
+import org.htmlunit.html.HtmlAnchor;
+import org.htmlunit.html.HtmlPage;
 import java.io.IOException;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;

--- a/page-object/test-automation/src/main/java/com/iluwatar/pageobject/AlbumPage.java
+++ b/page-object/test-automation/src/main/java/com/iluwatar/pageobject/AlbumPage.java
@@ -24,12 +24,12 @@
  */
 package com.iluwatar.pageobject;
 
-import com.gargoylesoftware.htmlunit.WebClient;
-import com.gargoylesoftware.htmlunit.html.HtmlNumberInput;
-import com.gargoylesoftware.htmlunit.html.HtmlPage;
-import com.gargoylesoftware.htmlunit.html.HtmlSelect;
-import com.gargoylesoftware.htmlunit.html.HtmlSubmitInput;
-import com.gargoylesoftware.htmlunit.html.HtmlTextInput;
+import org.htmlunit.WebClient;
+import org.htmlunit.html.HtmlNumberInput;
+import org.htmlunit.html.HtmlPage;
+import org.htmlunit.html.HtmlSelect;
+import org.htmlunit.html.HtmlSubmitInput;
+import org.htmlunit.html.HtmlTextInput;
 import java.io.IOException;
 import lombok.extern.slf4j.Slf4j;
 

--- a/page-object/test-automation/src/main/java/com/iluwatar/pageobject/LoginPage.java
+++ b/page-object/test-automation/src/main/java/com/iluwatar/pageobject/LoginPage.java
@@ -24,11 +24,11 @@
  */
 package com.iluwatar.pageobject;
 
-import com.gargoylesoftware.htmlunit.WebClient;
-import com.gargoylesoftware.htmlunit.html.HtmlPage;
-import com.gargoylesoftware.htmlunit.html.HtmlPasswordInput;
-import com.gargoylesoftware.htmlunit.html.HtmlSubmitInput;
-import com.gargoylesoftware.htmlunit.html.HtmlTextInput;
+import org.htmlunit.WebClient;
+import org.htmlunit.html.HtmlPage;
+import org.htmlunit.html.HtmlPasswordInput;
+import org.htmlunit.html.HtmlSubmitInput;
+import org.htmlunit.html.HtmlTextInput;
 import java.io.IOException;
 import lombok.extern.slf4j.Slf4j;
 

--- a/page-object/test-automation/src/main/java/com/iluwatar/pageobject/Page.java
+++ b/page-object/test-automation/src/main/java/com/iluwatar/pageobject/Page.java
@@ -24,7 +24,7 @@
  */
 package com.iluwatar.pageobject;
 
-import com.gargoylesoftware.htmlunit.WebClient;
+import org.htmlunit.WebClient;
 
 /**
  * Encapsulation for a generic 'Page'.

--- a/page-object/test-automation/src/test/java/com/iluwatar/pageobject/AlbumListPageTest.java
+++ b/page-object/test-automation/src/test/java/com/iluwatar/pageobject/AlbumListPageTest.java
@@ -26,7 +26,7 @@ package com.iluwatar.pageobject;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.gargoylesoftware.htmlunit.WebClient;
+import org.htmlunit.WebClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/page-object/test-automation/src/test/java/com/iluwatar/pageobject/AlbumPageTest.java
+++ b/page-object/test-automation/src/test/java/com/iluwatar/pageobject/AlbumPageTest.java
@@ -26,7 +26,7 @@ package com.iluwatar.pageobject;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.gargoylesoftware.htmlunit.WebClient;
+import org.htmlunit.WebClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/page-object/test-automation/src/test/java/com/iluwatar/pageobject/LoginPageTest.java
+++ b/page-object/test-automation/src/test/java/com/iluwatar/pageobject/LoginPageTest.java
@@ -26,7 +26,7 @@ package com.iluwatar.pageobject;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.gargoylesoftware.htmlunit.WebClient;
+import org.htmlunit.WebClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/pom.xml
+++ b/pom.xml
@@ -242,7 +242,7 @@
       <dependency>
         <groupId>org.htmlunit</groupId>
         <artifactId>htmlunit</artifactId>
-        <version>3.11.0</version>
+        <version>${htmlunit.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.code.gson</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <spring-boot.version>2.7.5</spring-boot.version>
     <jacoco.version>0.8.11</jacoco.version>
     <commons-dbcp.version>1.4</commons-dbcp.version>
-    <htmlunit.version>2.70.0</htmlunit.version>
+    <htmlunit.version>3.11.0</htmlunit.version>
     <gson.version>2.10.1</gson.version>
     <guice.version>5.1.0</guice.version>
     <system-lambda.version>1.1.0</system-lambda.version>
@@ -240,9 +240,9 @@
         <version>${commons-dbcp.version}</version>
       </dependency>
       <dependency>
-        <groupId>net.sourceforge.htmlunit</groupId>
+        <groupId>org.htmlunit</groupId>
         <artifactId>htmlunit</artifactId>
-        <version>${htmlunit.version}</version>
+        <version>3.11.0</version>
       </dependency>
       <dependency>
         <groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
Pull request title

- Changed the HtmlUnit from 2.x.x to HtmlUnit 3.x.x
- Upgrade to Htmlunit 3.11.0 (Latest release February 10, 2024)


Pull request description

- 1. adjust maven group id to org.htmlunit
                    <dependency>
                        <groupId>org.htmlunit</groupId>
                        <artifactId>htmlunit</artifactId>
                        <version>3.11.0</version>
                    </dependency>


-2. Replace all usages of com.gargoylesoftware.htmlunit by org.htmlunit.

      Replace all usages of net.sourceforge.htmlunit by org.htmlunit.

a. import org.htmlunit.BrowserVersion;
b. import org.htmlunit.WebClient;
c. import org.htmlunit.html.HtmlInput;
d. import org.htmlunit.html.HtmlPage;



- Reference: https://htmlunit.sourceforge.io/



> For detailed contributing instructions see https://github.com/iluwatar/java-design-patterns/wiki/01.-How-to-contribute
