### PR TITLE
docs: fix 'Here is the implementations' to 'Here are the implementations' in dao-factory/README.md

### DIFF
--- a/dao-factory/README.md
+++ b/dao-factory/README.md
@@ -86,7 +86,7 @@ public interface CustomerDAO<T> {
 }
 ```
 
-Here is the implementations
+Here are the implementations
 
 ``` java
 @Slf4j


### PR DESCRIPTION
## Description

This PR fixes a subject-verb agreement error in `dao-factory/README.md` (line 89).

### Problem
'Here is the implementations' should be 'Here are the implementations' — 'implementations' is plural.

### Before
```
Here is the implementations
```

### After
```
Here are the implementations
```