### PR TITLE
fix: remove unsafe exec() in App.java

### DIFF
--- a/page-object/src/main/java/com/iluwatar/pageobject/App.java
+++ b/page-object/src/main/java/com/iluwatar/pageobject/App.java
@@ -77,7 +77,7 @@ public final class App {
       } else {
         // Java Desktop not supported - above unlikely to work for Windows so try the
         // following instead...
-        Runtime.getRuntime().exec("cmd.exe start " + applicationFile);
+        new ProcessBuilder("cmd.exe", "/c", "start", "", applicationFile.getAbsolutePath()).start();
       }
 
     } catch (IOException ex) {


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `page-object/src/main/java/com/iluwatar/pageobject/App.java`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `page-object/src/main/java/com/iluwatar/pageobject/App.java:80` |
| **CWE** | CWE-78 |

**Description**: The application uses Runtime.exec() with string concatenation to execute system commands, directly concatenating the applicationFile variable into the command string without validation or sanitization. This creates a critical command injection vulnerability where attackers can inject arbitrary commands using shell metacharacters (&, |, ;, &&, ||). The use of 'cmd.exe start' with concatenated user-controlled input allows complete bypass of intended command execution, enabling attackers to execute any system command with the privileges of the Java application.

## Changes
- `page-object/src/main/java/com/iluwatar/pageobject/App.java`

## Verification
- [ ] Build not verified
- [ ] Scanner re-scan not performed
- [ ] LLM code review not performed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
