### PR TITLE
fix: Refactored Visitor #2975 

### DIFF
--- a/visitor/src/test/java/com/iluwatar/visitor/CommanderVisitorTest.java
+++ b/visitor/src/test/java/com/iluwatar/visitor/CommanderVisitorTest.java
@@ -38,9 +38,9 @@ class CommanderVisitorTest extends VisitorTest<CommanderVisitor> {
   public CommanderVisitorTest() {
     super(
         new CommanderVisitor(),
-        Optional.of("Good to see you commander"),
-        Optional.empty(),
-        Optional.empty()
+        ("Good to see you commander"),
+        null,
+         null
     );
   }
 

--- a/visitor/src/test/java/com/iluwatar/visitor/SergeantVisitorTest.java
+++ b/visitor/src/test/java/com/iluwatar/visitor/SergeantVisitorTest.java
@@ -38,9 +38,9 @@ class SergeantVisitorTest extends VisitorTest<SergeantVisitor> {
   public SergeantVisitorTest() {
     super(
         new SergeantVisitor(),
-        Optional.empty(),
-        Optional.of("Hello sergeant"),
-        Optional.empty()
+        null,
+        ("Hello sergeant"),
+        null
     );
   }
 

--- a/visitor/src/test/java/com/iluwatar/visitor/SoldierVisitorTest.java
+++ b/visitor/src/test/java/com/iluwatar/visitor/SoldierVisitorTest.java
@@ -38,9 +38,9 @@ class SoldierVisitorTest extends VisitorTest<SoldierVisitor> {
   public SoldierVisitorTest() {
     super(
         new SoldierVisitor(),
-        Optional.empty(),
-        Optional.empty(),
-        Optional.of("Greetings soldier")
+        null,
+        null,
+        ("Greetings soldier")
     );
   }
 

--- a/visitor/src/test/java/com/iluwatar/visitor/VisitorTest.java
+++ b/visitor/src/test/java/com/iluwatar/visitor/VisitorTest.java
@@ -31,7 +31,6 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.AppenderBase;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -62,32 +61,32 @@ public abstract class VisitorTest<V extends UnitVisitor> {
   private final V visitor;
 
   /**
-   * The optional expected response when being visited by a commander.
+   * The expected response when being visited by a commander.
    */
-  private final Optional<String> commanderResponse;
+  private final String commanderResponse;
 
   /**
-   * The optional expected response when being visited by a sergeant.
+   * The expected response when being visited by a sergeant.
    */
-  private final Optional<String> sergeantResponse;
+  private final String sergeantResponse;
 
   /**
-   * The optional expected response when being visited by a soldier.
+   * The expected response when being visited by a soldier.
    */
-  private final Optional<String> soldierResponse;
+  private final String soldierResponse;
 
   /**
    * Create a new test instance for the given visitor.
    *
-   * @param commanderResponse The optional expected response when being visited by a commander
-   * @param sergeantResponse  The optional expected response when being visited by a sergeant
-   * @param soldierResponse   The optional expected response when being visited by a soldier
+   * @param commanderResponse The expected response when being visited by a commander
+   * @param sergeantResponse  The expected response when being visited by a sergeant
+   * @param soldierResponse   The expected response when being visited by a soldier
    */
   public VisitorTest(
       final V visitor,
-      final Optional<String> commanderResponse,
-      final Optional<String> sergeantResponse,
-      final Optional<String> soldierResponse
+      final String commanderResponse,
+      final String sergeantResponse,
+      final String soldierResponse
   ) {
     this.visitor = visitor;
     this.commanderResponse = commanderResponse;
@@ -98,8 +97,8 @@ public abstract class VisitorTest<V extends UnitVisitor> {
   @Test
   void testVisitCommander() {
     this.visitor.visit(new Commander());
-    if (this.commanderResponse.isPresent()) {
-      assertEquals(this.commanderResponse.get(), appender.getLastMessage());
+    if (this.commanderResponse != null) {
+      assertEquals(this.commanderResponse, appender.getLastMessage());
       assertEquals(1, appender.getLogSize());
     }
   }
@@ -107,8 +106,8 @@ public abstract class VisitorTest<V extends UnitVisitor> {
   @Test
   void testVisitSergeant() {
     this.visitor.visit(new Sergeant());
-    if (this.sergeantResponse.isPresent()) {
-      assertEquals(this.sergeantResponse.get(), appender.getLastMessage());
+    if (this.sergeantResponse != null) {
+      assertEquals(this.sergeantResponse, appender.getLastMessage());
       assertEquals(1, appender.getLogSize());
     }
   }
@@ -116,8 +115,8 @@ public abstract class VisitorTest<V extends UnitVisitor> {
   @Test
   void testVisitSoldier() {
     this.visitor.visit(new Soldier());
-    if (this.soldierResponse.isPresent()) {
-      assertEquals(this.soldierResponse.get(), appender.getLastMessage());
+    if (this.soldierResponse != null) {
+      assertEquals(this.soldierResponse, appender.getLastMessage());
       assertEquals(1, appender.getLogSize());
     }
   }


### PR DESCRIPTION
<!--
Thank you for contributing to Java Design Patterns!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/iluwatar/java-design-patterns/wiki/01.-How-to-contribute

If you still have questions, please let us know via issues or [gitter](https://matrix.to/#/#iluwatar_java-design-patterns:gitter.im).
-->

## What problem does this PR solve?

This PR refactors the VisitorTest class to address code smells related to the misuse of Optional<String> for class fields and constructor parameters. Optional is intended for method return types to indicate "no result," and not for class fields or parameters.

Close #2975
