### PR TITLE
Fix Video.toString() output illegal json and refactor

### DIFF
--- a/partial-response/src/main/java/com/iluwatar/partialresponse/FieldJsonMapper.java
+++ b/partial-response/src/main/java/com/iluwatar/partialresponse/FieldJsonMapper.java
@@ -25,6 +25,7 @@
 package com.iluwatar.partialresponse;
 
 import java.lang.reflect.Field;
+import java.util.StringJoiner;
 
 /**
  * Map a video to json.
@@ -39,18 +40,15 @@ public class FieldJsonMapper {
    * @return json of required fields from video
    */
   public String toJson(Video video, String[] fields) throws Exception {
-    var json = new StringBuilder().append("{");
+    var json = new StringJoiner(",", "{", "}");
 
     var i = 0;
     var fieldsLength = fields.length;
     while (i < fieldsLength) {
-      json.append(getString(video, Video.class.getDeclaredField(fields[i])));
-      if (i != fieldsLength - 1) {
-        json.append(",");
-      }
+      json.add(getString(video, Video.class.getDeclaredField(fields[i])));
       i++;
     }
-    json.append("}");
+
     return json.toString();
   }
 

--- a/partial-response/src/main/java/com/iluwatar/partialresponse/Video.java
+++ b/partial-response/src/main/java/com/iluwatar/partialresponse/Video.java
@@ -43,7 +43,7 @@ public record Video(Integer id, String title, Integer length, String description
             + "\"length\": " + length + ","
             + "\"description\": \"" + description + "\","
             + "\"director\": \"" + director + "\","
-            + "\"language\": \"" + language + "\","
+            + "\"language\": \"" + language + "\""
             + "}";
   }
 }

--- a/partial-response/src/test/java/com/iluwatar/partialresponse/VideoResourceTest.java
+++ b/partial-response/src/test/java/com/iluwatar/partialresponse/VideoResourceTest.java
@@ -63,7 +63,7 @@ class VideoResourceTest {
     var actualDetails = resource.getDetails(1);
 
     var expectedDetails = "{\"id\": 1,\"title\": \"Avatar\",\"length\": 178,\"description\": "
-        + "\"epic science fiction film\",\"director\": \"James Cameron\",\"language\": \"English\",}";
+        + "\"epic science fiction film\",\"director\": \"James Cameron\",\"language\": \"English\"}";
     Assertions.assertEquals(expectedDetails, actualDetails);
   }
 
@@ -75,6 +75,19 @@ class VideoResourceTest {
     Mockito.when(fieldJsonMapper.toJson(any(Video.class), eq(fields))).thenReturn(expectedDetails);
 
     var actualFieldsDetails = resource.getDetails(2, fields);
+
+    Assertions.assertEquals(expectedDetails, actualFieldsDetails);
+  }
+
+  @Test
+  void shouldAllSpecifiedFieldsInformationOfVideo() throws Exception {
+    var fields = new String[]{"id", "title", "length", "description", "director", "language"};
+
+    var expectedDetails = "{\"id\": 1,\"title\": \"Avatar\",\"length\": 178,\"description\": "
+        + "\"epic science fiction film\",\"director\": \"James Cameron\",\"language\": \"English\"}";
+    Mockito.when(fieldJsonMapper.toJson(any(Video.class), eq(fields))).thenReturn(expectedDetails);
+
+    var actualFieldsDetails = resource.getDetails(1, fields);
 
     Assertions.assertEquals(expectedDetails, actualFieldsDetails);
   }


### PR DESCRIPTION
## What problem does this PR solve?

1. Fixes the issue where Video.toString() outputs an illegal JSON string. All samples should output valid JSON, but in the example below, line 3 is incorrect:
```
17:11:13.976 [main] INFO com.iluwatar.partialresponse.App -- Retrieving full response from server:-
17:11:13.985 [main] INFO com.iluwatar.partialresponse.App -- Get all video information:
17:11:14.014 [main] INFO com.iluwatar.partialresponse.App -- {"id": 1,"title": "Avatar","length": 178,"description": "epic science fiction film","director": "James Cameron","language": "English",}
17:11:14.015 [main] INFO com.iluwatar.partialresponse.App -- ----------------------------------------------------------
17:11:14.015 [main] INFO com.iluwatar.partialresponse.App -- Retrieving partial response from server:-
17:11:14.015 [main] INFO com.iluwatar.partialresponse.App -- Get video @id, @title, @director:
17:11:14.022 [main] INFO com.iluwatar.partialresponse.App -- {"id": 3,"title": "Interstellar","director": "Christopher Nolan"}
17:11:14.023 [main] INFO com.iluwatar.partialresponse.App -- Get video @id, @length:
17:11:14.023 [main] INFO com.iluwatar.partialresponse.App -- {"id": 3,"length": 169}
```

2. Refactors FieldJsonMapper.toJson for better readability (possibly).