### PR TITLE
Fixed busy waiting in point #2

### DIFF
--- a/twin/src/main/java/com/iluwatar/twin/BallThread.java
+++ b/twin/src/main/java/com/iluwatar/twin/BallThread.java
@@ -24,39 +24,45 @@
  */
 package com.iluwatar.twin;
 
-import lombok.Setter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * This class is a UI thread for drawing the {@link BallItem}, and provide the method for suspend
+ * This class is a UI thread for drawing the {@link BallItem}, and provides methods for suspend
  * and resume. It holds the reference of {@link BallItem} to delegate the draw task.
  */
 
 @Slf4j
 public class BallThread extends Thread {
 
-  @Setter
-  private BallItem twin;
-
-  private volatile boolean isSuspended;
+  private static final Logger LOGGER = LoggerFactory.getLogger(BallThread.class);
 
   private volatile boolean isRunning = true;
+  private volatile boolean isSuspended = false;
+  private final Object lock = new Object();
+  private final BallItem twin;
 
-  /**
-   * Run the thread.
-   */
+  public BallThread(BallItem twin) {
+    this.twin = twin;
+  }
+
+  @Override
   public void run() {
-
-    while (isRunning) {
-      if (!isSuspended) {
-        twin.draw();
+    try {
+      while (isRunning) {
+        synchronized (lock) {
+          while (isSuspended) {
+            lock.wait();
+          }
+        }
+        twin.doDraw();
         twin.move();
-      }
-      try {
         Thread.sleep(250);
-      } catch (InterruptedException e) {
-        throw new RuntimeException(e);
       }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException(e);
     }
   }
 
@@ -66,13 +72,15 @@ public class BallThread extends Thread {
   }
 
   public void resumeMe() {
-    isSuspended = false;
+    synchronized (lock) {
+      isSuspended = false;
+      lock.notifyAll();
+    }
     LOGGER.info("Begin to resume BallThread");
   }
 
   public void stopMe() {
-    this.isRunning = false;
-    this.isSuspended = true;
+    isRunning = false;
+    resumeMe(); // Ensure the thread exits if it is waiting
   }
 }
-


### PR DESCRIPTION
the run() method now efficiently waits when suspendMe() is called and resumes execution when resumeMe() is invoked. This prevents unnecessary overhead by avoiding constant checks for the suspension state while the thread is running. Instead, the thread only proceeds with drawing and movement tasks when it's explicitly resumed, optimizing performance and resource usage.