### PR TITLE
chore: bump github actions to v4

### DIFF
--- a/.github/workflows/maven-ci.yml
+++ b/.github/workflows/maven-ci.yml
@@ -42,20 +42,20 @@ jobs:
     steps:
 
     - name: Checkout Code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         # Disabling shallow clone for improving relevancy of SonarQube reporting
         fetch-depth: 0
 
     - name: Set up JDK 17
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: '17'
         distribution: 'temurin'
         cache: 'maven'
 
     - name: Cache local Maven repository
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -64,7 +64,7 @@ jobs:
 
     # Cache Sonar packages which as used to run analysis and collect metrics
     - name: Cache SonarCloud packages
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.sonar/cache
         key: ${{ runner.os }}-sonar

--- a/.github/workflows/maven-pr-builder.yml
+++ b/.github/workflows/maven-pr-builder.yml
@@ -42,19 +42,19 @@ jobs:
     steps:
     
     - name: Checkout Code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
     
     - name: Set up JDK 17
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: '17'
         distribution: 'temurin'
         cache: 'maven'
 
     - name: Cache local Maven repository
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -63,7 +63,7 @@ jobs:
 
     # Cache Sonar packages which as used to run analysis and collect metrics
     - name: Cache SonarCloud packages
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.sonar/cache
         key: ${{ runner.os }}-sonar


### PR DESCRIPTION
## What problem does this PR solve?

Required for using Node.js 20.x in CI
* Changelog for actions/checkout@v4 https://github.com/actions/checkout/blob/main/CHANGELOG.md?rgh-link-date=2024-09-04T18%3A38%3A10Z#v400
* Changelog for actions/setup-java@v4 https://github.com/actions/setup-java/releases/tag/v4.0.0
* Changelog for actions/cache@v4 https://github.com/actions/cache/releases/tag/v4.0.0

GitHub Blog post: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/