### PR TITLE
docs: fix spelling error 'Sequnce' → 'Sequence' in special-case/README.md

### DIFF
--- a/special-case/README.md
+++ b/special-case/README.md
@@ -37,7 +37,7 @@ In [Patterns of Enterprise Application Architecture](https://amzn.to/3WfKBPR) Ma
 
 > If you’ll pardon the unresistable pun, I see [Null Object](https://java-design-patterns.com/patterns/null-object/) as special case of Special Case.
 
-Sequnce diagram
+Sequence diagram
 
 ![Special Case sequence diagram](./etc/special-case-sequence-diagram.png)
 


### PR DESCRIPTION
## Summary

This PR fixes a spelling error in `special-case/README.md` (line 40).

## Problem

The word 'Sequnce' is misspelled and should be 'Sequence'.

## Fix

Changed `Sequnce diagram` to `Sequence diagram`.

## Type of Change

- [x] Documentation fix (spelling)
- [ ] Code change
- [ ] Breaking change