### PR TITLE
add shortTitle column to readme for zh

### DIFF
--- a/localization/zh/abstract-document/README.md
+++ b/localization/zh/abstract-document/README.md
@@ -1,5 +1,6 @@
 ---
 title: Abstract Document
+shortTitle: Abstract Document
 category: Structural
 language: zh
 tag: 

--- a/localization/zh/abstract-factory/README.md
+++ b/localization/zh/abstract-factory/README.md
@@ -1,5 +1,6 @@
 ---
 title: Abstract Factory
+shortTitle: Abstract Factory
 category: Creational
 language: zh
 tag:

--- a/localization/zh/active-object/README.md
+++ b/localization/zh/active-object/README.md
@@ -1,5 +1,6 @@
 ---
 title: Active Object
+shortTitle: Active Object
 category: Concurrency
 language: zh
 tag:

--- a/localization/zh/acyclic-visitor/README.md
+++ b/localization/zh/acyclic-visitor/README.md
@@ -1,5 +1,6 @@
 ---
 title: Acyclic Visitor
+shortTitle: Acyclic Visitor
 category: Behavioral
 language: zh
 tag:

--- a/localization/zh/adapter/README.md
+++ b/localization/zh/adapter/README.md
@@ -1,5 +1,6 @@
 ---
 title: Adapter
+shortTitle: Adapter
 category: Structural
 language: zh
 tag:

--- a/localization/zh/aggregator-microservices/README.md
+++ b/localization/zh/aggregator-microservices/README.md
@@ -1,5 +1,6 @@
 ---
 title: Aggregator Microservices
+shortTitle: Aggregator Microservices
 category: Architectural
 language: zh
 tag:

--- a/localization/zh/ambassador/README.md
+++ b/localization/zh/ambassador/README.md
@@ -1,5 +1,6 @@
 ---
 title: Ambassador
+shortTitle: Ambassador
 category: Structural
 language: zh
 tag:

--- a/localization/zh/api-gateway/README.md
+++ b/localization/zh/api-gateway/README.md
@@ -1,5 +1,6 @@
 ---
 title: API Gateway
+shortTitle: API Gateway
 category: Architectural
 language: zh
 tag:

--- a/localization/zh/arrange-act-assert/README.md
+++ b/localization/zh/arrange-act-assert/README.md
@@ -1,5 +1,6 @@
 ---
 title: Arrange/Act/Assert
+shortTitle: Arrange/Act/Assert
 category: Idiom
 language: zh
 tag:

--- a/localization/zh/async-method-invocation/README.md
+++ b/localization/zh/async-method-invocation/README.md
@@ -1,5 +1,6 @@
 ---
 title: Async Method Invocation
+shortTitle: Async Method Invocation
 category: Concurrency
 language: zh
 tag:

--- a/localization/zh/balking/README.md
+++ b/localization/zh/balking/README.md
@@ -1,5 +1,6 @@
 ---
 title: Balking
+shortTitle: Balking
 category: Concurrency
 language: zh
 tag:

--- a/localization/zh/bridge/README.md
+++ b/localization/zh/bridge/README.md
@@ -1,5 +1,6 @@
 ---
 title: Bridge
+shortTitle: Bridge
 category: Structural
 language: zh
 tag:

--- a/localization/zh/builder/README.md
+++ b/localization/zh/builder/README.md
@@ -1,5 +1,6 @@
 ---
 title: Builder
+shortTitle: Builder
 category: Creational
 language: zh
 tag:

--- a/localization/zh/business-delegate/README.md
+++ b/localization/zh/business-delegate/README.md
@@ -1,5 +1,6 @@
 ---
 title: Business Delegate
+shortTitle: Business Delegate
 category: Structural
 language: zh
 tag:

--- a/localization/zh/bytecode/README.md
+++ b/localization/zh/bytecode/README.md
@@ -1,5 +1,6 @@
 ---
 title: Bytecode
+shortTitle: Bytecode
 category: Behavioral
 language: zh
 tag:

--- a/localization/zh/caching/README.md
+++ b/localization/zh/caching/README.md
@@ -1,5 +1,6 @@
 ---
 title: Caching
+shortTitle: Caching
 category: Behavioral
 language: zh
 tag:

--- a/localization/zh/callback/README.md
+++ b/localization/zh/callback/README.md
@@ -1,5 +1,6 @@
 ---
 title: Callback
+shortTitle: Callback
 category: Idiom
 language: zh
 tag:

--- a/localization/zh/chain/README.md
+++ b/localization/zh/chain/README.md
@@ -1,5 +1,6 @@
 ---
 title: Chain of responsibility
+shortTitle: Chain of responsibility
 category: Behavioral
 language: zh
 tag:

--- a/localization/zh/circuit-breaker/README.md
+++ b/localization/zh/circuit-breaker/README.md
@@ -1,5 +1,6 @@
 ---
 title: Circuit Breaker
+shortTitle: Circuit Breaker
 category: Behavioral
 language: zh
 tag:

--- a/localization/zh/cloud-static-content-hosting/README.md
+++ b/localization/zh/cloud-static-content-hosting/README.md
@@ -1,5 +1,6 @@
 ---
 title: Static Content Hosting
+shortTitle: Static Content Hosting
 category: Cloud
 language: zh
 tag:

--- a/localization/zh/collection-pipeline/README.md
+++ b/localization/zh/collection-pipeline/README.md
@@ -1,5 +1,6 @@
 ---
 title: Collection Pipeline
+shortTitle: Collection Pipeline
 category: Functional
 language: zh
 tag:

--- a/localization/zh/combinator/README.md
+++ b/localization/zh/combinator/README.md
@@ -1,5 +1,6 @@
 ---
 title: Combinator
+shortTitle: Combinator
 category: Idiom
 language: zh
 tag:

--- a/localization/zh/command/README.md
+++ b/localization/zh/command/README.md
@@ -1,5 +1,6 @@
 ---
 title: Command
+shortTitle: Command
 category: Behavioral
 language: zh
 tag:

--- a/localization/zh/commander/README.md
+++ b/localization/zh/commander/README.md
@@ -1,5 +1,6 @@
 ---
 title: Commander
+shortTitle: Commander
 category: Concurrency
 language: zh
 tag:

--- a/localization/zh/composite-entity/README.md
+++ b/localization/zh/composite-entity/README.md
@@ -1,5 +1,6 @@
 ---
 title: Composite Entity
+shortTitle: Composite Entity
 category: Structural
 language: zh
 tag:

--- a/localization/zh/composite/README.md
+++ b/localization/zh/composite/README.md
@@ -1,5 +1,6 @@
 ---
 title: Composite
+shortTitle: Composite
 category: Structural
 language: zh
 tag:

--- a/localization/zh/converter/README.md
+++ b/localization/zh/converter/README.md
@@ -1,5 +1,6 @@
 ---
 title: Converter
+shortTitle: Converter
 category: Creational
 language: zh
 tag:

--- a/localization/zh/crtp/README.md
+++ b/localization/zh/crtp/README.md
@@ -1,5 +1,6 @@
 ---
 title: Curiously Recurring Template Pattern
+shortTitle: Curiously Recurring Template Pattern
 language: zh
 category: Structural
 tag:

--- a/localization/zh/dao/README.md
+++ b/localization/zh/dao/README.md
@@ -1,5 +1,6 @@
 ---
 title: Data Access Object
+shortTitle: Data Access Object
 category: Architectural
 language: zh
 tag:

--- a/localization/zh/data-bus/README.md
+++ b/localization/zh/data-bus/README.md
@@ -1,5 +1,6 @@
 ---
 title: Data Bus
+shortTitle: Data Bus
 category: Architectural
 language: zh
 tag:

--- a/localization/zh/data-mapper/README.md
+++ b/localization/zh/data-mapper/README.md
@@ -1,5 +1,6 @@
 ---
 title: Data Mapper
+shortTitle: Data Mapper
 category: Architectural
 language: zh
 tag:

--- a/localization/zh/data-transfer-object/README.md
+++ b/localization/zh/data-transfer-object/README.md
@@ -1,5 +1,6 @@
 ---
 title: Data Transfer Object
+shortTitle: Data Transfer Object
 category: Architectural
 language: zh
 tag:

--- a/localization/zh/decorator/README.md
+++ b/localization/zh/decorator/README.md
@@ -1,5 +1,6 @@
 ---
 title: Decorator
+shortTitle: Decorator
 category: Structural
 language: zh
 tag:

--- a/localization/zh/delegation/README.md
+++ b/localization/zh/delegation/README.md
@@ -1,5 +1,6 @@
 ---
 title: Delegation
+shortTitle: Delegation
 category: Structural
 language: zh
 tag:

--- a/localization/zh/dependency-injection/README.md
+++ b/localization/zh/dependency-injection/README.md
@@ -1,5 +1,6 @@
 ---
 title: Dependency Injection
+shortTitle: Dependency Injection
 category: Creational
 language: zh
 tag:

--- a/localization/zh/dirty-flag/README.md
+++ b/localization/zh/dirty-flag/README.md
@@ -1,5 +1,6 @@
 ---
 title: Dirty Flag
+shortTitle: Dirty Flag
 category: Behavioral
 language: zh
 tag:

--- a/localization/zh/double-checked-locking/README.md
+++ b/localization/zh/double-checked-locking/README.md
@@ -1,5 +1,6 @@
 ---
 title: Double Checked Locking
+shortTitle: Double Checked Locking
 category: Idiom
 language: zh
 tag:

--- a/localization/zh/facade/README.md
+++ b/localization/zh/facade/README.md
@@ -1,5 +1,6 @@
 ---
 title: Facade
+shortTitle: Facade
 category: Structural
 language: zh
 tag:

--- a/localization/zh/factory-kit/README.md
+++ b/localization/zh/factory-kit/README.md
@@ -1,5 +1,6 @@
 ---
 title: Factory Kit
+shortTitle: Factory Kit
 category: Creational
 language: zh
 tag:

--- a/localization/zh/factory-method/README.md
+++ b/localization/zh/factory-method/README.md
@@ -1,5 +1,6 @@
 ---
 title: Factory Method
+shortTitle: Factory Method
 category: Creational
 language: zh
 tag:

--- a/localization/zh/factory/README.md
+++ b/localization/zh/factory/README.md
@@ -1,5 +1,6 @@
 ---
 title: Factory
+shortTitle: Factory
 category: Creational
 language: zh
 tag:

--- a/localization/zh/interpreter/README.md
+++ b/localization/zh/interpreter/README.md
@@ -1,5 +1,6 @@
 ---
 title: Interpreter
+shortTitle: Interpreter
 category: Behavioral
 language: zh
 tag:

--- a/localization/zh/iterator/README.md
+++ b/localization/zh/iterator/README.md
@@ -1,5 +1,6 @@
 ---
 title: Iterator
+shortTitle: Iterator
 category: Behavioral
 language: zh
 tag:

--- a/localization/zh/monitor/README.md
+++ b/localization/zh/monitor/README.md
@@ -1,5 +1,6 @@
 ---
 title: Monitor
+shortTitle: Monitor
 category: Concurrency
 language: zh
 tag:

--- a/localization/zh/observer/README.md
+++ b/localization/zh/observer/README.md
@@ -1,5 +1,6 @@
 ---
 title: Observer
+shortTitle: Observer
 category: Behavioral
 language: zh
 tag:

--- a/localization/zh/private-class-data/README.md
+++ b/localization/zh/private-class-data/README.md
@@ -1,5 +1,6 @@
 ---
 title: Private Class Data
+shortTitle: Private Class Data
 category: Idiom
 language: zh
 tag:

--- a/localization/zh/producer-consumer/README.md
+++ b/localization/zh/producer-consumer/README.md
@@ -1,5 +1,6 @@
 ---
 title: Producer Consumer
+shortTitle: Producer Consumer
 category: Concurrency
 language: zh
 tag:

--- a/localization/zh/proxy/README.md
+++ b/localization/zh/proxy/README.md
@@ -1,5 +1,6 @@
 ---
 title: Proxy
+shortTitle: Proxy
 category: Structural
 language: zh
 tag:

--- a/localization/zh/servant/README.md
+++ b/localization/zh/servant/README.md
@@ -1,5 +1,6 @@
 ---
 title: Servant
+shortTitle: Servant
 category: Behavioral
 language: zh
 tag:

--- a/localization/zh/sharding/README.md
+++ b/localization/zh/sharding/README.md
@@ -1,5 +1,6 @@
 ---
-title: Sharding 
+title: Sharding
+shortTitle: Sharding
 category: Behavioral
 language: zh
 tag:  

--- a/localization/zh/singleton/README.md
+++ b/localization/zh/singleton/README.md
@@ -1,5 +1,6 @@
 ---
 title: Singleton
+shortTitle: Singleton
 category: Creational
 language: zh
 tag:

--- a/localization/zh/state/README.md
+++ b/localization/zh/state/README.md
@@ -1,5 +1,6 @@
 ---
 title: State
+shortTitle: State
 category: Behavioral
 language: zh
 tag:

--- a/localization/zh/step-builder/README.md
+++ b/localization/zh/step-builder/README.md
@@ -1,5 +1,6 @@
 ---
 title: Step Builder
+shortTitle: Step Builder
 category: Creational
 language: zn
 tag:

--- a/localization/zh/strategy/README.md
+++ b/localization/zh/strategy/README.md
@@ -1,5 +1,6 @@
 ---
 title: Strategy
+shortTitle: Strategy
 category: Behavioral
 language: zh
 tag:

--- a/localization/zh/table-module/README.md
+++ b/localization/zh/table-module/README.md
@@ -1,5 +1,6 @@
 ---
 title: Table Module
+shortTitle: Table Module
 category: Structural
 language: zh
 tag:

--- a/localization/zh/template-method/README.md
+++ b/localization/zh/template-method/README.md
@@ -1,5 +1,6 @@
 ---
 title: Template method
+shortTitle: Template method
 category: Behavioral
 language: zh
 tag:

--- a/localization/zh/trampoline/README.md
+++ b/localization/zh/trampoline/README.md
@@ -1,5 +1,6 @@
 ---
 title: Trampoline
+shortTitle: Trampoline
 category: Behavioral
 language: zh
 tag:

--- a/localization/zh/unit-of-work/README.md
+++ b/localization/zh/unit-of-work/README.md
@@ -1,5 +1,6 @@
 ---
 title: Unit Of Work
+shortTitle: Unit Of Work
 category: Architectural
 language: zn
 tag:

--- a/localization/zh/update-method/README.md
+++ b/localization/zh/update-method/README.md
@@ -1,5 +1,6 @@
 ---  
 title: Update Method
+shortTitle: Update Method
 category: Behavioral
 language: zn
 tag:  

--- a/localization/zh/value-object/README.md
+++ b/localization/zh/value-object/README.md
@@ -1,5 +1,6 @@
 ---
 title: Value Object
+shortTitle: Value Object
 category: Creational
 language: zn
 tag:

--- a/localization/zh/version-number/README.md
+++ b/localization/zh/version-number/README.md
@@ -1,5 +1,6 @@
 ---
 title: Version Number
+shortTitle: Version Number
 category: Concurrency
 language: zh
 tag:

--- a/localization/zh/visitor/README.md
+++ b/localization/zh/visitor/README.md
@@ -1,5 +1,6 @@
 ---
 title: Visitor
+shortTitle: Visitor
 category: Behavioral
 language: zh
 tag:


### PR DESCRIPTION
<!--
Thank you for contributing to Java Design Patterns!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/iluwatar/java-design-patterns/wiki/01.-How-to-contribute

If you still have questions, please let us know via issues or [gitter](https://matrix.to/#/#iluwatar_java-design-patterns:gitter.im).
-->

## What problem does this PR solve?

<!-- Please describe the problem you're trying to solve. Uncomment the following line if this PR closes some issues -->
<!-- Close #<issue number> -->
this pr [build: pattern index page uses shortTitle
](https://github.com/iluwatar/java-design-patterns-vuepress-web/commit/67769cbd2e685ae19e0c36e81e237bf6bb1be1da) prevents the site from displaying properly in languages other than English. like this [zh/patterns](https://java-design-patterns.com/zh/patterns/)