### PR TITLE
fix: Version number pattern update overwritten #2968

### DIFF
--- a/version-number/src/main/java/com/iluwatar/versionnumber/BookRepository.java
+++ b/version-number/src/main/java/com/iluwatar/versionnumber/BookRepository.java
@@ -58,7 +58,7 @@ public class BookRepository {
     }
 
     // used synchronized block to ensure only one thread compares and update the version
-    synchronized (lock){
+    synchronized (lock) {
       var latestBook = collection.get(book.getId());
       if (book.getVersion() != latestBook.getVersion()) {
         throw new VersionMismatchException(

--- a/version-number/src/main/java/com/iluwatar/versionnumber/BookRepository.java
+++ b/version-number/src/main/java/com/iluwatar/versionnumber/BookRepository.java
@@ -24,8 +24,7 @@
  */
 package com.iluwatar.versionnumber;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * This repository represents simplified database.
@@ -34,7 +33,8 @@ import java.util.Map;
  * as much as in real databases.
  */
 public class BookRepository {
-  private final Map<Long, Book> collection = new HashMap<>();
+  private final ConcurrentHashMap<Long, Book> collection = new ConcurrentHashMap<>();
+  private final Object lock = new Object();
 
   /**
    * Adds book to collection.
@@ -57,19 +57,22 @@ public class BookRepository {
       throw new BookNotFoundException("Not found book with id: " + book.getId());
     }
 
-    var latestBook = collection.get(book.getId());
-    if (book.getVersion() != latestBook.getVersion()) {
-      throw new VersionMismatchException(
-        "Tried to update stale version " + book.getVersion()
-          + " while actual version is " + latestBook.getVersion()
-      );
+    // used synchronized block to ensure only one thread compares and update the version
+    synchronized (lock){
+      var latestBook = collection.get(book.getId());
+      if (book.getVersion() != latestBook.getVersion()) {
+        throw new VersionMismatchException(
+            "Tried to update stale version " + book.getVersion()
+                + " while actual version is " + latestBook.getVersion()
+        );
+      }
+
+      // update version, including client representation - modify by reference here
+      book.setVersion(book.getVersion() + 1);
+
+      // save book copy to repository
+      collection.put(book.getId(), new Book(book));
     }
-
-    // update version, including client representation - modify by reference here
-    book.setVersion(book.getVersion() + 1);
-
-    // save book copy to repository
-    collection.put(book.getId(), new Book(book));
   }
 
   /**


### PR DESCRIPTION
## What problem does this PR solve?

Currently the version number pattern is not thread safe in case multiple updates are done at the same time. To resolve this I have used ConcurrentHashMap and written the critical code inside the synchronized block with a lock to avoid dirty read and  overwriting.
