### PR TITLE
Fix README formatting in Introduction and Getting Started sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,14 @@ Read in different language : [**zh**](localization/zh/README.md), [**ko**](local
 
 # Introduction
 
-Design patterns are the best, formalized practices a programmer can use to solve common problems when designing an application or system.
-
-Design patterns can speed up the development process by providing tested, proven development paradigms.
-
-Reusing design patterns helps prevent subtle issues that cause major problems, and it also improves code readability for coders and architects who are familiar with the patterns.
+Design patterns are the best, formalized practices a programmer can use to solve common problems when designing an application or system. Design patterns can speed up the development process by providing tested, proven development paradigms. Reusing design patterns helps prevent subtle issues that cause major problems, and it also improves code readability for coders and architects who are familiar with the patterns.
 
 # Getting Started
 
-This site showcases Java Design Patterns. The solutions have been developed by experienced programmers and architects from the open-source community. The patterns can be browsed by their high-level descriptions or by looking at their
+This site showcases Java Design Patterns.
+
+
+The solutions have been developed by experienced programmers and architects from the open-source community. The patterns can be browsed by their high-level descriptions or by looking at their
 source code. The source code examples are well commented and can be thought of as programming tutorials on how to implement a specific pattern. We use the most popular battle-proven open-source Java technologies.
 
 Before you dive into the material, you should be familiar with various [Software Design Principles](https://java-design-patterns.com/principles/).


### PR DESCRIPTION
…tarted sections

# Pull Request Template

## What does this PR do?

This PR improves the Markdown formatting in the README by separating the "Introduction" and "Getting Started" headings from their body text.

The formatting issue appeared in two duplicated sections of the README, so both were aligned and cleaned. No content was modified — only spacing, blank lines, and structure to improve readability and rendering.


<!-- Provide a short description of what this pull request does. -->

<!-- Fixes #<issue-number> (if applicable) -->
