### PR TITLE
Include project version in final name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -317,9 +317,8 @@
                 <descriptorRefs>
                   <descriptorRef>jar-with-dependencies</descriptorRef>
                 </descriptorRefs>
-                <!-- below two line make sure the fat jar is sharing the same name
-                                    as of project name -->
-                <finalName>${project.artifactId}</finalName>
+                <!-- below two line make sure the fat jar is sharing the same name as of project name -->
+                <finalName>${project.artifactId}-${project.version}</finalName>
                 <appendAssemblyId>false</appendAssemblyId>
               </configuration>
             </execution>


### PR DESCRIPTION
## What problem does this PR solve?

This PR configures the Maven assembly plugin to build a single fat JAR for each subproject. Each fat JAR follows the naming scheme `${pattern}-${version}-SNAPSHOT.jar`. 
After the Maven Assembly Plugin has been executed, the resulting artifact can be executed as follows:

```bash
$ mvn clean package -DskipTests=true
...
$ cd proxy/target
$ ls -al
drwxr-xr-x  14 patrick  staff     448 Oct  8 00:12 .
drwxr-xr-x   7 patrick  staff     224 Oct  8 00:12 ..
drwxr-xr-x   3 patrick  staff      96 Oct  8 00:12 archive-tmp
-rw-r--r--   1 patrick  staff     846 Oct  8 00:12 checkstyle-cachefile
-rw-r--r--   1 patrick  staff   17646 Oct  8 00:12 checkstyle-checker.xml
-rw-r--r--   1 patrick  staff     696 Oct  8 00:12 checkstyle-result.xml
-rw-r--r--   1 patrick  staff     699 Oct  8 00:12 checkstyle-suppressions.xml
drwxr-xr-x   3 patrick  staff      96 Oct  8 00:12 classes
drwxr-xr-x   3 patrick  staff      96 Oct  8 00:12 generated-sources
drwxr-xr-x   3 patrick  staff      96 Oct  8 00:12 generated-test-sources
drwxr-xr-x   3 patrick  staff      96 Oct  8 00:12 maven-archiver
drwxr-xr-x   3 patrick  staff      96 Oct  8 00:12 maven-status
-rw-r--r--   1 patrick  staff  958950 Oct  8 00:12 proxy-1.26.0-SNAPSHOT.jar
drwxr-xr-x   3 patrick  staff      96 Oct  8 00:12 test-classes
$ java -jar proxy-1.26.0-SNAPSHOT.jar
20:55:56.257 [main] INFO com.iluwatar.proxy.IvoryTower -- Red wizard enters the tower.
20:55:56.260 [main] INFO com.iluwatar.proxy.IvoryTower -- White wizard enters the tower.
20:55:56.260 [main] INFO com.iluwatar.proxy.IvoryTower -- Black wizard enters the tower.
20:55:56.260 [main] INFO com.iluwatar.proxy.WizardTowerProxy -- Green wizard is not allowed to enter!
20:55:56.260 [main] INFO com.iluwatar.proxy.WizardTowerProxy -- Brown wizard is not allowed to enter!

```

Close #2565 
