### PR TITLE
Fixed busy waiting in point 2

### DIFF
--- a/twin/src/main/java/com/iluwatar/twin/BallThread.java
+++ b/twin/src/main/java/com/iluwatar/twin/BallThread.java
@@ -24,39 +24,45 @@
  */
 package com.iluwatar.twin;
 
-import lombok.Setter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * This class is a UI thread for drawing the {@link BallItem}, and provide the method for suspend
+ * This class is a UI thread for drawing the {@link BallItem}, and provides methods for suspend
  * and resume. It holds the reference of {@link BallItem} to delegate the draw task.
  */
 
 @Slf4j
 public class BallThread extends Thread {
 
-  @Setter
-  private BallItem twin;
-
-  private volatile boolean isSuspended;
+  private static final Logger LOGGER = LoggerFactory.getLogger(BallThread.class);
 
   private volatile boolean isRunning = true;
+  private volatile boolean isSuspended = false;
+  private final Object lock = new Object();
+  private final BallItem twin;
 
-  /**
-   * Run the thread.
-   */
+  public BallThread(BallItem twin) {
+    this.twin = twin;
+  }
+
+  @Override
   public void run() {
-
-    while (isRunning) {
-      if (!isSuspended) {
-        twin.draw();
+    try {
+      while (isRunning) {
+        synchronized (lock) {
+          while (isSuspended) {
+            lock.wait();
+          }
+        }
+        twin.doDraw();
         twin.move();
-      }
-      try {
         Thread.sleep(250);
-      } catch (InterruptedException e) {
-        throw new RuntimeException(e);
       }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException(e);
     }
   }
 
@@ -66,13 +72,15 @@ public class BallThread extends Thread {
   }
 
   public void resumeMe() {
-    isSuspended = false;
+    synchronized (lock) {
+      isSuspended = false;
+      lock.notifyAll();
+    }
     LOGGER.info("Begin to resume BallThread");
   }
 
   public void stopMe() {
-    this.isRunning = false;
-    this.isSuspended = true;
+    isRunning = false;
+    resumeMe(); // Ensure the thread exits if it is waiting
   }
 }
-

--- a/twin/src/main/java/com/iluwatar/twin/BallThread.java
+++ b/twin/src/main/java/com/iluwatar/twin/BallThread.java
@@ -6,7 +6,7 @@
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
+ * in the Software without restriction, including but not limited to the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:

--- a/twin/src/main/java/com/iluwatar/twin/BallThread.java
+++ b/twin/src/main/java/com/iluwatar/twin/BallThread.java
@@ -6,7 +6,7 @@
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including but not limited to the rights
+ * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
@@ -55,15 +55,14 @@ public class BallThread extends Thread {
   public void run() {
     try {
       while (isRunning) {
-        if (isSuspended) {
-          synchronized (lock) {
+        synchronized (lock) {
+          while (isSuspended) {
             lock.wait();
           }
-        } else {
-          twin.doDraw();
-          twin.move();
-          Thread.sleep(250);
         }
+        twin.doDraw();
+        twin.move();
+        Thread.sleep(250);
       }
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
@@ -83,21 +82,18 @@ public class BallThread extends Thread {
    * Notify run to resume.
    */
   public void resumeMe() {
-    isSuspended = false;
-    LOGGER.info("Begin to resume BallThread");
     synchronized (lock) {
+      isSuspended = false;
       lock.notifyAll();
     }
+    LOGGER.info("Begin to resume BallThread");
   }
 
   /**
    * Stop running thread.
    */
   public void stopMe() {
-    this.isRunning = false;
-    this.isSuspended = true;
-    synchronized (lock) {
-      lock.notifyAll();
-    }
+    isRunning = false;
+    resumeMe(); // Ensure the thread exits if it is waiting
   }
 }

--- a/twin/src/main/java/com/iluwatar/twin/BallThread.java
+++ b/twin/src/main/java/com/iluwatar/twin/BallThread.java
@@ -32,7 +32,6 @@ import lombok.extern.slf4j.Slf4j;
  * This class is a UI thread for drawing the {@link BallItem}, and provides methods for suspend
  * and resume. It holds the reference of {@link BallItem} to delegate the draw task.
  */
-
 @Slf4j
 public class BallThread extends Thread {
 
@@ -43,6 +42,11 @@ public class BallThread extends Thread {
   private final Object lock = new Object();
   private final BallItem twin;
 
+  /**
+   * Constructor.
+   *
+   * @param twin the BallItem instance
+   */
   public BallThread(BallItem twin) {
     this.twin = twin;
   }


### PR DESCRIPTION
the run() method now efficiently waits when suspendMe() is called and resumes execution when resumeMe() is invoked. This approach eliminates the need for constant suspension checks during the thread's execution, reducing unnecessary overhead. The thread pauses gracefully while suspended and only resumes performing the drawing and movement tasks when explicitly notified, thereby optimizing performance and conserving system resources.