### PR TITLE
fix: prevent RCE via pull_request_target in maven-pr-builder.yml

### DIFF
--- a/.github/workflows/maven-pr-builder.yml
+++ b/.github/workflows/maven-pr-builder.yml
@@ -13,6 +13,7 @@ jobs:
 
     name: Build on JDK 21
     runs-on: ubuntu-22.04
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
 
       - name: Checkout Code


### PR DESCRIPTION
Fixes #3478

Added a job-level `if` condition to restrict workflow execution 
to PRs from the same repository only, preventing potential RCE 
via fork PRs with write-scoped tokens.