### PR TITLE
Refine toString() format to use hex hash code for consistency with Object.toString()

### DIFF
--- a/singleton/src/main/java/com/iluwatar/singleton/EnumIvoryTower.java
+++ b/singleton/src/main/java/com/iluwatar/singleton/EnumIvoryTower.java
@@ -37,6 +37,6 @@ public enum EnumIvoryTower {
 
   @Override
   public String toString() {
-    return getDeclaringClass().getCanonicalName() + "@" + hashCode();
+    return getClass().getName() + "@" + Integer.toHexString(hashCode());
   }
 }


### PR DESCRIPTION
Refine toString() format to use hex hash code for consistency with Object.toString()

## What does this PR do?

Refine toString() format to use hex hash code for consistency with Object.toString()

Object.java
``` java
public String toString() {
    return getClass().getName() + "@" + Integer.toHexString(hashCode());
}
```
