### PR TITLE
Update factory method Java API links

### DIFF
--- a/factory-method/README.md
+++ b/factory-method/README.md
@@ -103,13 +103,12 @@ Use the Factory Method Pattern in Java when:
 
 ## Real-World Applications of Factory Method Pattern in Java
 
-* [java.util.Calendar](http://docs.oracle.com/javase/8/docs/api/java/util/Calendar.html#getInstance--)
-* [java.util.ResourceBundle](http://docs.oracle.com/javase/8/docs/api/java/util/ResourceBundle.html#getBundle-java.lang.String-)
-* [java.text.NumberFormat](http://docs.oracle.com/javase/8/docs/api/java/text/NumberFormat.html#getInstance--)
-* [java.nio.charset.Charset](http://docs.oracle.com/javase/8/docs/api/java/nio/charset/Charset.html#forName-java.lang.String-)
-* [java.net.URLStreamHandlerFactory](http://docs.oracle.com/javase/8/docs/api/java/net/URLStreamHandlerFactory.html#createURLStreamHandler-java.lang.String-)
-* [java.util.EnumSet](https://docs.oracle.com/javase/8/docs/api/java/util/EnumSet.html#of-E-)
-* [javax.xml.bind.JAXBContext](https://docs.oracle.com/javase/8/docs/api/javax/xml/bind/JAXBContext.html#createMarshaller--)
+* [java.util.Calendar](<https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/Calendar.html#getInstance()>)
+* [java.util.ResourceBundle](<https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/ResourceBundle.html#getBundle(java.lang.String)>)
+* [java.text.NumberFormat](<https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/text/NumberFormat.html#getInstance()>)
+* [java.nio.charset.Charset](<https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/nio/charset/Charset.html#forName(java.lang.String)>)
+* [java.net.URLStreamHandlerFactory](<https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/net/URLStreamHandlerFactory.html#createURLStreamHandler(java.lang.String)>)
+* [java.util.EnumSet](<https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/EnumSet.html#of(E)>)
 * Frameworks that run application components, configured dynamically at runtime.
 
 ## Benefits and Trade-offs of Factory Method Pattern


### PR DESCRIPTION
## What does this PR do?

Updates the Factory Method README to replace outdated Java 8 API documentation links with Java 21 links and removes the obsolete `javax.xml.bind.JAXBContext` example.

Fixes #3368