### PR TITLE
Fix Semgrep finding by adding no-new-privileges:true to MongoDB container

### DIFF
--- a/caching/docker-compose.yml
+++ b/caching/docker-compose.yml
@@ -34,3 +34,5 @@ services:
       - '27017:27017'
     volumes:
       - ./mongo-data/:/data/db
+    security_opt:
+      - no-new-privileges:true


### PR DESCRIPTION
Hi Maintainers 👋,

I’m submitting this PR to address a Semgrep medium-severity security finding in the project’s docker-compose.yml.

🔍 Issue

Rule ID: no-new-privileges
Semgrep Message: Service mongodb_container allows for privilege escalation via setuid or setgid binaries. Add no-new-privileges:true in security_opt to prevent this.

📍 Location

File: /tools/scanResult/unzipped-3949820752/caching/docker-compose.yml
Line: 28

✅ Fix

Added the following to the mongodb_container service:

security_opt:
  - no-new-privileges:true

🎯 Outcome

This prevents privilege escalation inside the container by ensuring the container cannot gain new privileges (even if setuid/setgid binaries exist).

This remediation was identified and validated using AI-Guardian, an internal security tool developed by my company OpsMx.

Thanks for reviewing the PR 🙏