### PR TITLE
fix: pin 1 actions to commit SHA, extract 1 expressions to env vars

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -17,11 +17,13 @@ jobs:
         steps:
             - name: Check required secrets
               run: |
-                  if [ -z "${{ secrets.LLM_API_KEY }}" ]; then
+                  if [ -z "${LLM_API_KEY}" ]; then
                     echo "Error: LLM_API_KEY secret is not configured"
                     exit 1
                   fi
-            - uses: presubmit/ai-reviewer@latest
+              env:
+                LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+            - uses: presubmit/ai-reviewer@5f1290b6142b14b44cd2e8e3ffda84cd0a22e94f # latest
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   LLM_API_KEY: ${{ secrets.LLM_API_KEY }}


### PR DESCRIPTION
Re-submission of #3455. Had a problem with my fork and had to delete it, which closed the original PR. Apologies for the noise.

## Summary

This PR pins all GitHub Actions to immutable commit SHAs instead of mutable version tags and extracts expressions from `run:` blocks into `env:` mappings.

- Pin 1 unpinned actions to full 40-character SHAs
- Add version comments for readability
- Extract 1 expressions from run blocks to env vars

## Changes by file

| File | Changes |
|------|---------|
| presubmit.yml | Pinned actions to SHA |

## A note on internal action pinning

This PR pins all actions including org-owned ones. Best practice is to pin everything — the tj-actions/changed-files attack was an internally maintained action that was compromised, and every repo referencing it by tag silently executed attacker code. That said, it's your codebase. If you'd prefer to leave org-owned actions unpinned, let us know and we'll adjust the PR.

## How to verify

Review the diff — each change is mechanical and preserves workflow behavior:
- **SHA pinning**: `action@v3` becomes `action@abc123 # v3` — original version preserved as comment
- **Expression extraction**: `${{ expr }}` in `run:` moves to `env:` block, referenced as `$ENV_VAR` in the script
- No workflow logic, triggers, or permissions are modified

I wrote a scanner called Runner Guard and open sourced it [here](https://github.com/Vigilant-LLC/runner-guard).

If you have any questions, reach out. I'll be monitoring comms.

\- Chris Nyhuis (dagecko)