### PR TITLE
fix: no-new-privileges-28 – prevent privilege escalation in mongodb_container

### DIFF
--- a/caching/docker-compose.yml
+++ b/caching/docker-compose.yml
@@ -34,3 +34,5 @@ services:
       - '27017:27017'
     volumes:
       - ./mongo-data/:/data/db
+    security_opt:
+      - no-new-privileges:true


### PR DESCRIPTION
Hi Maintainers 👋,

This Pull Request addresses a Semgrep security finding related to potential privilege escalation in the Docker configuration.

🔍 Issue Details

```
Rule ID: no-new-privileges

Severity: Medium

Rule Message:
Service mongodb_container allows for privilege escalation via setuid or setgid binaries. Add no-new-privileges:true in security_opt to prevent this.

📍 Affected Location

File Path: /tools/scanResult/unzipped-3949820752/caching/docker-compose.yml
Line: 28
```


✅ Fix Applied

Added the following security hardening option to the mongodb_container service:

```
security_opt:
  - no-new-privileges:true
```

🎯 Impact

This change ensures that the container cannot gain additional privileges at runtime, effectively mitigating the risk of privilege escalation.

The issue was identified and remediated using AI-Guardian, a security analysis tool developed by my company OpsMx.

Thanks for your time and review 🙏