### PR TITLE
docs: fix typo 'ava' → 'Java' in microservices-log-aggregation/README.md

### DIFF
--- a/microservices-log-aggregation/README.md
+++ b/microservices-log-aggregation/README.md
@@ -137,7 +137,7 @@ In this example, the `LogProducer` services generate logs of different levels. T
 
 ## Real-World Applications of Microservices Log Aggregation Pattern in Java
 
-* ava applications using frameworks like Log4j2 or SLF4J with centralized log management tools such as the ELK stack or Splunk benefit from microservices log aggregation.
+* Java applications using frameworks like Log4j2 or SLF4J with centralized log management tools such as the ELK stack or Splunk benefit from microservices log aggregation.
 * Microservices architectures where each service outputs logs that are aggregated into a single system to provide a unified view of the system’s health and behavior.
 
 ## Benefits and Trade-offs of Microservices Log Aggregation Pattern


### PR DESCRIPTION
## Summary

This PR fixes a typo in `microservices-log-aggregation/README.md` (line 140).

## Problem

The word 'ava' is missing the letter 'J' and should be 'Java'.

## Fix

Changed `ava applications` to `Java applications`.

## Type of Change

- [x] Documentation fix (typo)
- [ ] Code change
- [ ] Breaking change