### PR TITLE
chore: update actions to current release versions

### DIFF
--- a/.github/workflows/maven-ci.yml
+++ b/.github/workflows/maven-ci.yml
@@ -13,13 +13,13 @@ jobs:
     steps:
 
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # Disabling shallow clone for improving relevancy of SonarQube reporting
           fetch-depth: 0
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'

--- a/.github/workflows/maven-pr-builder.yml
+++ b/.github/workflows/maven-pr-builder.yml
@@ -16,12 +16,12 @@ jobs:
     steps:
 
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -23,7 +23,7 @@ jobs:
           fi
 
       - name: Check out PR code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,7 +7,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v10
         with:
           stale-issue-message: 'This issue is stale because it has been open 60 days with no activity.'
           stale-pr-message: 'This PR is stale because it has been open 60 days with no activity.'


### PR DESCRIPTION
Update github actions to current release versions. Note runner versions need to be [v2.327.1](https://github.com/actions/runner/releases/tag/v2.327.1) or later, since all the new action releases use Node 24.

## What does this PR do?

* Updates `actions/checkout` to [v5](https://github.com/actions/checkout/releases/tag/v5.0.0).
* Updates `actions/setup-java` to [v5](https://github.com/actions/setup-java/releases/tag/v5.0.0).
* Updates `actions/stale` to [v10](https://github.com/actions/stale/releases/tag/v10.0.0).
