### PR TITLE
docs: fix spelling error 'polluding' → 'polluting' in servant/README.md

### DIFF
--- a/servant/README.md
+++ b/servant/README.md
@@ -136,7 +136,7 @@ In this example, the `Servant` class provides services to the `Royalty` objects.
 
 ## When to Use the Servant Pattern in Java
 
-* Use the Servant pattern when you need to provide a common functionality to a group of classes without polluding their class definitions, perfect for enhancing Java application architecture.
+* Use the Servant pattern when you need to provide a common functionality to a group of classes without polluting their class definitions, perfect for enhancing Java application architecture.
 * Suitable when the operations performed on the objects are not the primary responsibility of the objects themselves.
 
 ## Real-World Applications of Servant Pattern in Java


### PR DESCRIPTION
## Summary

This PR fixes a spelling error in `servant/README.md` (line 139).

## Problem

The word 'polluding' is misspelled and should be 'polluting'.

## Fix

Changed `polluding` to `polluting`.

## Type of Change

- [x] Documentation fix (spelling)
- [ ] Code change
- [ ] Breaking change