### PR TITLE
docs: fix 'encapsulate' to 'encapsulates' in service-layer/README.md

### DIFF
--- a/service-layer/README.md
+++ b/service-layer/README.md
@@ -20,7 +20,7 @@ tag:
 
 The Service Layer pattern is crucial for Java developers focusing on building robust application architectures that separate business processes from user interface concerns.
 
-The pattern encapsulate business logic in a distinct layer to promote separation of concerns and to provide a well-defined API for the presentation layer.
+The pattern encapsulates business logic in a distinct layer to promote separation of concerns and to provide a well-defined API for the presentation layer.
 
 ## Detailed Explanation of Service Layer Pattern with Real-World Examples
 


### PR DESCRIPTION
## Description

This PR fixes a subject-verb agreement error in `service-layer/README.md` (line 23).

### Problem
'The pattern encapsulate' should be 'The pattern encapsulates' — 'pattern' is singular.

### Before
```
The pattern encapsulate business logic in a distinct layer
```

### After
```
The pattern encapsulates business logic in a distinct layer
```