### PR TITLE
Improve singleton code doc

### DIFF
--- a/observer/README.md
+++ b/observer/README.md
@@ -174,6 +174,7 @@ Use the Observer pattern in any of the following situations:
 * When an abstraction has two aspects, one dependent on the other. Encapsulating these aspects in separate objects lets you vary and reuse them independently.
 * When a change to one object requires changing others, and you don't know how many objects need to be changed.
 * When an object should be able to notify other objects without making assumptions about who these objects are. In other words, you don't want these objects tightly coupled.
+* This pattern is especially useful in event-driven systems where changes in one object need to be automatically reflected in multiple dependent objects.
 
 ## Real-World Applications of Observer Pattern in Java
 

--- a/singleton/README.md
+++ b/singleton/README.md
@@ -78,6 +78,7 @@ Use the Singleton pattern when
 * Configuration classes in many applications
 * Connection pools
 * File manager
+* Database connection management systems to ensure a single shared instance across the application
 * [java.lang.Runtime#getRuntime()](http://docs.oracle.com/javase/8/docs/api/java/lang/Runtime.html#getRuntime%28%29)
 * [java.awt.Desktop#getDesktop()](http://docs.oracle.com/javase/8/docs/api/java/awt/Desktop.html#getDesktop--)
 * [java.lang.System#getSecurityManager()](http://docs.oracle.com/javase/8/docs/api/java/lang/System.html#getSecurityManager--)

--- a/singleton/src/main/java/com/iluwatar/singleton/IvoryTower.java
+++ b/singleton/src/main/java/com/iluwatar/singleton/IvoryTower.java
@@ -24,7 +24,10 @@
  */
 package com.iluwatar.singleton;
 
-/** Singleton class. Eagerly initialized static instance guarantees thread safety. */
+/**
+ * Singleton class. Eagerly initialized static instance guarantees thread
+ * safety.
+ */
 public final class IvoryTower {
 
   /** Private constructor so nobody can instantiate the class. */
@@ -42,6 +45,11 @@ public final class IvoryTower {
    * To be called by user to obtain instance of the class.
    *
    * @return instance of the singleton.
+   */
+
+  /**
+   * Returns the single instance of IvoryTower.
+   * Ensures that only one instance exists throughout the application.
    */
   public static IvoryTower getInstance() {
     return INSTANCE;


### PR DESCRIPTION
Added JavaDoc comments to improve clarity of the Singleton implementation.

This change enhances code readability by explaining the purpose of the getInstance() method and how it ensures a single instance throughout the application.