### PR TITLE
Add identity test for EnumIvoryTower single

### DIFF
--- a/singleton/src/test/java/com/iluwatar/singleton/EnumIvoryTowerTest.java
+++ b/singleton/src/test/java/com/iluwatar/singleton/EnumIvoryTowerTest.java
@@ -26,6 +26,8 @@ package com.iluwatar.singleton;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import static org.junit.jupiter.api.Assertions.assertSame;
+
 import org.junit.jupiter.api.Test;
 
 /** EnumIvoryTowerTest */
@@ -43,5 +45,13 @@ class EnumIvoryTowerTest extends SingletonTest<EnumIvoryTower> {
     // Java does not allow Enum instantiation
     // http://docs.oracle.com/javase/specs/jls/se7/html/jls-8.html#jls-8.9
     assertThrows(ReflectiveOperationException.class, EnumIvoryTower.class::getDeclaredConstructor);
+    
+    
+}
+@Test
+void testEnumSingletonIdentity() {
+  var instance1 = EnumIvoryTower.INSTANCE;
+  var instance2 = EnumIvoryTower.INSTANCE;
+  assertSame(instance1, instance2, "Enum singleton instances should be identical");
   }
 }


### PR DESCRIPTION
This pull request adds a new JUnit test verifying that EnumIvoryTower.INSTANCE 
returns the same instance on repeated access. This improves test coverage for 
the Enum-based singleton implementation.
