### PR TITLE
docs: fix 'seperate' to 'separate' in dao-factory/README.md

### DIFF
--- a/dao-factory/README.md
+++ b/dao-factory/README.md
@@ -19,7 +19,7 @@ tag:
 
 ## Intent of Data Access Object Factory Design Pattern
 
-The DAO Factory combines the Data Access Object and Abstract Factory patterns to seperate business logic from data access logic, while increasing flexibility when switching between different data sources.
+The DAO Factory combines the Data Access Object and Abstract Factory patterns to separate business logic from data access logic, while increasing flexibility when switching between different data sources.
 
 ## Detailed Explanation of Data Access Object Factory Pattern with Real-World Examples
 


### PR DESCRIPTION
## Description

This PR fixes a spelling error in `dao-factory/README.md` (line 22).

### Problem
's seperate' is a common misspelling of 'separate'.

### Before
```
combines the Data Access Object and Abstract Factory patterns to seperate business logic
```

### After
```
combines the Data Access Object and Abstract Factory patterns to separate business logic
```