### PR TITLE
docs: add real-world example to Observer pattern README

### DIFF
--- a/observer/README.md
+++ b/observer/README.md
@@ -209,3 +209,10 @@ Trade-offs:
 * [Head First Design Patterns: Building Extensible and Maintainable Object-Oriented Software](https://amzn.to/49NGldq)
 * [Pattern-Oriented Software Architecture Volume 1: A System of Patterns](https://amzn.to/3xZ1ELU)
 * [Refactoring to Patterns](https://amzn.to/3VOO4F5)
+
+## Real-World Example
+
+The Observer pattern is widely used in event-driven architectures.
+For instance, in Java Swing or JavaFX applications, UI components can register listeners
+to react to user actions without tightly coupling the business logic to the interface.
+This makes the system more modular and easier to extend.


### PR DESCRIPTION
### What has been done
Added a new "Real-World Example" section to the Observer pattern README file.

### Why this change
To provide a practical explanation of how the Observer pattern is applied in modern Java applications, 
helping readers better understand its use in real projects.

### How to test
Open the file `observer/README.md` and verify that the new section appears at the end of the document.

---

Hacktoberfest contribution 🎃
